### PR TITLE
Fix Metamask connect timeout issue

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -145,7 +145,6 @@ import useDebounce from './hooks/useDebounce';
 import { useRecentTokens } from './hooks/useRecentTokens';
 import { useTokenSearch } from './hooks/useTokenSearch';
 import WalletModalWagmi from './components/WalletModal/WalletModalWagmi';
-import Moralis from 'moralis';
 import { usePoolList } from './hooks/usePoolList';
 import { recentPoolsMethodsIF, useRecentPools } from './hooks/useRecentPools';
 import useMediaQuery from '../utils/hooks/useMediaQuery';
@@ -197,13 +196,6 @@ const wssGraphCacheServerDomain = 'wss://809821320828123.de:5000';
 const shouldCandleSubscriptionsReconnect = true;
 const shouldNonCandleSubscriptionsReconnect = true;
 
-const startMoralis = async () => {
-    await Moralis.start({
-        apiKey: 'xcsYd8HnEjWqQWuHs63gk7Oehgbusa05fGdQnlVPFV9qMyKYPcRlwBDLd1C2SVx5',
-        // ...and any other configuration
-    });
-};
-
 const LIQUIDITY_FETCH_PERIOD_MS = 60000; // We will call (and cache) fetchLiquidity every N milliseconds
 
 /** ***** React Function *******/
@@ -214,10 +206,6 @@ export default function App() {
 
     const { disconnect } = useDisconnect();
     const [isTutorialMode, setIsTutorialMode] = useState(false);
-
-    useEffect(() => {
-        startMoralis();
-    }, []);
 
     // hooks to manage ToS agreements in the app
     const walletToS: tosMethodsIF = useTermsOfService(


### PR DESCRIPTION
We've dealt with an error when a user opens the app, that Metamask is out of sync. This either causes the app to report they're logged in, when they're not. Which leads to transactions failing and the page reloading when user is at confirmation step. Or they go to Connect Wallet, and no matter how many times clicked there is no response from Metamask and they have to manually reload the page.

This problem was isolated to Google Chrome preloading. If the user is typing in the website, and their browser has auto-complete, Chrome will begin fetching the page. For some reason this is known to create problems that makes the Metamask RPC completely unresponsive. See below for more info:

https://community.metamask.io/t/google-chrome-page-preload-causes-weirdness-with-metamask/24042

### Describe your changes 

The only known solution is to short-circuit the preloading process. Chrome preloading does not process a `location.reload` directive. So at the top of the `index.ts` Javascript, the first step is to force a `location.reload`. This freezes preloading, until the user properly visits the page. At which point the page reloads, and the instance is fresh without Metamask being bricked.

The second load marks a flag in local storage to prevent the page from getting stuck in an infinite reloading loop. 

### Checklist before requesting a review
- [X ] I have performed a self-review of my code.
- [X ] Does my code following the style guide at `docs/CODING-STYLE.md`?
