### PR TITLE
add full adress under currency converter on withdraw

### DIFF
--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.module.css
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.module.css
@@ -58,3 +58,13 @@
 .swap_input {
     width: 100%;
 }
+
+.address_display{
+   overflow: hidden;
+   font-size: var(--body-size);
+   line-height: var(--body-lh);
+   color: var(--text-grey-light) ;
+   padding: 4px;
+   margin: 0 8px;
+   font-family: 'mono-space';
+}

--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.tsx
@@ -51,7 +51,9 @@ export default function TransferAddressInput(props: TransferAddressInputProps) {
                 <div className={styles.swap_input}>{rateInput}</div>
             </div>
             <p className={styles.address_display}>
-                {sendToAddress ? sendToAddress : undefined}
+                {sendToAddress && sendToAddress.length > 30
+                    ? sendToAddress
+                    : undefined}
             </p>
         </div>
     );

--- a/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/TransferAddressInput/TransferAddressInput.tsx
@@ -50,6 +50,9 @@ export default function TransferAddressInput(props: TransferAddressInputProps) {
             <div className={styles.swapbox_top}>
                 <div className={styles.swap_input}>{rateInput}</div>
             </div>
+            <p className={styles.address_display}>
+                {sendToAddress ? sendToAddress : undefined}
+            </p>
         </div>
     );
 }


### PR DESCRIPTION
### Describe your changes 
Wallet address entry in /account withdraw is not wide enough to display full address so this PR adds the full address under the input. This way, we can maintain the same input styling across the entire app.
_Describe the purpose + content of these changes_
<img width="379" alt="image" src="https://user-images.githubusercontent.com/83131501/232881782-58209dae-d103-474f-9a2e-47e25762f1cd.png">

### Link the related issue
https://github.com/CrocSwap/ambient-ts-app/issues/1503
_Closes #1503 _

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
