### PR TITLE
Add safety around math and null access corner case errors in chart logic

### DIFF
--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -3703,12 +3703,14 @@ export default function Chart(props: propsIF) {
             }
 
             context.beginPath();
-            if (d3.select(d3CanvasCrVertical?.current) === null) return;
-            if (
-                dateCrosshair &&
-                d3.select(d3CanvasCrVertical?.current).style('visibility') ===
-                    'visible'
-            ) {
+
+            // Access the element in a single place, instead of repeating d3.select
+            // in both conditions, because d3.select() value could change in a race
+            // condition
+            const element = d3.select(d3CanvasCrVertical?.current);
+            if (element === null) return;
+
+            if (dateCrosshair && element.style('visibility') === 'visible') {
                 context.fillText(
                     dateCrosshair,
                     xScale(crosshairData[0].x),

--- a/src/pages/Trade/TradeCharts/TradeChartsLoading/TvlSubChart.tsx
+++ b/src/pages/Trade/TradeCharts/TradeChartsLoading/TvlSubChart.tsx
@@ -250,6 +250,12 @@ export default function TvlSubChart(props: TvlData) {
                               Math.log10(tvlyScale.domain()[0])) /
                           (buffer * 2);
 
+                const DFLT_COLOR_STOP = 0.2;
+                const calcStop = 1 / (startPoint + 1);
+                const colorStop = isFinite(calcStop)
+                    ? calcStop
+                    : DFLT_COLOR_STOP;
+
                 const tvlGradient = ctx.createLinearGradient(
                     0,
                     0,
@@ -257,10 +263,7 @@ export default function TvlSubChart(props: TvlData) {
                     canvas.height / ratio,
                 );
                 tvlGradient.addColorStop(1, 'transparent');
-                tvlGradient.addColorStop(
-                    1 / (startPoint + 1),
-                    'rgba(115, 113, 252, 0.7)',
-                );
+                tvlGradient.addColorStop(colorStop, 'rgba(115, 113, 252, 0.7)');
 
                 setTvlGradient(() => {
                     return tvlGradient;


### PR DESCRIPTION
### Describe your changes 

Chart was crashing during certain TVL rendering events. This had to do with times when the TVL range in the window was non-zero but very small. Existing check was for a zero denominator, but this was producing a very small non-zero denominator which led to floating point overflow.

This change corrects by explicitly blocking a non-finite value in the affected code, as well as avoiding a downstream race condition that was triggering around it.