### PR TITLE
remove 'Click to ' from Approval button labels

### DIFF
--- a/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
@@ -175,7 +175,7 @@ export default function Deposit(props: propsIF) {
             );
         } else if (!isTokenAllowanceSufficient) {
             setIsButtonDisabled(false);
-            setButtonMessage(`Click to Approve ${selectedToken.symbol}`);
+            setButtonMessage(`Approve ${selectedToken.symbol}`);
         } else if (isDepositQtyValid) {
             setIsButtonDisabled(false);
             setButtonMessage('Deposit');

--- a/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
@@ -205,27 +205,15 @@ export default function Transfer(props: propsIF) {
             setButtonMessage(
                 `${selectedToken.symbol} Exchange Balance Insufficient`,
             );
-        }
-        // else if (isApprovalPending) {
-        //     setIsButtonDisabled(true);
-        //     setButtonMessage(`${selectedToken.symbol} Approval Pending`);
-        // }
-        else if (isTransferPending) {
+        } else if (isTransferPending) {
             setIsButtonDisabled(true);
             setButtonMessage(`${selectedToken.symbol} Transfer Pending`);
-        }
-        // else if (!isTokenAllowanceSufficient) {
-        //     setIsButtonDisabled(false);
-        //     setButtonMessage(`Click to Approve ${selectedToken.symbol}`);
-        // }
-        else if (isTransferQtyValid) {
+        } else if (isTransferQtyValid) {
             setIsButtonDisabled(false);
             setButtonMessage('Transfer');
         }
     }, [
-        // isApprovalPending,
         isTransferPending,
-        // isTokenAllowanceSufficient,
         isDexBalanceSufficient,
         isTransferQtyValid,
         selectedToken.symbol,

--- a/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
@@ -205,21 +205,13 @@ export default function Withdraw(props: propsIF) {
         [withdrawQtyNonDisplay],
     );
 
-    // const [isApprovalPending, setIsApprovalPending] = useState(false);
     const [isWithdrawPending, setIsWithdrawPending] = useState(false);
 
     useEffect(() => {
         setIsWithdrawPending(false);
     }, [JSON.stringify(selectedToken)]);
 
-    // const chooseToken = (tok: TokenIF) => {
-    //     console.log(tok);
-    //     dispatch(setToken(tok));
-    //     closeGlobalModal();
-    // };
-
     useEffect(() => {
-        // console.log({ isDepositQtyValid });
         if (isSendToAddressChecked && !isResolvedAddressValid) {
             setIsButtonDisabled(true);
             setButtonMessage('Please Enter a Valid Address');
@@ -231,45 +223,21 @@ export default function Withdraw(props: propsIF) {
             setButtonMessage(
                 `${selectedToken.symbol} Exchange Balance Insufficient`,
             );
-        }
-        // else if (isApprovalPending) {
-        //     setIsButtonDisabled(true);
-        //     setButtonMessage(`${selectedToken.symbol} Approval Pending`);
-        // }
-        else if (isWithdrawPending) {
+        } else if (isWithdrawPending) {
             setIsButtonDisabled(true);
             setButtonMessage(`${selectedToken.symbol} Withdrawal Pending`);
-        }
-        // else if (!isTokenAllowanceSufficient) {
-        //     setIsButtonDisabled(false);
-        //     setButtonMessage(`Click to Approve ${selectedToken.symbol}`);
-        // }
-        else if (isWithdrawQtyValid) {
+        } else if (isWithdrawQtyValid) {
             setIsButtonDisabled(false);
             setButtonMessage('Withdraw');
         }
     }, [
-        // isApprovalPending,
         isWithdrawPending,
-        // isTokenAllowanceSufficient,
         isDexBalanceSufficient,
         isWithdrawQtyValid,
         selectedToken.symbol,
         isResolvedAddressValid,
         isSendToAddressChecked,
     ]);
-
-    // const chooseTokenDiv = (
-    //     <div>
-    //         {defaultTokens
-    //             .filter((token: TokenIF) => token.chainId === parseInt('0x5'))
-    //             .map((token: TokenIF) => (
-    //                 <button key={'button_to_set_' + token.name} onClick={() => chooseToken(token)}>
-    //                     {token.name}
-    //                 </button>
-    //             ))}
-    //     </div>
-    // );
 
     const withdraw = async (withdrawQtyNonDisplay: string) => {
         if (crocEnv && withdrawQtyNonDisplay) {

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -394,7 +394,7 @@ export default function InitPool(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenA.symbol}`
+                    ? `Approve ${tokenPair.dataTokenA.symbol}`
                     : `${tokenPair.dataTokenA.symbol} Approval Pending`
             }
             disabled={isApprovalPending}
@@ -409,7 +409,7 @@ export default function InitPool(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenB.symbol}`
+                    ? `Approve ${tokenPair.dataTokenB.symbol}`
                     : `${tokenPair.dataTokenB.symbol} Approval Pending`
             }
             disabled={isApprovalPending}

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -424,7 +424,7 @@ export default function Swap(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenA.symbol}`
+                    ? `Approve ${tokenPair.dataTokenA.symbol}`
                     : `${tokenPair.dataTokenA.symbol} Approval Pending`
             }
             disabled={isApprovalPending}

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -792,7 +792,7 @@ export default function Limit(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenA.symbol}`
+                    ? `Approve ${tokenPair.dataTokenA.symbol}`
                     : `${tokenPair.dataTokenA.symbol} Approval Pending`
             }
             disabled={isApprovalPending}

--- a/src/pages/Trade/Range/Range.tsx
+++ b/src/pages/Trade/Range/Range.tsx
@@ -1561,7 +1561,7 @@ export default function Range(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenA.symbol}`
+                    ? `Approve ${tokenPair.dataTokenA.symbol}`
                     : `${tokenPair.dataTokenA.symbol} Approval Pending`
             }
             disabled={isApprovalPending}
@@ -1576,7 +1576,7 @@ export default function Range(props: propsIF) {
         <Button
             title={
                 !isApprovalPending
-                    ? `Click to Approve ${tokenPair.dataTokenB.symbol}`
+                    ? `Approve ${tokenPair.dataTokenB.symbol}`
                     : `${tokenPair.dataTokenB.symbol} Approval Pending`
             }
             disabled={isApprovalPending}


### PR DESCRIPTION
### Describe your changes 

'Click to ' might imply that an on-chain transaction would not be necessary. Therefore, we're removing it from Approval button labels, since sending ERC-20 tokens to CrocSwap requires an on-chain transaction.

### Link the related issue

Closes #1555 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
