### PR TITLE
Set ghost lines to be based on real tick grid

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.2",
     "private": true,
     "dependencies": {
-        "@crocswap-libs/sdk": "^0.2.55",
+        "@crocswap-libs/sdk": "^0.2.56",
         "@d3fc/d3fc-extent": "^4.0.2",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",


### PR DESCRIPTION
### Describe your changes 

The ghost lines around the price line selector in the limit order chart were previously based on mock value. This update makes them reflect the real lines from the pool grid.


### Checklist before requesting a review
- [ X] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [X ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [X ] Does my code following the style guide at `docs/CODING-STYLE.md`?
