### PR TITLE
fix max width and styling of cards container on home page

### DIFF
--- a/src/components/Home/Stats/Stats.module.css
+++ b/src/components/Home/Stats/Stats.module.css
@@ -1,6 +1,7 @@
 .container {
     display: flex;
     flex-direction: column;
+
     gap: 1rem;
     padding: 4rem 0;
 }
@@ -20,12 +21,20 @@
     outline: none;
     }
 .content {
-    max-width: 1120px;
+    max-width: 1200px;
     margin: 0 auto;
 
-    display: grid;
-    grid-gap: 1rem;
+
     list-style-type: none;
+
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
+   
+
+    
 }
 
 .stat_card_container {
@@ -66,14 +75,4 @@
     color: var(--text-grey-white);
     font-family: var(--mono);
 }
-@media (min-width: 600px) {
-    .content {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
 
-@media (min-width: 900px) {
-    .content {
-        grid-template-columns: repeat(3, 1fr);
-    }
-}

--- a/src/components/Home/TopPools/TopPools.module.css
+++ b/src/components/Home/TopPools/TopPools.module.css
@@ -22,28 +22,19 @@ outline: none;
 }
 
 .content {
-    --auto-grid-min-size: 300px;
-    max-width: 1120px;
+    max-width: 1200px;
     margin: 0 auto;
-    display: grid;
-    grid-gap: 1rem;
+
     list-style-type: none;
-    /* grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); */
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    align-items: center;
+    gap: 1rem;
 }
 
 .divider {
     width: 100%;
     height: 1px;
     background: var(--border);
-}
-@media (min-width: 600px) {
-    .content {
-        grid-template-columns: repeat(2, 1fr);
-    }
-}
-
-@media (min-width: 900px) {
-    .content {
-        grid-template-columns: repeat(4, 1fr);
-    }
 }


### PR DESCRIPTION
### Describe your changes 
Doug pointed out that when there is only one card on the home page, it ends up all the way on the left instead of being centered. This PR should solve this for all the cards on the landing page.

**TO TEST:** 
Go into TopPools.tsx in /Home. Slice the mapped variable so it only returns 1 item in the array:
`topPools.slice(0,1).map((pool, idx)`


_Describe the purpose + content of these changes_

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
