### PR TITLE
enable swapping from dex balance without token approval

### DIFF
--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -88,6 +88,7 @@ interface propsIF {
     ) => void;
     lastBlockNumber: number;
     dexBalancePrefs: allDexBalanceMethodsIF;
+    setTokenAQtyCoveredByWalletBalance: Dispatch<SetStateAction<number>>;
 }
 
 export default function CurrencyConverter(props: propsIF) {
@@ -136,6 +137,7 @@ export default function CurrencyConverter(props: propsIF) {
         openGlobalPopup,
         lastBlockNumber,
         dexBalancePrefs,
+        setTokenAQtyCoveredByWalletBalance,
     } = props;
 
     // TODO: update name of functions with 'handle' verbiage
@@ -214,6 +216,7 @@ export default function CurrencyConverter(props: propsIF) {
 
     const tokenASurplusMinusTokenARemainderNum =
         parseFloat(tokenADexBalance || '0') - parseFloat(tokenAQtyLocal || '0');
+
     const tokenASurplusMinusTokenAQtyNum =
         tokenASurplusMinusTokenARemainderNum >= 0
             ? tokenASurplusMinusTokenARemainderNum
@@ -230,6 +233,10 @@ export default function CurrencyConverter(props: propsIF) {
             ? tokenASurplusMinusTokenARemainderNum * -1
             : 0
         : parseFloat(tokenAQtyLocal || '0');
+
+    useEffect(() => {
+        setTokenAQtyCoveredByWalletBalance(tokenAQtyCoveredByWalletBalance);
+    }, [tokenAQtyCoveredByWalletBalance]);
 
     const tokenAWalletMinusTokenAQtyNum = isSellTokenEth
         ? isWithdrawFromDexChecked

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -583,8 +583,13 @@ export default function Swap(props: propsIF) {
         }
     }, [gasPriceInGwei, ethMainnetUsdPrice]);
 
+    const [
+        tokenAQtyCoveredByWalletBalance,
+        setTokenAQtyCoveredByWalletBalance,
+    ] = useState<number>(0);
+
     const isTokenAAllowanceSufficient =
-        parseFloat(tokenAAllowance) >= parseFloat(sellQtyString);
+        parseFloat(tokenAAllowance) >= tokenAQtyCoveredByWalletBalance;
 
     const swapContainerStyle = pathname.startsWith('/swap')
         ? styles.swap_page_container
@@ -730,6 +735,7 @@ export default function Swap(props: propsIF) {
         openGlobalPopup: openGlobalPopup,
         lastBlockNumber: lastBlockNumber,
         dexBalancePrefs: dexBalancePrefs,
+        setTokenAQtyCoveredByWalletBalance: setTokenAQtyCoveredByWalletBalance,
     };
 
     const handleSwapButtonClickWithBypass = () => {


### PR DESCRIPTION
### Describe your changes 

switch from comparing sell token approval quantity with token A quantity to tokenAQtyCoveredByWalletBalance.

### Link the related issue

closes #1615

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
