### PR TITLE
Account Page - Disable Transfer + Withdraw buttons + inputs during transaction

### DIFF
--- a/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
@@ -99,6 +99,10 @@ export default function Transfer(props: propsIF) {
     >();
     const [buttonMessage, setButtonMessage] = useState<string>('...');
     const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
+    const [isCurrencyFieldDisabled, setIsCurrencyFieldDisabled] =
+        useState<boolean>(true);
+    const [isAddressFieldDisabled, setIsAddressFieldDisabled] =
+        useState<boolean>(true);
     const [sendToAddressDexBalance, setSendToAddressDexBalance] =
         useState<string>('');
     const [recheckSendToAddressDexBalance, setRecheckSendToAddressDexBalance] =
@@ -196,20 +200,30 @@ export default function Transfer(props: propsIF) {
         // console.log({ isTokenAllowanceSufficient });
         if (!isResolvedAddressValid) {
             setIsButtonDisabled(true);
+            setIsAddressFieldDisabled(false);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Please Enter a Valid Address');
         } else if (!transferQtyNonDisplay) {
             setIsButtonDisabled(true);
+            setIsAddressFieldDisabled(false);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Enter a Transfer Amount');
         } else if (!isDexBalanceSufficient) {
             setIsButtonDisabled(true);
+            setIsAddressFieldDisabled(false);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage(
                 `${selectedToken.symbol} Exchange Balance Insufficient`,
             );
         } else if (isTransferPending) {
             setIsButtonDisabled(true);
+            setIsAddressFieldDisabled(true);
+            setIsCurrencyFieldDisabled(true);
             setButtonMessage(`${selectedToken.symbol} Transfer Pending`);
         } else if (isTransferQtyValid) {
             setIsButtonDisabled(false);
+            setIsAddressFieldDisabled(false);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Transfer');
         }
     }, [
@@ -396,6 +410,7 @@ export default function Transfer(props: propsIF) {
                 fieldId='exchange-balance-transfer-address'
                 setTransferToAddress={setSendToAddress}
                 sendToAddress={sendToAddress}
+                disable={isAddressFieldDisabled}
             />
             <TransferCurrencySelector
                 fieldId='exchange-balance-transfer'
@@ -404,6 +419,7 @@ export default function Transfer(props: propsIF) {
                 setTransferQty={setTransferQtyNonDisplay}
                 inputValue={inputValue}
                 setInputValue={setInputValue}
+                disable={isCurrencyFieldDisabled}
             />
             <div
                 onClick={handleBalanceClick}

--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferButton/TransferButton.module.css
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferButton/TransferButton.module.css
@@ -1,0 +1,3 @@
+.button_container_disabled button {
+    color: var(--text-grey-dark);
+}

--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferButton/TransferButton.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferButton/TransferButton.tsx
@@ -11,7 +11,13 @@ export default function TransferButton(props: PortfolioTransferButtonProps) {
     const { onClick, disabled, buttonMessage } = props;
 
     const ButtonDisplay = (
-        <div className={styles.button_container}>
+        <div
+            className={
+                disabled
+                    ? styles.button_container_disabled
+                    : styles.button_container
+            }
+        >
             <Button
                 title={buttonMessage}
                 // action={() => console.log('clicked')}

--- a/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
@@ -119,6 +119,8 @@ export default function Withdraw(props: propsIF) {
     >();
     const [buttonMessage, setButtonMessage] = useState<string>('...');
     const [isButtonDisabled, setIsButtonDisabled] = useState<boolean>(true);
+    const [isCurrencyFieldDisabled, setIsCurrencyFieldDisabled] =
+        useState<boolean>(true);
 
     const [isSendToAddressChecked, setIsSendToAddressChecked] =
         useState<boolean>(false);
@@ -214,20 +216,25 @@ export default function Withdraw(props: propsIF) {
     useEffect(() => {
         if (isSendToAddressChecked && !isResolvedAddressValid) {
             setIsButtonDisabled(true);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Please Enter a Valid Address');
         } else if (!withdrawQtyNonDisplay) {
             setIsButtonDisabled(true);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Enter a Withdrawal Amount');
         } else if (!isDexBalanceSufficient) {
             setIsButtonDisabled(true);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage(
                 `${selectedToken.symbol} Exchange Balance Insufficient`,
             );
         } else if (isWithdrawPending) {
             setIsButtonDisabled(true);
+            setIsCurrencyFieldDisabled(true);
             setButtonMessage(`${selectedToken.symbol} Withdrawal Pending`);
         } else if (isWithdrawQtyValid) {
             setIsButtonDisabled(false);
+            setIsCurrencyFieldDisabled(false);
             setButtonMessage('Withdraw');
         }
     }, [
@@ -456,6 +463,7 @@ export default function Withdraw(props: propsIF) {
                 setIsSendToAddressChecked={setIsSendToAddressChecked}
                 inputValue={inputValue}
                 setInputValue={setInputValue}
+                disable={isCurrencyFieldDisabled}
             />
             <div
                 onClick={handleBalanceClick}

--- a/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawButton/WithdrawButton.module.css
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawButton/WithdrawButton.module.css
@@ -1,0 +1,3 @@
+.button_container_disabled button {
+    color: var(--text-grey-dark);
+}

--- a/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawButton/WithdrawButton.tsx
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawButton/WithdrawButton.tsx
@@ -11,7 +11,13 @@ export default function WithdrawButton(props: PortfolioWithdrawButtonProps) {
     const { onClick, disabled, buttonMessage } = props;
 
     const ButtonDisplay = (
-        <div className={styles.button_container}>
+        <div
+            className={
+                disabled
+                    ? styles.button_container_disabled
+                    : styles.button_container
+            }
+        >
             <Button
                 title={buttonMessage}
                 // action={() => console.log('clicked')}


### PR DESCRIPTION
### Describe your changes 

Disables inputs on Account Page during Transfer + Withdraw transactions.

<img width="442" alt="Screenshot 2023-04-04 at 2 05 33 PM" src="https://user-images.githubusercontent.com/6332196/229879873-ca944ec1-7ef0-4d02-a479-0685fb1078b5.png">
<img width="424" alt="Screenshot 2023-04-04 at 2 05 53 PM" src="https://user-images.githubusercontent.com/6332196/229879880-acd53e44-c0d8-4c8e-b5a7-1c41241768d7.png">

### Link the related issue

Closes #1618 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
