### PR TITLE
Account Page - set Wallet display to 0 if value is too low

### DIFF
--- a/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
@@ -98,7 +98,7 @@ export default function Deposit(props: propsIF) {
 
     const tokenWalletBalanceTruncated = tokenWalletBalanceDisplayNum
         ? tokenWalletBalanceDisplayNum < 0.0001
-            ? tokenWalletBalanceDisplayNum.toExponential(2)
+            ? 0.0
             : tokenWalletBalanceDisplayNum < 2
             ? tokenWalletBalanceDisplayNum.toPrecision(3)
             : tokenWalletBalanceDisplayNum.toLocaleString(undefined, {


### PR DESCRIPTION
### Describe your changes 

Wallet display displayed odd values when less than 0.001. After discussion on #1502, it was decided to just set it to 0.0 instead.

![Screenshot 2023-03-30 at 3 37 20 PM](https://user-images.githubusercontent.com/6332196/228945782-1a24eb29-4633-420d-8082-0cbb60e8b7e8.png)

### Link the related issue

Closes #1502 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
