### PR TITLE
Account Page - add token address tooltips

### DIFF
--- a/src/components/Portfolio/EchangeBalance/Deposit/DepositCurrencySelector/DepositCurrencySelector.tsx
+++ b/src/components/Portfolio/EchangeBalance/Deposit/DepositCurrencySelector/DepositCurrencySelector.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { fromDisplayQty } from '@crocswap-libs/sdk';
 import uriToHttp from '../../../../../utils/functions/uriToHttp';
 import NoTokenIcon from '../../../../Global/NoTokenIcon/NoTokenIcon';
+import { DefaultTooltip } from '../../../../Global/StyledTooltip/StyledTooltip';
 
 interface propsIF {
     fieldId: string;
@@ -68,27 +69,36 @@ export default function DepositCurrencySelector(props: propsIF) {
             <span className={styles.direction}>Select Token</span>
             <div className={styles.swapbox_top}>
                 <div className={styles.swap_input}>{qtyInput}</div>
-                <div className={styles.token_select} onClick={onClick}>
-                    {selectedToken.logoURI ? (
-                        <img
-                            className={styles.token_list_img}
-                            src={uriToHttp(selectedToken.logoURI)}
-                            alt={selectedToken.symbol.charAt(0)}
-                            // alt={`logo for token ${token.name}`}
-                            width='30px'
-                        />
-                    ) : (
-                        <NoTokenIcon
-                            tokenInitial={selectedToken.symbol.charAt(0)}
-                            width='30px'
-                        />
-                    )}
+                <DefaultTooltip
+                    interactive
+                    title={`${selectedToken.symbol + ':'} ${
+                        selectedToken.address
+                    }`}
+                    placement={'top'}
+                    enterDelay={200}
+                >
+                    <div className={styles.token_select} onClick={onClick}>
+                        {selectedToken.logoURI ? (
+                            <img
+                                className={styles.token_list_img}
+                                src={uriToHttp(selectedToken.logoURI)}
+                                alt={selectedToken.symbol.charAt(0)}
+                                // alt={`logo for token ${token.name}`}
+                                width='30px'
+                            />
+                        ) : (
+                            <NoTokenIcon
+                                tokenInitial={selectedToken.symbol.charAt(0)}
+                                width='30px'
+                            />
+                        )}
 
-                    <span className={styles.token_list_text}>
-                        {selectedToken.symbol}
-                    </span>
-                    <RiArrowDownSLine size={27} />
-                </div>
+                        <span className={styles.token_list_text}>
+                            {selectedToken.symbol}
+                        </span>
+                        <RiArrowDownSLine size={27} />
+                    </div>
+                </DefaultTooltip>
             </div>
         </div>
     );

--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferCurrencySelector/TransferCurrencySelector.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferCurrencySelector/TransferCurrencySelector.tsx
@@ -5,6 +5,7 @@ import { Dispatch, SetStateAction } from 'react';
 import { fromDisplayQty } from '@crocswap-libs/sdk';
 import uriToHttp from '../../../../../utils/functions/uriToHttp';
 import NoTokenIcon from '../../../../Global/NoTokenIcon/NoTokenIcon';
+import { DefaultTooltip } from '../../../../Global/StyledTooltip/StyledTooltip';
 
 interface propsIF {
     fieldId: string;
@@ -69,27 +70,36 @@ export default function TransferCurrencySelector(props: propsIF) {
             <span className={styles.direction}>Select Token</span>
             <div className={styles.swapbox_top}>
                 <div className={styles.swap_input}>{rateInput}</div>
-                <div className={styles.token_select} onClick={onClick}>
-                    {selectedToken.logoURI ? (
-                        <img
-                            className={styles.token_list_img}
-                            src={uriToHttp(selectedToken.logoURI)}
-                            alt={selectedToken.symbol.charAt(0)}
-                            // alt={`logo for token ${token.name}`}
-                            width='30px'
-                        />
-                    ) : (
-                        <NoTokenIcon
-                            tokenInitial={selectedToken.symbol.charAt(0)}
-                            width='30px'
-                        />
-                    )}
+                <DefaultTooltip
+                    interactive
+                    title={`${selectedToken.symbol + ':'} ${
+                        selectedToken.address
+                    }`}
+                    placement={'top'}
+                    enterDelay={200}
+                >
+                    <div className={styles.token_select} onClick={onClick}>
+                        {selectedToken.logoURI ? (
+                            <img
+                                className={styles.token_list_img}
+                                src={uriToHttp(selectedToken.logoURI)}
+                                alt={selectedToken.symbol.charAt(0)}
+                                // alt={`logo for token ${token.name}`}
+                                width='30px'
+                            />
+                        ) : (
+                            <NoTokenIcon
+                                tokenInitial={selectedToken.symbol.charAt(0)}
+                                width='30px'
+                            />
+                        )}
 
-                    <span className={styles.token_list_text}>
-                        {selectedToken.symbol}
-                    </span>
-                    <RiArrowDownSLine size={27} />
-                </div>
+                        <span className={styles.token_list_text}>
+                            {selectedToken.symbol}
+                        </span>
+                        <RiArrowDownSLine size={27} />
+                    </div>
+                </DefaultTooltip>
             </div>
         </div>
     );

--- a/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawCurrencySelector/WithdrawCurrencySelector.tsx
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/WithdrawCurrencySelector/WithdrawCurrencySelector.tsx
@@ -5,6 +5,7 @@ import { TokenIF } from '../../../../../utils/interfaces/exports';
 import { fromDisplayQty } from '@crocswap-libs/sdk';
 import NoTokenIcon from '../../../../Global/NoTokenIcon/NoTokenIcon';
 import uriToHttp from '../../../../../utils/functions/uriToHttp';
+import { DefaultTooltip } from '../../../../Global/StyledTooltip/StyledTooltip';
 
 interface propsIF {
     fieldId: string;
@@ -70,27 +71,36 @@ export default function WithdrawCurrencySelector(props: propsIF) {
             <span className={styles.direction}>Select Token</span>
             <div className={styles.swapbox_top}>
                 <div className={styles.swap_input}>{rateInput}</div>
-                <div className={styles.token_select} onClick={onClick}>
-                    {selectedToken.logoURI ? (
-                        <img
-                            className={styles.token_list_img}
-                            src={uriToHttp(selectedToken.logoURI)}
-                            alt={selectedToken.symbol.charAt(0)}
-                            // alt={`logo for token ${token.name}`}
-                            width='30px'
-                        />
-                    ) : (
-                        <NoTokenIcon
-                            tokenInitial={selectedToken.symbol.charAt(0)}
-                            width='30px'
-                        />
-                    )}
+                <DefaultTooltip
+                    interactive
+                    title={`${selectedToken.symbol + ':'} ${
+                        selectedToken.address
+                    }`}
+                    placement={'top'}
+                    enterDelay={200}
+                >
+                    <div className={styles.token_select} onClick={onClick}>
+                        {selectedToken.logoURI ? (
+                            <img
+                                className={styles.token_list_img}
+                                src={uriToHttp(selectedToken.logoURI)}
+                                alt={selectedToken.symbol.charAt(0)}
+                                // alt={`logo for token ${token.name}`}
+                                width='30px'
+                            />
+                        ) : (
+                            <NoTokenIcon
+                                tokenInitial={selectedToken.symbol.charAt(0)}
+                                width='30px'
+                            />
+                        )}
 
-                    <span className={styles.token_list_text}>
-                        {selectedToken.symbol}
-                    </span>
-                    <RiArrowDownSLine size={27} />
-                </div>
+                        <span className={styles.token_list_text}>
+                            {selectedToken.symbol}
+                        </span>
+                        <RiArrowDownSLine size={27} />
+                    </div>
+                </DefaultTooltip>
             </div>
         </div>
     );


### PR DESCRIPTION
### Describe your changes 

Added tooltips to token dropdowns on Account Page to show token addresses.

<img width="495" alt="Screenshot 2023-04-04 at 4 11 45 PM" src="https://user-images.githubusercontent.com/6332196/229909390-b5e5aa35-e351-4c5f-b6e1-a2475d0f103c.png">

### Link the related issue

Closes #1594 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
