### PR TITLE
Render speedup for /trade

### DIFF
--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -472,7 +472,44 @@ export default function Ranges(props: propsIF) {
             ))}
         </ul>
     );
-    const rowItemContent = usePaginateDataOrNull?.map((position, idx) => (
+    const sortedRowItemContent = sortedPositions.map((position, idx) => (
+        <RangesRow
+            cachedQuerySpotPrice={cachedQuerySpotPrice}
+            account={account}
+            key={idx}
+            // key={`Ranges-Row-wefwewa4564f-${JSON.stringify(position)}`}
+            position={position}
+            currentPositionActive={currentPositionActive}
+            setCurrentPositionActive={setCurrentPositionActive}
+            openGlobalModal={props.openGlobalModal}
+            closeGlobalModal={props.closeGlobalModal}
+            isShowAllEnabled={isShowAllEnabled}
+            ipadView={ipadView}
+            showColumns={showColumns}
+            showSidebar={showSidebar}
+            isUserLoggedIn={isUserLoggedIn}
+            crocEnv={crocEnv}
+            chainData={chainData}
+            provider={provider}
+            chainId={chainId}
+            baseTokenBalance={baseTokenBalance}
+            quoteTokenBalance={quoteTokenBalance}
+            baseTokenDexBalance={baseTokenDexBalance}
+            quoteTokenDexBalance={quoteTokenDexBalance}
+            lastBlockNumber={lastBlockNumber}
+            isOnPortfolioPage={isOnPortfolioPage}
+            idx={idx}
+            handlePulseAnimation={handlePulseAnimation}
+            showPair={showPair}
+            setSimpleRangeWidth={setSimpleRangeWidth}
+            dexBalancePrefs={dexBalancePrefs}
+            slippage={slippage}
+            gasPriceInGwei={gasPriceInGwei}
+            ethMainnetUsdPrice={ethMainnetUsdPrice}
+        />
+    ));
+
+    const currentRowItemContent = currentRanges.map((position, idx) => (
         <RangesRow
             cachedQuerySpotPrice={cachedQuerySpotPrice}
             account={account}
@@ -520,7 +557,11 @@ export default function Ranges(props: propsIF) {
         ? 'calc(100vh - 19.5rem)'
         : expandStyle;
     const rangeDataOrNull = rangeData.length ? (
-        rowItemContent
+        usePaginateDataOrNull ? (
+            currentRowItemContent
+        ) : (
+            sortedRowItemContent
+        )
     ) : (
         <NoTableData
             isShowAllEnabled={isShowAllEnabled}

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -632,7 +632,31 @@ export default function Transactions(props: propsIF) {
         </div>
     );
 
-    const rowItemContent = usePaginateDataOrNull?.map((tx, idx) => (
+    const currentRowItemContent = currentTransactions.map((tx, idx) => (
+        <TransactionRow
+            account={account}
+            key={idx}
+            tx={tx}
+            tradeData={tradeData}
+            isTokenABase={isTokenABase}
+            currentTxActiveInTransactions={currentTxActiveInTransactions}
+            setCurrentTxActiveInTransactions={setCurrentTxActiveInTransactions}
+            openGlobalModal={openGlobalModal}
+            isShowAllEnabled={isShowAllEnabled}
+            ipadView={ipadView}
+            showColumns={showColumns}
+            view2={view2}
+            showPair={showPair}
+            showSidebar={showSidebar}
+            blockExplorer={blockExplorer}
+            closeGlobalModal={closeGlobalModal}
+            isOnPortfolioPage={isOnPortfolioPage}
+            handlePulseAnimation={handlePulseAnimation}
+            setSimpleRangeWidth={setSimpleRangeWidth}
+            chainData={chainData}
+        />
+    ));
+    const sortedRowItemContent = sortedTransactions.map((tx, idx) => (
         <TransactionRow
             account={account}
             key={idx}
@@ -697,7 +721,11 @@ export default function Transactions(props: propsIF) {
         />
     ) : (
         <div onKeyDown={handleKeyDown}>
-            <ul ref={listRef}>{rowItemContent}</ul>
+            <ul ref={listRef}>
+                {usePaginateDataOrNull
+                    ? currentRowItemContent
+                    : sortedRowItemContent}
+            </ul>
         </div>
     );
 


### PR DESCRIPTION
### Describe your changes 

Noticed that the Trade and Range table rows were the source of a lot of rendering slowdown.

This PR adds the additional step of pre-calculating both the `current` and `sorted` tables, which saves us from constructing the `Trade` or `Range` table rows every time the page is loaded. 

To see the benefits of this: 

1. open the preview for this PR in tab A [here](https://deploy-preview-1779--ambient-finance.netlify.app/trade/market/chain=0x5&tokenA=0xD87Ba7A50B2E7E660f678A895E4B72E7CB4CCd9C&tokenB=0x0000000000000000000000000000000000000000&lowTick=0&highTick=0)
2. open the preview for main in tab B [here](https://testnet.ambient.finance/trade/market/chain=0x5&tokenA=0xD87Ba7A50B2E7E660f678A895E4B72E7CB4CCd9C&tokenB=0x0000000000000000000000000000000000000000&lowTick=0&highTick=0)
3. flip between `Trade` and `Pool` in the page header, and witness the smoothness of the animation in the header (underline)

 

### Link the related issue

closes #1690 

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
