### PR TITLE
Remove key duplication console errors for Wallet Modal

### DIFF
--- a/src/App/components/WalletModal/WalletModalWagmi.tsx
+++ b/src/App/components/WalletModal/WalletModalWagmi.tsx
@@ -109,7 +109,7 @@ export default function WalletModalWagmi(props: WalletModalPropsIF) {
                             : ''
                     }`}
                     disabled={!connector.ready}
-                    key={connector.id}
+                    key={connector.id + '|' + connector.name} // Join both to ensure uniqueness
                     action={() => {
                         connect({ connector });
                         IS_LOCAL_ENV && console.debug({ connector });


### PR DESCRIPTION
Wallet modal tags each button's HTML entry with a key cased on the Wagmi `connector.id`. Because we now have two injector wallets, this key was duplicated and the console was emitting an error. This PR corrects this by setting key to a concatenation of `connector.id` and `connector.name`

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ X] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ X] Does my code following the style guide at `docs/CODING-STYLE.md`?
