### PR TITLE
Fix leaderboard places CSS

### DIFF
--- a/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
@@ -172,7 +172,7 @@
     transition: background 0.5s ease-out;
 }
 
-.leaderboard > ul:nth-child(3) {
+.leaderboard > ul:nth-child(4) {
     background: linear-gradient(
         90deg,
         rgba(224, 224, 224, 0.35) 0%,
@@ -181,7 +181,7 @@
     );
     transition: background 0.5s ease-out;
 }
-.leaderboard > ul:nth-child(4) {
+.leaderboard > ul:nth-child(6) {
     background: linear-gradient(
         90deg,
         rgba(176, 141, 87, 0.35) 0%,


### PR DESCRIPTION
### Describe your changes 

Due to the additional of additional children to the RangesRow.tsx component, the CSS was thrown off for displaying the leaderboard places. This change fixes that. 

### Link the related issue

Closes #2032 

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Is my code following the style guide at `docs/CODING-STYLE.md`?
