### PR TITLE
create tooltip for token symbols longer than 4 letters

### DIFF
--- a/src/components/Swap/CurrencySelector/CurrencySelector.module.css
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.module.css
@@ -134,8 +134,15 @@
     line-height: var(--header2-lh);
     color: var(--text-grey-white);
     font-weight: 200;
+
+    width: 53px;
+    overflow-y: scroll;
 }
 
+.token_list_text::-webkit-scrollbar {
+    display: none;
+  }
+  
 /* bottom info */
 
 .token_select_button {

--- a/src/components/Swap/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.tsx
@@ -535,6 +535,21 @@ export default function CurrencySelector(props: propsIF) {
         soloTokenSelectInput.value = '';
     };
 
+    const tokenSymbol =
+        thisToken?.symbol?.length > 4 ? (
+            <DefaultTooltip
+                title={thisToken.symbol}
+                placement={'top'}
+                arrow
+                enterDelay={100}
+                leaveDelay={200}
+            >
+                <div className={styles.token_list_text}>{thisToken.symbol}</div>
+            </DefaultTooltip>
+        ) : (
+            <div className={styles.token_list_text}>{thisToken.symbol}</div>
+        );
+
     return (
         <div className={styles.swapbox}>
             <div className={styles.direction}> </div>
@@ -570,9 +585,7 @@ export default function CurrencySelector(props: propsIF) {
                             width='30px'
                         />
                     )}
-                    <div className={styles.token_list_text}>
-                        {thisToken.symbol}
-                    </div>
+                    {tokenSymbol}
                     <RiArrowDownSLine size={27} />
                 </div>
             </div>


### PR DESCRIPTION
### Describe your changes 
- Added a max width to the token symbol container.
- Added an overflow container and disabled the scroll view.
- Created a tooltip for token symbols with more than 4 characters.
_Describe the purpose + content of these changes_
<img width="1034" alt="image" src="https://user-images.githubusercontent.com/83131501/227741927-17b12499-f730-407c-b4f1-657212e26cf2.png">
<img width="765" alt="image" src="https://user-images.githubusercontent.com/83131501/227741977-4cdced27-8fef-4fa4-9e20-3fdf943cd5a1.png">

### Link the related issue
https://github.com/CrocSwap/ambient-ts-app/issues/249

_Closes #249_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
