### PR TITLE
refactor fetch function

### DIFF
--- a/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
@@ -166,8 +166,6 @@ export const SoloTokenSelect = (props: propsIF) => {
         closeModal();
     };
 
-    // *NEW STARTS HERE
-
     // hook to hold data for a token pulled from on-chain
     // null value is allowed to clear the hook when needed or on error
     const [customToken, setCustomToken] = useState<TokenIF | null>(null);
@@ -210,57 +208,8 @@ export const SoloTokenSelect = (props: propsIF) => {
 
         console.log('running');
     }, [searchType, validatedInput, provider, cachedFetchContractDetails]);
-    // // EDS Test Token 2 address (please do not delete!)
-    // // '0x0B0322d75bad9cA72eC7708708B54e6b38C26adA'
-    // *NEW ENDS HERE
-
-    // // *OLD FUNCTION HERE
-    // // hook to hold data for a token pulled from on-chain
-    // // null value is allowed to clear the hook when needed or on error
-    // const [customToken, setCustomToken] = useState<TokenIF | null>(null);
-    // useEffect(() => {
-    //     // gatekeeping to pull token data from on-chain query
-    //     // make sure a provider exists
-    //     // validated input must appear to be a valid contract address
-    //     // app must fail to find token in local data
-    //     if (
-    //         provider &&
-    //         searchType === 'address' &&
-    //         !verifyToken(validatedInput, chainId)
-    //     ) {
-    //         // local instance of function to pull back token data from chain
-    //         const cachedFetchContractDetails = memoizeFetchContractDetails();
-    //         // promise holding query to get token metadata from on-chain
-    //         const promise: Promise<TokenIF | undefined> =
-    //             cachedFetchContractDetails(provider, validatedInput, chainId);
-    //         // resolve the promise
-    //         Promise.resolve(promise)
-    //             // if response has a `decimals` value treat it as valid
-    //             .then(
-    //                 (res: TokenIF | undefined) =>
-    //                     res?.decimals && setCustomToken(res),
-    //             )
-    //             // error handling
-    //             .catch((err) => {
-    //                 // log error to console
-    //                 console.error(err);
-    //                 // set custom token as `null`
-    //                 setCustomToken(null);
-    //             });
-    //     } else {
-    //         // clear token data if conditions do not indicate necessity
-    //         setCustomToken(null);
-    //     }
-
-    //     console.log('running')
-    //     // run hook when validated input or type of search changes
-    //     // searchType is redundant but may be relevant in the future
-    //     // until then it does not hurt anything to put it there
-    // }, [searchType, validatedInput]);
-
-    // // EDS Test Token 2 address (please do not delete!)
-    // // '0x0B0322d75bad9cA72eC7708708B54e6b38C26adA'
-    // // *OLD FUNCTION ENDS HERE
+    // EDS Test Token 2 address (please do not delete!)
+    // '0x0B0322d75bad9cA72eC7708708B54e6b38C26adA'
 
     // value to determine what should be displayed in the DOM
     // this approach is necessary because not all data takes the same shape


### PR DESCRIPTION
### Describe your changes 
While trying to address issue 1813, I noticed a few other things that could be improved.
1. Moved the memoized function to fetch the contract details outside of the use-effect and add in useMemo.
The `memoizeFetchContractDetails()` function is now being memoized . This means that the function will only be created once when the component is mounted, rather than on every render as it is doing now.
2. We currently have a separate promise variable which isn't necessary. 
The handling of the promise returned by `cachedFetchContractDetails()` has been simplified. Instead of creating a separate promise variable, the promise is passed directly to Promise.resolve() and the then() method is used to handle the response. I also added an error handler which is just a console log..
3. The dependency array for the useEffect() hook has been updated to include cachedFetchContractDetails as a dependency. This is because the memoized function is now being used within the hook, and so any changes to it could trigger a re-render.

**Testing**
The old function is still in the codebase to help with testing this PR.
To test, comment out the new refactor (Line 169 -215) and uncomment out the old code (Line 217 - 263)
Go on the swap page, open your console and open the token selector. You should see 'running' in your console. This is even before adding a custom address.

Do the vice versa and you should notice running only logs when you add in a custom address search:  '0x0B0322d75bad9cA72eC7708708B54e6b38C26adA'
_Describe the purpose + content of these changes_
### Link the related issue
https://github.com/CrocSwap/ambient-ts-app/issues/1813
_Closes #1813_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
