### PR TITLE
bug fix #1765: only re-calculate out of range status against current …

### DIFF
--- a/src/components/RangeDetails/RangeDetails.tsx
+++ b/src/components/RangeDetails/RangeDetails.tsx
@@ -394,6 +394,7 @@ export default function RangeDetails(props: propsIF) {
                     position={position}
                     baseFeesDisplay={baseFeesDisplay}
                     quoteFeesDisplay={quoteFeesDisplay}
+                    isOnPortfolioPage={isOnPortfolioPage}
                 />
             )}
             {snackbarContent}

--- a/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
+++ b/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
@@ -23,11 +23,18 @@ interface RangeDetailsSimplifyPropsIF {
     account: string;
     baseFeesDisplay: string | undefined;
     quoteFeesDisplay: string | undefined;
+    isOnPortfolioPage: boolean;
 }
 export default function RangeDetailsSimplify(
     props: RangeDetailsSimplifyPropsIF,
 ) {
-    const { account, position, baseFeesDisplay, quoteFeesDisplay } = props;
+    const {
+        account,
+        position,
+        baseFeesDisplay,
+        quoteFeesDisplay,
+        isOnPortfolioPage,
+    } = props;
 
     const {
         userNameToDisplay,
@@ -52,7 +59,7 @@ export default function RangeDetailsSimplify(
         tokenBAddressLowerCase,
         baseDisplayFrontend,
         quoteDisplayFrontend,
-    } = useProcessRange(position, account);
+    } = useProcessRange(position, account, isOnPortfolioPage);
 
     const [openSnackbar, setOpenSnackbar] = useState(false);
 


### PR DESCRIPTION
…pool price while on /trade

### Describe your changes 

fix out of range indicator error on non-active pool range details cards, when accessed from portfolio

### Link the related issue

fixes #1765

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
