### PR TITLE
Fix incorrect colour for Swap Max button

### DIFF
--- a/src/components/Swap/CurrencySelector/CurrencySelector.module.css
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.module.css
@@ -275,7 +275,6 @@
 }
 .max_button_enable {
     border-radius: 4px;
-    background: var(--dark2);
 }
 
 .max_button:hover {


### PR DESCRIPTION
### Describe your changes 

Fix bg colour of Swap Max button.
![Screenshot 2023-04-28 at 11 33 42 AM](https://user-images.githubusercontent.com/6332196/235191052-326228cc-2345-4940-a3c8-1be17bc75f0a.png)

### Link the related issue

Closes #1900 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
