### PR TITLE
Remove any hardcoded reference to pool index number

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -2869,6 +2869,7 @@ export default function App() {
         toggleSidebar: toggleSidebar,
         setShowSidebar: setShowSidebar,
         chainId: chainData.chainId,
+        poolId: chainData.poolIndex,
 
         currentTxActiveInTransactions: currentTxActiveInTransactions,
         setCurrentTxActiveInTransactions: setCurrentTxActiveInTransactions,

--- a/src/App/components/Sidebar/Sidebar.tsx
+++ b/src/App/components/Sidebar/Sidebar.tsx
@@ -64,6 +64,7 @@ interface propsIF {
         event: MouseEvent<HTMLDivElement> | MouseEvent<HTMLLIElement>,
     ) => void;
     chainId: string;
+    poolId: number;
     currentTxActiveInTransactions: string;
     setCurrentTxActiveInTransactions: Dispatch<SetStateAction<string>>;
     currentPositionActive: string;
@@ -102,6 +103,7 @@ export default function Sidebar(props: propsIF) {
         toggleSidebar,
         showSidebar,
         chainId,
+        poolId,
         currentTxActiveInTransactions,
         setCurrentTxActiveInTransactions,
         setCurrentPositionActive,
@@ -227,6 +229,7 @@ export default function Sidebar(props: propsIF) {
                     cachedPoolStatsFetch={cachedPoolStatsFetch}
                     lastBlockNumber={lastBlockNumber}
                     chainId={chainId}
+                    poolId={poolId}
                 />
             ),
         },

--- a/src/App/components/Sidebar/SidebarSearchResults/PoolsSearchResults/PoolLI.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/PoolsSearchResults/PoolLI.tsx
@@ -72,7 +72,7 @@ export default function PoolLI(props: propsIF) {
                 chainId,
                 pool.base,
                 pool.quote,
-                pool.poolIdx ?? 36000,
+                pool.poolIdx,
                 1,
             );
             const volume = poolStatsFresh?.volumeTotal; // display the total volume for all time

--- a/src/components/Chat/FullChat/FullChat.tsx
+++ b/src/components/Chat/FullChat/FullChat.tsx
@@ -91,7 +91,9 @@ export default function FullChat(props: FullChatPropsIF) {
     );
 
     // eslint-disable-next-line
-    const [readableRoom, setReadableRoom] = useState<any>();
+    const [readableRoom, setReadableRoom] = useState<PoolIF | undefined>(
+        undefined,
+    );
     const [showChannelsDropdown, setShowChannelsDropdown] = useState(false);
 
     useEffect(() => {
@@ -471,26 +473,30 @@ export default function FullChat(props: FullChatPropsIF) {
         </div>
     );
 
-    const isButtonFavorited = props.favePools.check(
-        readableRoom?.base.address,
-        readableRoom?.quote.address,
-        readableRoom?.chainId,
-        readableRoom?.poolId,
-    );
+    const isButtonFavorited =
+        readableRoom &&
+        props.favePools.check(
+            readableRoom.base.address,
+            readableRoom.quote.address,
+            readableRoom.chainId,
+            readableRoom.poolId,
+        );
     function handleFavButton() {
-        isButtonFavorited
-            ? props.favePools.remove(
-                  readableRoom.quote,
-                  readableRoom.base,
-                  readableRoom?.chainId,
-                  36000,
-              )
-            : props.favePools.add(
-                  readableRoom.quote,
-                  readableRoom.base,
-                  readableRoom?.chainId,
-                  36000,
-              );
+        if (readableRoom) {
+            isButtonFavorited
+                ? props.favePools.remove(
+                      readableRoom.quote,
+                      readableRoom.base,
+                      readableRoom.chainId,
+                      readableRoom.poolId,
+                  )
+                : props.favePools.add(
+                      readableRoom.quote,
+                      readableRoom.base,
+                      readableRoom.chainId,
+                      readableRoom.poolId,
+                  );
+        }
     }
 
     const favButton = !currentRoomIsGlobal ? (

--- a/src/components/Global/Sidebar/FavoritePools/FavoritePools.tsx
+++ b/src/components/Global/Sidebar/FavoritePools/FavoritePools.tsx
@@ -9,10 +9,17 @@ interface propsIF {
     lastBlockNumber: number;
     cachedPoolStatsFetch: PoolStatsFn;
     chainId: string;
+    poolId: number;
 }
 
 export default function FavoritePools(props: propsIF) {
-    const { favePools, lastBlockNumber, cachedPoolStatsFetch, chainId } = props;
+    const {
+        favePools,
+        lastBlockNumber,
+        cachedPoolStatsFetch,
+        chainId,
+        poolId,
+    } = props;
 
     const { tradeData } = useAppSelector((state) => state);
 
@@ -20,7 +27,7 @@ export default function FavoritePools(props: propsIF) {
         tradeData.baseToken.address,
         tradeData.quoteToken.address,
         chainId,
-        36000,
+        poolId,
     );
 
     // TODO:   @Junior  please refactor the header <div> as a <header> element
@@ -40,7 +47,7 @@ export default function FavoritePools(props: propsIF) {
                             tradeData.baseToken,
                             tradeData.quoteToken,
                             chainId,
-                            36000,
+                            poolId,
                         )
                     }
                 >

--- a/src/components/Pools/PoolRow.tsx
+++ b/src/components/Pools/PoolRow.tsx
@@ -65,13 +65,13 @@ export default function PoolRow(props: propsIF) {
                   { address: poolData.token0.address } as TokenIF,
                   { address: poolData.token1.address } as TokenIF,
                   '',
-                  36000,
+                  pool.poolId,
               )
             : favePools.add(
                   { address: poolData.token0.address } as TokenIF,
                   { address: poolData.token1.address } as TokenIF,
                   '',
-                  36000,
+                  pool.poolId,
               );
         event.stopPropagation();
     };

--- a/src/components/Trade/TradeTabs/TradeTabs2.tsx
+++ b/src/components/Trade/TradeTabs/TradeTabs2.tsx
@@ -507,6 +507,7 @@ export default function TradeTabs2(props: propsIF) {
 
     const TradeChartsTokenInfoProps = {
         chainId: chainId,
+        poolId: chainData.poolIndex,
         favePools: favePools,
         poolPriceDisplay: poolPriceDisplay,
         poolPriceChangePercent: poolPriceChangePercent,

--- a/src/pages/Trade/TradeCharts/TradeChartsComponents/TradeChartsTokenInfo.tsx
+++ b/src/pages/Trade/TradeCharts/TradeChartsComponents/TradeChartsTokenInfo.tsx
@@ -133,7 +133,7 @@ export default function TradeChartsTokenInfo(props: propsIF) {
         base: tradeData.baseToken,
         quote: tradeData.quoteToken,
         chainId: chainId,
-        poolId: 36000,
+        poolId: chainData.poolIndex,
     };
 
     const isButtonFavorited = favePools.check(
@@ -149,13 +149,13 @@ export default function TradeChartsTokenInfo(props: propsIF) {
                   tradeData.baseToken,
                   tradeData.quoteToken,
                   chainId,
-                  36000,
+                  chainData.poolIndex,
               )
             : favePools.add(
                   tradeData.quoteToken,
                   tradeData.baseToken,
                   chainId,
-                  36000,
+                  chainData.poolIndex,
               );
         IS_LOCAL_ENV && console.debug(tradeData);
     }

--- a/src/utils/data/defaultTopPools.ts
+++ b/src/utils/data/defaultTopPools.ts
@@ -50,16 +50,18 @@ export function getDefaultTopPools(chainId: string): topPoolIF[] {
     }
 }
 
+const GOERLI_POOL_ID = 36000;
+
 const defaultTopPools = {
     '0x5': [
-        new TopPool(goerliETH, goerliUSDC, 36000, 0, 1),
-        new TopPool(goerliETH, goerliWBTC, 36000, 0.5, 3),
-        new TopPool(goerliWBTC, goerliUSDC, 36000, -2, 4),
-        new TopPool(goerliUSDC, goerliDAI, 36000, -2, 4),
+        new TopPool(goerliETH, goerliUSDC, GOERLI_POOL_ID, 0, 1),
+        new TopPool(goerliETH, goerliWBTC, GOERLI_POOL_ID, 0.5, 3),
+        new TopPool(goerliWBTC, goerliUSDC, GOERLI_POOL_ID, -2, 4),
+        new TopPool(goerliUSDC, goerliDAI, GOERLI_POOL_ID, -2, 4),
     ],
     '0x66eed': [
-        new TopPool(arbGoerliETH, arbGoerliUSDC, 36000, 0, 1),
-        new TopPool(arbGoerliETH, arbGoerliWBTC, 36000, 0.5, 3),
-        new TopPool(arbGoerliETH, arbGoerliDAI, 36000, 0.5, 3),
+        new TopPool(arbGoerliETH, arbGoerliUSDC, GOERLI_POOL_ID, 0, 1),
+        new TopPool(arbGoerliETH, arbGoerliWBTC, GOERLI_POOL_ID, 0.5, 3),
+        new TopPool(arbGoerliETH, arbGoerliDAI, GOERLI_POOL_ID, 0.5, 3),
     ],
 };

--- a/src/utils/hooks/useProcessOrder.ts
+++ b/src/utils/hooks/useProcessOrder.ts
@@ -67,7 +67,7 @@ export const useProcessOrder = (
                   limitOrder.quote,
                   limitOrder.bidTick,
                   limitOrder.askTick,
-                  36000,
+                  limitOrder.poolIdx,
               ).toString()
             : '…';
 

--- a/src/utils/hooks/useProcessRange.ts
+++ b/src/utils/hooks/useProcessRange.ts
@@ -72,7 +72,12 @@ export const useProcessRange = (
 
     let posHash;
     if (position.positionType == 'ambient') {
-        posHash = ambientPosSlot(ownerId, position.base, position.quote, 36000);
+        posHash = ambientPosSlot(
+            ownerId,
+            position.base,
+            position.quote,
+            position.poolIdx,
+        );
     } else {
         posHash =
             position.user &&
@@ -86,7 +91,7 @@ export const useProcessRange = (
                       position.quote,
                       position.bidTick,
                       position.askTick,
-                      36000,
+                      position.poolIdx,
                   ).toString()
                 : '…';
     }


### PR DESCRIPTION
Remove the dangling references we had throughout the code base to hardcoded `36000` as the pool index. Everywhere should consume the pool index number from chain-specific `chainData` (which itself is defined in the SDK)