### PR TITLE
Trade Tables - Unify fonts and center status circle

### DIFF
--- a/src/components/Global/RangeStatus/RangeStatus.module.css
+++ b/src/components/Global/RangeStatus/RangeStatus.module.css
@@ -20,36 +20,37 @@
 }
 
 .range_container {
-    width: 21.5px;
-    height: 21.5px;
-    background: #555555;
-    padding: 1px;
-    border-radius: 50%;
     display: flex;
-    justify-content: center;
-    align-items: center;
     color: var(--text-grey-white);
+    position: relative;
 }
 
 .range_text_positive {
     width: 18px;
     height: 18px;
-    background: #15be6f;
+    padding: 1px;
     border-radius: 50%;
+    background: #15be6f;
+    box-shadow: 0 0 0 2px #555555;
+    margin: 2px;
 }
 .range_text_negative {
     width: 18px;
     height: 18px;
-
-    background: #f7385b;
+    padding: 1px;
     border-radius: 50%;
+    box-shadow: 0 0 0 2px #555555;
+    margin: 2px;
+    background: #f7385b;
 }
 .range_text_ambient {
     width: 18px;
     height: 18px;
-
-    background: var(--title-gradient);
+    padding: 1px;
     border-radius: 50%;
+    box-shadow: 0 0 0 2px #555555;
+    margin: 2px;
+    background: var(--title-gradient);
 }
 .in_range_display {
     display: flex;

--- a/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
+++ b/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
@@ -230,7 +230,6 @@ export default function OrderRow(props: propsIF) {
                 onClick={openDetailsModal}
                 data-label='id'
                 className={`${styles.base_color} ${styles.hover_style}`}
-                style={{ fontFamily: 'monospace' }}
             >
                 {posHashTruncated}
             </li>
@@ -242,7 +241,7 @@ export default function OrderRow(props: propsIF) {
             onClick={openDetailsModal}
             data-label='value'
             className='base_color'
-            style={{ textAlign: 'right', fontFamily: 'monospace' }}
+            style={{ textAlign: 'right' }}
             onMouseEnter={handleRowMouseDown}
             onMouseLeave={handleRowMouseOut}
         >
@@ -313,7 +312,7 @@ export default function OrderRow(props: propsIF) {
                 }}
                 data-label='wallet'
                 className={`${usernameStyle} ${styles.hover_style}`}
-                style={{ textTransform: 'lowercase', fontFamily: 'monospace' }}
+                style={{ textTransform: 'lowercase' }}
             >
                 {userNameToDisplay}
             </li>
@@ -416,7 +415,6 @@ export default function OrderRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                 }}
             >
                 {baseDisplay}
@@ -439,7 +437,6 @@ export default function OrderRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                 }}
             >
                 {quoteDisplay}
@@ -478,9 +475,7 @@ export default function OrderRow(props: propsIF) {
                 onMouseEnter={handleRowMouseDown}
                 onMouseLeave={handleRowMouseOut}
             >
-                <p className='base_color' style={{ fontFamily: 'monospace' }}>
-                    {elapsedTimeString}
-                </p>
+                <p className='base_color'>{elapsedTimeString}</p>
             </li>
         </TextOnlyTooltip>
     ) : (
@@ -490,9 +485,7 @@ export default function OrderRow(props: propsIF) {
             onMouseEnter={handleRowMouseDown}
             onMouseLeave={handleRowMouseOut}
         >
-            <p className='base_color' style={{ fontFamily: 'monospace' }}>
-                {elapsedTimeString}
-            </p>
+            <p className='base_color'>{elapsedTimeString}</p>
         </li>
     );
 
@@ -565,7 +558,7 @@ export default function OrderRow(props: propsIF) {
                         ? (
                               <p className={`${styles.align_right} `}>
                                   <span>{priceCharacter}</span>
-                                  <span style={{ fontFamily: 'monospace' }}>
+                                  <span>
                                       {truncatedDisplayPriceDenomByMoneyness}
                                   </span>
                               </p>
@@ -573,9 +566,7 @@ export default function OrderRow(props: propsIF) {
                         : (
                               <p className={`${styles.align_right} `}>
                                   <span>{priceCharacter}</span>
-                                  <span style={{ fontFamily: 'monospace' }}>
-                                      {truncatedDisplayPrice}
-                                  </span>
+                                  <span>{truncatedDisplayPrice}</span>
                               </p>
                           ) || '…'}
                 </li>
@@ -632,7 +623,6 @@ export default function OrderRow(props: propsIF) {
                     <div
                         className={styles.token_qty}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >
@@ -643,7 +633,6 @@ export default function OrderRow(props: propsIF) {
                     <div
                         className={styles.token_qty}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -274,7 +274,6 @@ export default function RangesRow(props: propsIF) {
                 onClick={openDetailsModal}
                 data-label='id'
                 className={`${styles.base_color} ${styles.hover_style}`}
-                style={{ fontFamily: 'monospace' }}
             >
                 {posHashTruncated}
             </li>
@@ -286,7 +285,7 @@ export default function RangesRow(props: propsIF) {
             onClick={openDetailsModal}
             data-label='value'
             className='base_color'
-            style={{ textAlign: 'right', fontFamily: 'monospace' }}
+            style={{ textAlign: 'right' }}
             onMouseEnter={handleRowMouseDown}
             onMouseLeave={handleRowMouseOut}
         >
@@ -318,7 +317,7 @@ export default function RangesRow(props: propsIF) {
             }}
             data-label='wallet'
             className={`${usernameStyle} ${styles.hover_style}`}
-            style={{ textTransform: 'lowercase', fontFamily: 'monospace' }}
+            style={{ textTransform: 'lowercase' }}
         >
             {userNameToDisplay}
         </li>
@@ -413,7 +412,6 @@ export default function RangesRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                     whiteSpace: 'nowrap',
                 }}
             >
@@ -437,7 +435,6 @@ export default function RangesRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                     whiteSpace: 'nowrap',
                 }}
             >
@@ -500,9 +497,7 @@ export default function RangesRow(props: propsIF) {
                 onMouseEnter={handleRowMouseDown}
                 onMouseLeave={handleRowMouseOut}
             >
-                <p className='base_color' style={{ fontFamily: 'monospace' }}>
-                    {elapsedTimeString}
-                </p>
+                <p className='base_color'>{elapsedTimeString}</p>
             </li>
         </TextOnlyTooltip>
     );
@@ -573,9 +568,7 @@ export default function RangesRow(props: propsIF) {
                         onMouseEnter={handleRowMouseDown}
                         onMouseLeave={handleRowMouseOut}
                     >
-                        <span style={{ fontFamily: 'monospace' }}>
-                            {'0.00'}
-                        </span>
+                        <span>{'0.00'}</span>
                     </li>
                 ) : (
                     <li
@@ -587,7 +580,7 @@ export default function RangesRow(props: propsIF) {
                         onMouseLeave={handleRowMouseOut}
                     >
                         <span>{sideCharacter}</span>
-                        <span style={{ fontFamily: 'monospace' }}>
+                        <span>
                             {isOnPortfolioPage && !isAmbient
                                 ? minRangeDenomByMoneyness || '…'
                                 : ambientOrMin || '…'}
@@ -623,7 +616,7 @@ export default function RangesRow(props: propsIF) {
                         onMouseLeave={handleRowMouseOut}
                     >
                         <span>{sideCharacter}</span>
-                        <span style={{ fontFamily: 'monospace' }}>
+                        <span>
                             {isOnPortfolioPage
                                 ? maxRangeDenomByMoneyness || '…'
                                 : ambientOrMax || '…'}
@@ -642,7 +635,7 @@ export default function RangesRow(props: propsIF) {
                 >
                     <p>
                         <span>{sideCharacter}</span>
-                        <span style={{ fontFamily: 'monospace' }}>
+                        <span>
                             {isOnPortfolioPage && !isAmbient
                                 ? minRangeDenomByMoneyness || '…'
                                 : ambientOrMin || '…'}
@@ -650,7 +643,7 @@ export default function RangesRow(props: propsIF) {
                     </p>
                     <p>
                         <span>{sideCharacter}</span>
-                        <span style={{ fontFamily: 'monospace' }}>
+                        <span>
                             {isOnPortfolioPage
                                 ? maxRangeDenomByMoneyness || '…'
                                 : ambientOrMax || '…'}
@@ -692,7 +685,6 @@ export default function RangesRow(props: propsIF) {
                     <div
                         className={styles.token_qty}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >
@@ -703,7 +695,6 @@ export default function RangesRow(props: propsIF) {
                     <div
                         className={styles.token_qty}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >
@@ -721,9 +712,7 @@ export default function RangesRow(props: propsIF) {
                 onMouseLeave={handleRowMouseOut}
             >
                 {' '}
-                <p style={{ fontFamily: 'monospace' }} className={apyClassname}>
-                    {apyString}
-                </p>
+                <p className={apyClassname}>{apyString}</p>
             </li>
             <li
                 onClick={openDetailsModal}

--- a/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
@@ -240,7 +240,6 @@ export default function TransactionRow(props: propsIF) {
                 onClick={handleOpenExplorer}
                 data-label='id'
                 className={`${styles.base_color} ${styles.hover_style}`}
-                style={{ fontFamily: 'monospace' }}
             >
                 {txHashTruncated}
             </li>
@@ -254,7 +253,7 @@ export default function TransactionRow(props: propsIF) {
             onClick={openDetailsModal}
             data-label='value'
             className='base_color'
-            style={{ textAlign: 'right', fontFamily: 'monospace' }}
+            style={{ textAlign: 'right' }}
         >
             {usdValue}
         </li>
@@ -281,7 +280,7 @@ export default function TransactionRow(props: propsIF) {
             onClick={handleWalletClick}
             data-label='wallet'
             className={`${usernameStyle} ${styles.hover_style}`}
-            style={{ textTransform: 'lowercase', fontFamily: 'monospace' }}
+            style={{ textTransform: 'lowercase' }}
         >
             {userNameToDisplay}
         </li>
@@ -440,9 +439,7 @@ export default function TransactionRow(props: propsIF) {
                 onMouseEnter={handleRowMouseDown}
                 onMouseLeave={handleRowMouseOut}
             >
-                <p className='base_color' style={{ fontFamily: 'monospace' }}>
-                    {elapsedTimeString}
-                </p>
+                <p className='base_color'>{elapsedTimeString}</p>
             </li>
         </TextOnlyTooltip>
     );
@@ -462,7 +459,6 @@ export default function TransactionRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                 }}
             >
                 {baseQuantityDisplayShort}
@@ -485,7 +481,6 @@ export default function TransactionRow(props: propsIF) {
                     justifyContent: 'flex-end',
                     gap: '4px',
                     textAlign: 'right',
-                    fontFamily: 'monospace',
                 }}
             >
                 {quoteQuantityDisplayShort}
@@ -570,7 +565,6 @@ export default function TransactionRow(props: propsIF) {
                             className={'gradient_text'}
                             style={{
                                 textAlign: 'right',
-                                fontFamily: 'monospace',
                                 textTransform: 'lowercase',
                             }}
                         >
@@ -590,7 +584,7 @@ export default function TransactionRow(props: propsIF) {
                                         ? priceCharacter
                                         : '…'}
                                 </span>
-                                <span style={{ fontFamily: 'monospace' }}>
+                                <span>
                                     {isOnPortfolioPage
                                         ? truncatedLowDisplayPriceDenomByMoneyness
                                         : truncatedLowDisplayPrice}
@@ -602,7 +596,7 @@ export default function TransactionRow(props: propsIF) {
                                         ? priceCharacter
                                         : '…'}
                                 </span>
-                                <span style={{ fontFamily: 'monospace' }}>
+                                <span>
                                     {isOnPortfolioPage
                                         ? truncatedHighDisplayPriceDenomByMoneyness
                                         : truncatedHighDisplayPrice}
@@ -623,7 +617,6 @@ export default function TransactionRow(props: propsIF) {
                         }}
                         data-label='price'
                         className={`${styles.align_right}  ${priceStyle}`}
-                        style={{ fontFamily: 'monospace' }}
                     >
                         {isOnPortfolioPage
                             ? (
@@ -633,7 +626,7 @@ export default function TransactionRow(props: propsIF) {
                                               ? priceCharacter
                                               : '…'}
                                       </span>
-                                      <span style={{ fontFamily: 'monospace' }}>
+                                      <span>
                                           {
                                               truncatedDisplayPriceDenomByMoneyness
                                           }
@@ -647,9 +640,7 @@ export default function TransactionRow(props: propsIF) {
                                               ? priceCharacter
                                               : '…'}
                                       </span>
-                                      <span style={{ fontFamily: 'monospace' }}>
-                                          {truncatedDisplayPrice}
-                                      </span>
+                                      <span>{truncatedDisplayPrice}</span>
                                   </p>
                               ) || '…'}
                     </li>
@@ -714,7 +705,6 @@ export default function TransactionRow(props: propsIF) {
                     <div
                         className={`${styles.token_qty} ${positiveDisplayStyle}`}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >
@@ -738,7 +728,6 @@ export default function TransactionRow(props: propsIF) {
                     <div
                         className={`${styles.token_qty} ${negativeDisplayStyle}`}
                         style={{
-                            fontFamily: 'monospace',
                             whiteSpace: 'nowrap',
                         }}
                     >

--- a/src/css/GlobalCssClassnames.css
+++ b/src/css/GlobalCssClassnames.css
@@ -44,33 +44,11 @@
 /* apy */
 
 .apy_positive {
-    /* apr/green */
-
-    /* background: linear-gradient(90deg, #15be6f 32.38%, #8fe9bf 51.39%, #15be6f 68.17%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-fill-color: transparent;
-
-    text-shadow: 0px 0px 10px rgba(21, 190, 111, 0.75); */
-
     color: var(--text-grey-light);
-    font-family: monospace;
 }
 
 .apy_negative {
-    /* apr/green */
-
-    /* background: linear-gradient(90deg, #be4515 32.38%, #de5a2e 51.39%, #be5315 68.17%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    text-fill-color: transparent;
-
-    text-shadow: 0px 0px 10px rgba(190, 100, 21, 0.75); */
-
     color: var(--text-grey-light);
-    font-family: monospace;
 }
 
 /* sort */


### PR DESCRIPTION
### Describe your changes 

Removed monospace fonts as per table design here: https://www.figma.com/file/0ItLk4nJmtj741R8sn3HYp/ambient?node-id=4435-61252&t=tRzfMsNvA2hf8wE8-0

Noticed that the status circle logos on Range and Leaderboard tables were not centered, reworked CSS to simply and always make centered by using box-shadow.

### Link the related issue

Closes #1486 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
