### PR TITLE
fix multi row highlight on tables

### DIFF
--- a/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
+++ b/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
@@ -185,6 +185,8 @@ export default function OrderRow(props: propsIF) {
             ? styles.active_position_style
             : '';
 
+    console.log(activePositionStyle);
+
     const [highlightRow, setHighlightRow] = useState(false);
     const highlightStyle = highlightRow ? 'var(--dark2)' : '';
     const handleRowMouseDown = () => setHighlightRow(true);

--- a/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
+++ b/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
@@ -185,8 +185,6 @@ export default function OrderRow(props: propsIF) {
             ? styles.active_position_style
             : '';
 
-    console.log(activePositionStyle);
-
     const [highlightRow, setHighlightRow] = useState(false);
     const highlightStyle = highlightRow ? 'var(--dark2)' : '';
     const handleRowMouseDown = () => setHighlightRow(true);

--- a/src/components/Trade/TradeTabs/Orders/Orders.module.css
+++ b/src/components/Trade/TradeTabs/Orders/Orders.module.css
@@ -85,6 +85,9 @@
     transition: all var(--animation-speed) ease-in-out;
 }
 
+.row_container:hover{
+    background-color: var(--dark2);
+}
 .row_container li {
     font-weight: 300;
     font-size: var(--body-size);

--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -56,8 +56,7 @@ export const orderRowConstants = (props: Props) => {
     const {
         posHashTruncated,
         openDetailsModal,
-        handleRowMouseDown,
-        handleRowMouseOut,
+
         posHash,
         handleCopyPosHash,
         sellOrderStyle,
@@ -110,8 +109,6 @@ export const orderRowConstants = (props: Props) => {
         return (
             <li
                 onClick={noClick ? undefined : openDetailsModal}
-                onMouseEnter={handleRowMouseDown}
-                onMouseLeave={handleRowMouseOut}
                 className={className}
                 style={style}
             >

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
@@ -85,6 +85,10 @@
 /* .row_container:hover {
     background: var(--dark2);
 } */
+
+.row_container:hover{
+    background-color: var(--dark2);
+}
 .row_container li {
     font-weight: 300;
     font-size: var(--body-size);

--- a/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
@@ -70,8 +70,7 @@ export default function rangeRowConstants(props: Props) {
         posHashTruncated,
         usdValue,
         openDetailsModal,
-        handleRowMouseDown,
-        handleRowMouseOut,
+
         handleWalletLinkClick,
         handleWalletCopy,
         ownerId,
@@ -119,8 +118,6 @@ export default function rangeRowConstants(props: Props) {
         return (
             <li
                 onClick={noClick ? undefined : openDetailsModal}
-                onMouseEnter={handleRowMouseDown}
-                onMouseLeave={handleRowMouseOut}
                 className={className}
                 style={style}
             >


### PR DESCRIPTION
### Describe your changes 
Remove mouse down and switch to hover states on table rows.
_Describe the purpose + content of these changes_
There is currently an issue on the tables where the hover styling is active for more than 1 row at a time. This is more obvious when the tables are expanded:
<img width="1227" alt="image" src="https://user-images.githubusercontent.com/83131501/235194103-ce97ddb6-01e7-4c61-ba0f-34dabe46515a.png">
This PR should resolve that issue.
### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
