### PR TITLE
Hide Leaderboard toggle immediately

### DIFF
--- a/src/components/Trade/TradeTabs/PositionsOnlyToggle/PositionsOnlyToggle.tsx
+++ b/src/components/Trade/TradeTabs/PositionsOnlyToggle/PositionsOnlyToggle.tsx
@@ -87,6 +87,7 @@ export default function PositionsOnlyToggle(props: PositionsOnlyToggleProps) {
     const toggleOrNull =
         !isUserLoggedIn ||
         isCandleSelected ||
+        // hide toggle if current tab is leaderboard since React state takes time to update
         props.currentTab == LeaderboardTabName ? null : (
             <Toggle2
                 isOn={!isShowAllEnabled}
@@ -136,6 +137,7 @@ export default function PositionsOnlyToggle(props: PositionsOnlyToggleProps) {
                 >
                     {isUserLoggedIn &&
                     !isCandleSelected &&
+                    // hide toggle if current tab is leaderboard since React state takes time to update
                     props.currentTab !== LeaderboardTabName
                         ? `My ${props.currentTab}`
                         : null}


### PR DESCRIPTION
### Describe your changes 

React UseEffect() does not cause re-render immediately, resulting in a state where the 'My Leaderboard' toggle was visible and usable for a second upon selecting Leaderboard tab. This change uses the tab name to hide the toggle if the current tab is Leaderboard. 

### Link the related issue

Closes #1475

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
