### PR TITLE
Cleanup of solo token slice naming

### DIFF
--- a/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
@@ -3,14 +3,13 @@ import { useNavigate } from 'react-router-dom';
 import { TokenIF, TokenPairIF } from '../../../utils/interfaces/exports';
 import TokenSelect from '../TokenSelect/TokenSelect';
 import { useAppDispatch } from '../../../utils/hooks/reduxToolkit';
-import { setToken } from '../../../utils/state/temp';
-// import { useSoloSearch } from './useSoloSearch';
 import styles from './SoloTokenSelect.module.css';
 import { memoizeFetchContractDetails } from '../../../App/functions/fetchContractDetails';
 import { ethers } from 'ethers';
 import SoloTokenImport from './SoloTokenImport';
 import { useLocationSlug } from './hooks/useLocationSlug';
 import { setShouldRecheckLocalStorage } from '../../../utils/state/userDataSlice';
+import { setSoloToken } from '../../../utils/state/soloTokenDataSlice';
 // import SimpleLoader from '../LoadingAnimations/SimpleLoader/SimpleLoader';
 // import { AiOutlineQuestionCircle } from 'react-icons/ai';
 
@@ -105,7 +104,7 @@ export const SoloTokenSelect = (props: propsIF) => {
         }
         // dispatch token data object to RTK
         if (isSingleToken) {
-            dispatch(setToken(tkn));
+            dispatch(setSoloToken(tkn));
         }
         // // determine if the token is a previously imported token
         // const isTokenImported: boolean = importedTokens.some(

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -163,7 +163,9 @@ export default function Portfolio(props: propsIF) {
 
     const isUserLoggedIn = isConnected;
 
-    const selectedToken: TokenIF = useAppSelector((state) => state.temp.token);
+    const selectedToken: TokenIF = useAppSelector(
+        (state) => state.soloTokenData.token,
+    );
 
     const [tokenAllowance, setTokenAllowance] = useState<string>('');
     const [recheckTokenAllowance, setRecheckTokenAllowance] =

--- a/src/utils/state/soloTokenDataSlice.ts
+++ b/src/utils/state/soloTokenDataSlice.ts
@@ -2,25 +2,25 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit';
 import { goerliETH } from '../data/defaultTokens';
 import { TokenIF } from '../interfaces/exports';
 
-export interface stuff {
+interface soloTokenData {
     token: TokenIF;
 }
 
-const initialState: stuff = {
+const initialState: soloTokenData = {
     token: goerliETH,
 };
 
-export const tempSlice = createSlice({
-    name: 'temp',
+const soloTokenDataSlice = createSlice({
+    name: 'soloTokenData',
     initialState,
     reducers: {
-        setToken: (state, action: PayloadAction<TokenIF>) => {
+        setSoloToken: (state, action: PayloadAction<TokenIF>) => {
             state.token = action.payload;
         },
     },
 });
 
 // action creators are generated for each case reducer function
-export const { setToken } = tempSlice.actions;
+export const { setSoloToken } = soloTokenDataSlice.actions;
 
-export default tempSlice.reducer;
+export default soloTokenDataSlice.reducer;

--- a/src/utils/state/store.ts
+++ b/src/utils/state/store.ts
@@ -3,7 +3,7 @@ import tradeDataReducer from './tradeDataSlice';
 import graphDataReducer from './graphDataSlice';
 import receiptDataReducer from './receiptDataSlice';
 import userDataReducer from './userDataSlice';
-import tempReducer from './temp';
+import soloTokenReducer from './soloTokenDataSlice';
 
 export const store = configureStore({
     reducer: {
@@ -11,7 +11,7 @@ export const store = configureStore({
         graphData: graphDataReducer,
         receiptData: receiptDataReducer,
         userData: userDataReducer,
-        temp: tempReducer,
+        soloTokenData: soloTokenReducer,
     },
 });
 


### PR DESCRIPTION
Re-write the solo token redux slice so that it uses a more descriptiv…e name than temp and stuff

### Describe your changes 

The redux slice for solo token was in a file called `temp.ts` and the prop interface was `stuff`. This made it difficult to determine what the purpose of the code was. This push changes the naming convention to use more descriptive naming around "solo token".

Also the dispatch was called '`setToken` which was confusing because it specifically referred to solo token selectors like found in the deposit component. That was changed to `setSoloToken`

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [X ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ X] Does my code following the style guide at `docs/CODING-STYLE.md`?
