### PR TITLE
fix missing limit/range details graphs - set max candles

### DIFF
--- a/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.tsx
@@ -129,9 +129,15 @@ export default function TransactionDetailsGraph(
 
                 const period = decidePeriod(Math.floor(diff / 1000 / 200));
                 if (period !== undefined) {
-                    const numberofCandleNeeded = Math.floor(
+                    const calcNumberCandlesNeeded = Math.floor(
                         (diff * 2) / (period * 1000),
                     );
+                    const maxNumCandlesNeeded = 3000;
+
+                    const numCandlesNeeded =
+                        calcNumberCandlesNeeded < maxNumCandlesNeeded
+                            ? calcNumberCandlesNeeded
+                            : maxNumCandlesNeeded;
 
                     const startBoundary = Math.floor(
                         new Date().getTime() / 1000,
@@ -147,7 +153,7 @@ export default function TransactionDetailsGraph(
                             baseTokenAddress,
                             quoteTokenAddress,
                             startBoundary.toString(),
-                            numberofCandleNeeded.toString(),
+                            numCandlesNeeded.toString(),
                         );
 
                         if (graphData) {


### PR DESCRIPTION
### Describe your changes 

fix missing candles in old limit/range details graphs by setting a maximum of 3000 candles.

### Link the related issue

Closes #2024

### Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
