### PR TITLE
create appStateContext

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -145,7 +145,7 @@ import AppOverlay from '../components/Global/AppOverlay/AppOverlay';
 import { getLiquidityFee } from './functions/getLiquidityFee';
 import trimString from '../utils/functions/trimString';
 import { useToken } from './hooks/useToken';
-import { sidebarMethodsIF, useSidebar } from './hooks/useSidebar';
+import { useSidebar } from './hooks/useSidebar';
 import useDebounce from './hooks/useDebounce';
 import { useRecentTokens } from './hooks/useRecentTokens';
 import { useTokenSearch } from './hooks/useTokenSearch';
@@ -185,6 +185,9 @@ import Accessibility from '../pages/Accessibility/Accessibility';
 import { diffHashSig } from '../utils/functions/diffHashSig';
 import { useFavePools } from './hooks/useFavePools';
 import { UserPreferenceContext } from '../contexts/UserPreferenceContext';
+import { useTermsOfService } from './hooks/useTermsOfService';
+import { AppStateContext } from '../contexts/AppStateContext';
+import { useSnackbar } from '../components/Global/SnackbarComponent/useSnackbar';
 
 const cachedFetchAddress = memoizeFetchAddress();
 const cachedFetchNativeTokenBalance = memoizeFetchNativeTokenBalance();
@@ -203,12 +206,6 @@ const shouldNonCandleSubscriptionsReconnect = true;
 
 const LIQUIDITY_FETCH_PERIOD_MS = 60000; // We will call (and cache) fetchLiquidity every N milliseconds
 
-const isChartEnabled =
-    !!process.env.REACT_APP_CHART_IS_ENABLED &&
-    process.env.REACT_APP_CHART_IS_ENABLED.toLowerCase() === 'false'
-        ? false
-        : true;
-
 /** ***** React Function *******/
 export default function App() {
     const navigate = useNavigate();
@@ -216,27 +213,9 @@ export default function App() {
     // useKeyboardShortcuts()
 
     const { disconnect } = useDisconnect();
-    const [isTutorialMode, setIsTutorialMode] = useState(false);
-
-    // hooks to manage ToS agreements in the app
-    // const walletToS: tosMethodsIF = useTermsOfService(
-    //     'wallet',
-    //     process.env.REACT_APP_WALLET_TOS_CID as string,
-    // );
-    // const chatToS: tosMethodsIF = useTermsOfService(
-    //     'chat',
-    //     process.env.REACT_APP_CHAT_TOS_CID as string,
-    // );
 
     // hook to manage chart settings
     const chartSettings: chartSettingsMethodsIF = useChartSettings();
-
-    // hook to manage app skin
-    const skin = useSkin('purple_dark');
-    false && skin;
-
-    // hook to track user's sidebar preference open or closed
-    const sidebar: sidebarMethodsIF = useSidebar(location.pathname);
 
     const { address: account, isConnected } = useAccount();
 
@@ -252,6 +231,83 @@ export default function App() {
         bypassConfirmLimit: useSkipConfirm('limit'),
         bypassConfirmRange: useSkipConfirm('range'),
         bypassConfirmRepo: useSkipConfirm('repo'),
+    };
+
+    // TODO: this should be initialized inside AppStateContext - unable to do so currently due to dependencies that should be moved into child components
+    const [theme, setTheme] = useState<'dark' | 'light'>('dark');
+    const [isAppOverlayActive, setIsAppOverlayActive] = useState(false);
+    const [isTutorialMode, setIsTutorialMode] = useState(false);
+    const [selectedOutsideTab, setSelectedOutsideTab] = useState(0);
+    const [outsideControl, setOutsideControl] = useState(false);
+    const [isChatOpen, setIsChatOpen] = useState(false);
+    const [isChatEnabled, setIsChatEnabled] = useState(
+        process.env.REACT_APP_CHAT_IS_ENABLED !== undefined
+            ? process.env.REACT_APP_CHAT_IS_ENABLED.toLowerCase() === 'true'
+            : true,
+    );
+    const [fullScreenChart, setFullScreenChart] = useState(false);
+
+    // allow a local environment variable to be defined in [app_repo]/.env.local to turn off connections to the cache server
+    const isServerEnabled =
+        process.env.REACT_APP_CACHE_SERVER_IS_ENABLED !== undefined
+            ? process.env.REACT_APP_CACHE_SERVER_IS_ENABLED.toLowerCase() ===
+              'true'
+            : true;
+
+    // allow a local environment variable to be defined in [app_repo]/.env.local to turn off subscriptions to the cache and chat servers
+    const areSubscriptionsEnabled =
+        process.env.REACT_APP_SUBSCRIPTIONS_ARE_ENABLED !== undefined
+            ? process.env.REACT_APP_SUBSCRIPTIONS_ARE_ENABLED.toLowerCase() ===
+              'true'
+            : true;
+    const isChartEnabled =
+        !!process.env.REACT_APP_CHART_IS_ENABLED &&
+        process.env.REACT_APP_CHART_IS_ENABLED.toLowerCase() === 'false'
+            ? false
+            : true;
+
+    const appState = {
+        appOverlay: {
+            isActive: isAppOverlayActive,
+            setIsActive: setIsAppOverlayActive,
+        },
+        globalModal: useGlobalModal(),
+        globalPopup: useGlobalPopup(),
+        sidebar: useSidebar(location.pathname),
+        snackbar: useSnackbar(),
+        tutorial: { isActive: isTutorialMode, setIsActive: setIsTutorialMode },
+        skin: useSkin('purple_dark'),
+        // TODO: walletToS, chatToS unused
+        walletToS: useTermsOfService(
+            'wallet',
+            process.env.REACT_APP_WALLET_TOS_CID as string,
+        ),
+        chatToS: useTermsOfService(
+            'chat',
+            process.env.REACT_APP_CHAT_TOS_CID as string,
+        ),
+        theme: { selected: theme, setSelected: setTheme },
+        outsideTab: {
+            selected: selectedOutsideTab,
+            setSelected: setSelectedOutsideTab,
+        },
+        outsideControl: {
+            isActive: outsideControl,
+            setIsActive: setOutsideControl,
+        },
+        chat: {
+            isOpen: isChatOpen,
+            setIsOpen: setIsChatOpen,
+            isEnabled: isChatEnabled,
+            setIsEnabled: setIsChatEnabled,
+        },
+        chart: {
+            isFullScreen: fullScreenChart,
+            setIsFullScreen: setFullScreenChart,
+            isEnabled: isChartEnabled,
+        },
+        server: { isEnabled: isServerEnabled },
+        subscriptions: { isEnabled: areSubscriptionsEnabled },
     };
 
     useEffect(() => {
@@ -367,26 +423,6 @@ export default function App() {
 
     // hook to manage acknowledged tokens
     const ackTokens: ackTokensMethodsIF = useAckTokens();
-
-    // allow a local environment variable to be defined in [app_repo]/.env.local to turn off connections to the cache server
-    const isServerEnabled =
-        process.env.REACT_APP_CACHE_SERVER_IS_ENABLED !== undefined
-            ? process.env.REACT_APP_CACHE_SERVER_IS_ENABLED.toLowerCase() ===
-              'true'
-            : true;
-
-    // allow a local environment variable to be defined in [app_repo]/.env.local to turn off subscriptions to the cache and chat servers
-    const areSubscriptionsEnabled =
-        process.env.REACT_APP_SUBSCRIPTIONS_ARE_ENABLED !== undefined
-            ? process.env.REACT_APP_SUBSCRIPTIONS_ARE_ENABLED.toLowerCase() ===
-              'true'
-            : true;
-
-    const [isChatEnabled, setIsChatEnabled] = useState(
-        process.env.REACT_APP_CHAT_IS_ENABLED !== undefined
-            ? process.env.REACT_APP_CHAT_IS_ENABLED.toLowerCase() === 'true'
-            : true,
-    );
 
     useEffect(() => {
         if (isConnected) {
@@ -711,8 +747,6 @@ export default function App() {
 
     const receiptData = useAppSelector((state) => state.receiptData);
 
-    const [openSnackbar, setOpenSnackbar] = useState<boolean>(false);
-
     const sessionReceipts = receiptData?.sessionReceipts;
 
     const lastReceipt =
@@ -722,22 +756,6 @@ export default function App() {
 
     const isLastReceiptSuccess = lastReceipt?.status === 1;
 
-    const snackMessage = lastReceipt
-        ? isLastReceiptSuccess
-            ? `Transaction ${lastReceipt.transactionHash} successfully completed`
-            : `Transaction ${lastReceipt.transactionHash} failed`
-        : '';
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity={isLastReceiptSuccess ? 'info' : 'warning'}
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {snackMessage}
-        </SnackbarComponent>
-    );
-
     const lastReceiptHash = useMemo(
         () => (lastReceipt ? diffHashSig(lastReceipt) : undefined),
         [lastReceipt],
@@ -745,7 +763,14 @@ export default function App() {
     useEffect(() => {
         if (lastReceiptHash) {
             IS_LOCAL_ENV && console.debug('new receipt to display');
-            setOpenSnackbar(true);
+            appState.snackbar.open(
+                lastReceipt
+                    ? isLastReceiptSuccess
+                        ? `Transaction ${lastReceipt.transactionHash} successfully completed`
+                        : `Transaction ${lastReceipt.transactionHash} failed`
+                    : '',
+                isLastReceiptSuccess ? 'info' : 'warning',
+            );
         }
     }, [lastReceiptHash]);
 
@@ -2593,29 +2618,29 @@ export default function App() {
         if (!showSidebarByDefault) {
             return;
         } else {
-            sidebar.open();
+            appState.sidebar.open();
             if (
                 currentLocation === '/' ||
                 currentLocation === '/swap' ||
                 currentLocation.includes('/account')
             ) {
-                sidebar.close();
+                appState.sidebar.close();
             }
         }
     }
 
     function toggleTradeTabBasedOnRoute() {
-        setOutsideControl(true);
+        appState.outsideControl.setIsActive(true);
         if (currentLocation.includes('/market')) {
-            setSelectedOutsideTab(0);
+            appState.outsideTab.setSelected(0);
         } else if (currentLocation.includes('/limit')) {
-            setSelectedOutsideTab(1);
+            appState.outsideTab.setSelected(1);
         } else if (
             currentLocation.includes('/range') ||
             currentLocation.includes('reposition') ||
             currentLocation.includes('add')
         ) {
-            setSelectedOutsideTab(2);
+            appState.outsideTab.setSelected(2);
         }
     }
 
@@ -2672,26 +2697,6 @@ export default function App() {
         closeWagmiModalWallet,
     ] = useModal();
 
-    const [
-        isGlobalModalOpen,
-        openGlobalModal,
-        closeGlobalModal,
-        currentContent,
-        title,
-    ] = useGlobalModal();
-    const [
-        isGlobalPopupOpen,
-        openGlobalPopup,
-        closeGlobalPopup,
-        popupContent,
-        popupTitle,
-        popupPlacement,
-    ] = useGlobalPopup();
-
-    const [isMobileSidebarOpen, setIsMobileSidebarOpen] = useState(false);
-
-    const [isAppOverlayActive, setIsAppOverlayActive] = useState(false);
-
     // ------------------- FOLLOWING CODE IS PURELY RESPONSIBLE FOR PULSE ANIMATION------------
 
     const [isSwapCopied, setIsSwapCopied] = useState(false);
@@ -2725,17 +2730,6 @@ export default function App() {
     };
 
     // END OF------------------- FOLLOWING CODE IS PURELY RESPONSIBLE FOR PULSE ANIMATION------------
-
-    // --------------THEME--------------------------
-    // const defaultDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-    const [theme, setTheme] = useState('dark');
-
-    const switchTheme = () => {
-        const newTheme = theme === 'light' ? 'dark' : 'light';
-        setTheme(newTheme);
-    };
-
-    // --------------END OF THEME--------------------------
 
     const connectedUserErc20Tokens = useAppSelector(
         (state) => state.userData.tokens.erc20Tokens,
@@ -2816,21 +2810,11 @@ export default function App() {
         openWagmiModalWallet: openWagmiModalWallet,
         openMoralisModalWallet: openWagmiModalWallet,
         lastBlockNumber: lastBlockNumber,
-        isMobileSidebarOpen: isMobileSidebarOpen,
-        setIsMobileSidebarOpen: setIsMobileSidebarOpen,
         poolPriceDisplay: poolPriceDisplay,
-        openGlobalModal: openGlobalModal,
-        closeGlobalModal: closeGlobalModal,
-        isAppOverlayActive: isAppOverlayActive,
-        setIsAppOverlayActive: setIsAppOverlayActive,
         ethMainnetUsdPrice: ethMainnetUsdPrice,
         recentPools: recentPools,
-        switchTheme: switchTheme,
-        theme: theme,
         chainData: chainData,
         getTokenByAddress: getTokenByAddress,
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
     };
 
     const [outputTokens, validatedInput, setInput, searchType] = useTokenSearch(
@@ -2868,7 +2852,6 @@ export default function App() {
         isInitialized: isInitialized,
         poolExists: poolExists,
         setTokenPairLocal: setTokenPairLocal,
-        openGlobalModal: openGlobalModal,
         verifyToken: verifyToken,
         getTokensByName: getTokensByName,
         getTokenByAddress: getTokenByAddress,
@@ -2879,9 +2862,6 @@ export default function App() {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
         ackTokens: ackTokens,
         chainData: chainData,
     };
@@ -2910,7 +2890,6 @@ export default function App() {
         openModalWallet: openWagmiModalWallet,
         isInitialized: isInitialized,
         poolExists: poolExists,
-        openGlobalModal: openGlobalModal,
         isSwapCopied: isSwapCopied,
         verifyToken: verifyToken,
         getTokensByName: getTokensByName,
@@ -2922,9 +2901,6 @@ export default function App() {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
         tokenPairLocal: tokenPairLocal,
         ackTokens: ackTokens,
         chainData: chainData,
@@ -2953,8 +2929,6 @@ export default function App() {
         tokenAAllowance: tokenAAllowance,
         chainId: chainData.chainId,
         openModalWallet: openWagmiModalWallet,
-        openGlobalModal: openGlobalModal,
-        closeGlobalModal: closeGlobalModal,
         poolExists: poolExists,
         isOrderCopied: isOrderCopied,
         verifyToken: verifyToken,
@@ -2968,9 +2942,6 @@ export default function App() {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
         ackTokens: ackTokens,
     };
 
@@ -3002,7 +2973,6 @@ export default function App() {
         openModalWallet: openWagmiModalWallet,
         ambientApy: ambientApy,
         dailyVol: dailyVol,
-        openGlobalModal: openGlobalModal,
         poolExists: poolExists,
         isRangeCopied: isRangeCopied,
         tokenAQtyLocal: rangetokenAQtyLocal,
@@ -3019,9 +2989,6 @@ export default function App() {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
         setSimpleRangeWidth: setSimpleRangeWidth,
         simpleRangeWidth: simpleRangeWidth,
         setMaxPrice: setMaxRangePrice,
@@ -3038,17 +3005,10 @@ export default function App() {
         chainData: chainData,
     };
 
-    const [selectedOutsideTab, setSelectedOutsideTab] = useState(0);
-    const [outsideControl, setOutsideControl] = useState(false);
-    const [isChatOpen, setIsChatOpen] = useState(false);
-
-    const [fullScreenChart, setFullScreenChart] = useState(false);
-
     const [analyticsSearchInput, setAnalyticsSearchInput] = useState('');
 
     // props for <Sidebar/> React element
     const sidebarProps = {
-        sidebar: sidebar,
         tradeData: tradeData,
         isDenomBase: tradeData.isDenomBase,
         chainId: chainData.chainId,
@@ -3061,10 +3021,6 @@ export default function App() {
         setExpandTradeTable: setExpandTradeTable,
         tokenMap: tokensOnActiveLists,
         lastBlockNumber: lastBlockNumber,
-        selectedOutsideTab: selectedOutsideTab,
-        setSelectedOutsideTab: setSelectedOutsideTab,
-        outsideControl: outsideControl,
-        setOutsideControl: setOutsideControl,
         currentPositionActive: currentPositionActive,
         setCurrentPositionActive: setCurrentPositionActive,
         analyticsSearchInput: analyticsSearchInput,
@@ -3146,7 +3102,7 @@ export default function App() {
         currentLocation !== '/swap' &&
         currentLocation !== '/404' &&
         !currentLocation.includes('/chat') &&
-        !fullScreenChart &&
+        !appState.chart.isFullScreen &&
         isChainSupported && <Sidebar {...sidebarProps} />;
 
     // Heartbeat that checks if the chat server is reachable and has a stable db connection every 10 seconds.
@@ -3159,20 +3115,20 @@ export default function App() {
         ) {
             const interval = setInterval(() => {
                 getStatus().then((isChatUp) => {
-                    setIsChatEnabled(isChatUp);
+                    appState.chat.setIsEnabled(isChatUp);
                 });
             }, 10000);
             return () => clearInterval(interval);
         }
-    }, [isChatEnabled, process.env.REACT_APP_CHAT_IS_ENABLED]);
+    }, [appState.chat.isEnabled, process.env.REACT_APP_CHAT_IS_ENABLED]);
 
     useEffect(() => {
         if (!currentLocation.startsWith('/trade')) {
-            setFullScreenChart(false);
+            appState.chart.setIsFullScreen(false);
         }
     }, [currentLocation]);
 
-    const sidebarDislayStyle = sidebar.isOpen
+    const sidebarDislayStyle = appState.sidebar.isOpen
         ? 'sidebar_content_layout'
         : 'sidebar_content_layout_close';
 
@@ -3237,13 +3193,13 @@ export default function App() {
     useKeyboardShortcuts(
         { modifierKeys: ['Shift', 'Control'], key: ' ' },
         () => {
-            sidebar.toggle('persist');
+            appState.sidebar.toggle('persist');
         },
     );
     useKeyboardShortcuts(
         { modifierKeys: ['Shift', 'Control'], key: 'C' },
         () => {
-            setIsChatOpen(!isChatOpen);
+            appState.chat.setIsOpen(!appState.chat.isOpen);
         },
     );
 
@@ -3293,14 +3249,8 @@ export default function App() {
         expandTradeTable,
         setExpandTradeTable,
         tokenMap: tokensOnActiveLists,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
-        outsideControl,
-        setOutsideControl,
         currentPositionActive,
         setCurrentPositionActive,
-        openGlobalModal,
-        closeGlobalModal,
         isInitialized,
         poolPriceNonDisplay,
         setLimitRate: function (): void {
@@ -3313,8 +3263,6 @@ export default function App() {
         handlePulseAnimation,
         isCandleSelected,
         setIsCandleSelected,
-        fullScreenChart,
-        setFullScreenChart,
         fetchingCandle,
         setFetchingCandle,
         isCandleDataNull,
@@ -3325,8 +3273,6 @@ export default function App() {
         setMinPrice: setMinRangePrice,
         rescaleRangeBoundariesWithSlider,
         setRescaleRangeBoundariesWithSlider,
-        isTutorialMode,
-        setIsTutorialMode,
         setCandleDomains,
         setSimpleRangeWidth,
         simpleRangeWidth,
@@ -3334,7 +3280,6 @@ export default function App() {
         repositionRangeWidth,
         setChartTriggeredBy,
         chartTriggeredBy,
-        isSidebarOpen: sidebar.isOpen,
     };
 
     const accountProps = {
@@ -3360,12 +3305,6 @@ export default function App() {
         userImageData: imageData,
         chainId: chainData.chainId,
         tokensOnActiveLists,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
-        outsideControl,
-        setOutsideControl,
-        openGlobalModal,
-        closeGlobalModal,
         chainData: chainData,
         currentPositionActive,
         setCurrentPositionActive,
@@ -3387,7 +3326,6 @@ export default function App() {
         setSimpleRangeWidth,
         ackTokens,
         setExpandTradeTable,
-        isSidebarOpen: sidebar.isOpen,
     };
 
     const repositionProps = {
@@ -3409,263 +3347,264 @@ export default function App() {
         poolPriceDisplay,
         setSimpleRangeWidth: setRepositionRangeWidth,
         simpleRangeWidth: repositionRangeWidth,
-        openGlobalPopup,
     };
 
     const chatProps = {
-        isChatEnabled: isChatEnabled,
-        areSubscriptionsEnabled: areSubscriptionsEnabled,
-        isChatOpen: true,
         onClose: () => {
             console.error('Function not implemented.');
         },
         currentPool: currentPoolInfo,
-        setIsChatOpen: setIsChatOpen,
         isFullScreen: true,
         userImageData: imageData,
         username: ensName,
         appPage: true,
         topPools: topPools,
-        setIsChatEnabled: setIsChatEnabled,
     };
 
     return (
-        <UserPreferenceContext.Provider value={userPreferences}>
-            <div className={containerStyle} data-theme={theme}>
-                {isMobileSidebarOpen && <div className='blur_app' />}
-                <AppOverlay
-                    isAppOverlayActive={isAppOverlayActive}
-                    setIsAppOverlayActive={setIsAppOverlayActive}
-                />
-                {currentLocation !== '/404' && <PageHeader {...headerProps} />}
-                <CrocEnvContext.Provider value={crocEnv}>
-                    <section
-                        className={`${showSidebarOrNullStyle} ${swapBodyStyle}`}
-                    >
-                        {!currentLocation.startsWith('/swap') && sidebarRender}
-                        <Routes>
-                            <Route
-                                index
-                                element={
-                                    <Home
-                                        cachedQuerySpotPrice={
-                                            cachedQuerySpotPrice
-                                        }
-                                        tokenMap={tokensOnActiveLists}
-                                        lastBlockNumber={lastBlockNumber}
-                                        chainId={chainData.chainId}
-                                        isServerEnabled={isServerEnabled}
-                                        topPools={topPools}
-                                        cachedPoolStatsFetch={
-                                            cachedPoolStatsFetch
+        <AppStateContext.Provider value={appState}>
+            <UserPreferenceContext.Provider value={userPreferences}>
+                <div
+                    className={containerStyle}
+                    data-theme={appState.theme.selected}
+                >
+                    {appState.sidebar.isMobileOpen && (
+                        <div className='blur_app' />
+                    )}
+                    <AppOverlay />
+                    {currentLocation !== '/404' && (
+                        <PageHeader {...headerProps} />
+                    )}
+                    <CrocEnvContext.Provider value={crocEnv}>
+                        <section
+                            className={`${showSidebarOrNullStyle} ${swapBodyStyle}`}
+                        >
+                            {!currentLocation.startsWith('/swap') &&
+                                sidebarRender}
+                            <Routes>
+                                <Route
+                                    index
+                                    element={
+                                        <Home
+                                            cachedQuerySpotPrice={
+                                                cachedQuerySpotPrice
+                                            }
+                                            tokenMap={tokensOnActiveLists}
+                                            lastBlockNumber={lastBlockNumber}
+                                            chainId={chainData.chainId}
+                                            topPools={topPools}
+                                            cachedPoolStatsFetch={
+                                                cachedPoolStatsFetch
+                                            }
+                                        />
+                                    }
+                                />
+                                <Route
+                                    path='accessibility'
+                                    element={<Accessibility />}
+                                />
+                                <Route
+                                    path='trade'
+                                    element={
+                                        <PoolContext.Provider value={pool}>
+                                            <Trade {...tradeProps} />
+                                        </PoolContext.Provider>
+                                    }
+                                >
+                                    <Route
+                                        path=''
+                                        element={
+                                            <Navigate
+                                                to='/trade/market'
+                                                replace
+                                            />
                                         }
                                     />
-                                }
-                            />
-                            <Route
-                                path='accessibility'
-                                element={<Accessibility />}
-                            />
-                            <Route
-                                path='trade'
-                                element={
-                                    <PoolContext.Provider value={pool}>
-                                        <Trade {...tradeProps} />
-                                    </PoolContext.Provider>
-                                }
-                            >
+                                    <Route
+                                        path='market'
+                                        element={
+                                            <Navigate
+                                                to={defaultUrlParams.market}
+                                                replace
+                                            />
+                                        }
+                                    />
+                                    <Route
+                                        path='market/:params'
+                                        element={<Swap {...swapPropsTrade} />}
+                                    />
+
+                                    <Route
+                                        path='limit'
+                                        element={
+                                            <Navigate
+                                                to={defaultUrlParams.limit}
+                                                replace
+                                            />
+                                        }
+                                    />
+                                    <Route
+                                        path='limit/:params'
+                                        element={<Limit {...limitPropsTrade} />}
+                                    />
+
+                                    <Route
+                                        path='range'
+                                        element={
+                                            <Navigate
+                                                to={defaultUrlParams.range}
+                                                replace
+                                            />
+                                        }
+                                    />
+                                    <Route
+                                        path='range/:params'
+                                        element={<Range {...rangeProps} />}
+                                    />
+                                    <Route
+                                        path='reposition'
+                                        element={
+                                            <Navigate
+                                                to={defaultUrlParams.range}
+                                                replace
+                                            />
+                                        }
+                                    />
+                                    <Route
+                                        path='reposition/:params'
+                                        element={
+                                            <Reposition {...repositionProps} />
+                                        }
+                                    />
+                                    <Route path='add' element={<RangeAdd />} />
+                                    <Route
+                                        path='edit/'
+                                        element={
+                                            <Navigate
+                                                to='/trade/market'
+                                                replace
+                                            />
+                                        }
+                                    />
+                                </Route>
                                 <Route
-                                    path=''
-                                    element={
-                                        <Navigate to='/trade/market' replace />
-                                    }
-                                />
-                                <Route
-                                    path='market'
-                                    element={
-                                        <Navigate
-                                            to={defaultUrlParams.market}
-                                            replace
-                                        />
-                                    }
-                                />
-                                <Route
-                                    path='market/:params'
-                                    element={<Swap {...swapPropsTrade} />}
+                                    path='chat'
+                                    element={<ChatPanel {...chatProps} />}
                                 />
 
                                 <Route
-                                    path='limit'
-                                    element={
-                                        <Navigate
-                                            to={defaultUrlParams.limit}
-                                            replace
-                                        />
-                                    }
+                                    path='chat/:params'
+                                    element={<ChatPanel {...chatProps} />}
                                 />
                                 <Route
-                                    path='limit/:params'
-                                    element={<Limit {...limitPropsTrade} />}
-                                />
-
-                                <Route
-                                    path='range'
-                                    element={
-                                        <Navigate
-                                            to={defaultUrlParams.range}
-                                            replace
-                                        />
-                                    }
-                                />
-                                <Route
-                                    path='range/:params'
+                                    path='range2'
                                     element={<Range {...rangeProps} />}
                                 />
                                 <Route
-                                    path='reposition'
+                                    path='initpool/:params'
                                     element={
-                                        <Navigate
-                                            to={defaultUrlParams.range}
-                                            replace
+                                        <InitPool
+                                            isUserLoggedIn={isUserLoggedIn}
+                                            crocEnv={crocEnv}
+                                            gasPriceInGwei={gasPriceInGwei}
+                                            ethMainnetUsdPrice={
+                                                ethMainnetUsdPrice
+                                            }
+                                            openModalWallet={
+                                                openWagmiModalWallet
+                                            }
+                                            tokenAAllowance={tokenAAllowance}
+                                            tokenBAllowance={tokenBAllowance}
+                                            setRecheckTokenAApproval={
+                                                setRecheckTokenAApproval
+                                            }
+                                            setRecheckTokenBApproval={
+                                                setRecheckTokenBApproval
+                                            }
                                         />
                                     }
                                 />
                                 <Route
-                                    path='reposition/:params'
+                                    path='account'
                                     element={
-                                        <Reposition {...repositionProps} />
+                                        <Portfolio
+                                            {...accountProps}
+                                            userAccount={true}
+                                        />
                                     }
                                 />
-                                <Route path='add' element={<RangeAdd />} />
                                 <Route
-                                    path='edit/'
+                                    path='account/:address'
                                     element={
-                                        <Navigate to='/trade/market' replace />
+                                        <Portfolio
+                                            {...accountProps}
+                                            userAccount={false}
+                                        />
                                     }
                                 />
-                            </Route>
-                            <Route
-                                path='chat'
-                                element={<ChatPanel {...chatProps} />}
-                            />
 
-                            <Route
-                                path='chat/:params'
-                                element={<ChatPanel {...chatProps} />}
-                            />
-                            <Route
-                                path='range2'
-                                element={<Range {...rangeProps} />}
-                            />
-                            <Route
-                                path='initpool/:params'
-                                element={
-                                    <InitPool
-                                        isUserLoggedIn={isUserLoggedIn}
-                                        crocEnv={crocEnv}
-                                        gasPriceInGwei={gasPriceInGwei}
-                                        ethMainnetUsdPrice={ethMainnetUsdPrice}
-                                        openModalWallet={openWagmiModalWallet}
-                                        tokenAAllowance={tokenAAllowance}
-                                        tokenBAllowance={tokenBAllowance}
-                                        setRecheckTokenAApproval={
-                                            setRecheckTokenAApproval
-                                        }
-                                        setRecheckTokenBApproval={
-                                            setRecheckTokenBApproval
-                                        }
+                                <Route
+                                    path='swap'
+                                    element={
+                                        <Navigate
+                                            replace
+                                            to={defaultUrlParams.swap}
+                                        />
+                                    }
+                                />
+                                <Route
+                                    path='swap/:params'
+                                    element={<Swap {...swapProps} />}
+                                />
+                                <Route
+                                    path='tos'
+                                    element={<TermsOfService />}
+                                />
+                                {IS_LOCAL_ENV && (
+                                    <Route
+                                        path='testpage'
+                                        element={<TestPage />}
                                     />
-                                }
+                                )}
+                                <Route
+                                    path='/:address'
+                                    element={
+                                        <Portfolio
+                                            {...accountProps}
+                                            userAccount={false}
+                                        />
+                                    }
+                                />
+                                <Route path='/404' element={<NotFound />} />
+                            </Routes>
+                        </section>
+                    </CrocEnvContext.Provider>
+                </div>
+                <div className='footer_container'>
+                    {currentLocation !== '/' &&
+                        !currentLocation.includes('/chat') &&
+                        appState.chat.isEnabled && (
+                            <ChatPanel
+                                onClose={() => {
+                                    console.error('Function not implemented.');
+                                }}
+                                currentPool={currentPoolInfo}
+                                isFullScreen={false}
+                                userImageData={imageData}
+                                topPools={topPools}
                             />
-                            <Route
-                                path='account'
-                                element={
-                                    <Portfolio
-                                        {...accountProps}
-                                        userAccount={true}
-                                    />
-                                }
-                            />
-                            <Route
-                                path='account/:address'
-                                element={
-                                    <Portfolio
-                                        {...accountProps}
-                                        userAccount={false}
-                                    />
-                                }
-                            />
-
-                            <Route
-                                path='swap'
-                                element={
-                                    <Navigate
-                                        replace
-                                        to={defaultUrlParams.swap}
-                                    />
-                                }
-                            />
-                            <Route
-                                path='swap/:params'
-                                element={<Swap {...swapProps} />}
-                            />
-                            <Route path='tos' element={<TermsOfService />} />
-                            {IS_LOCAL_ENV && (
-                                <Route path='testpage' element={<TestPage />} />
-                            )}
-                            <Route
-                                path='/:address'
-                                element={
-                                    <Portfolio
-                                        {...accountProps}
-                                        userAccount={false}
-                                    />
-                                }
-                            />
-                            <Route path='/404' element={<NotFound />} />
-                        </Routes>
-                    </section>
-                </CrocEnvContext.Provider>
-                {snackbarContent}
-            </div>
-            <div className='footer_container'>
-                {currentLocation !== '/' &&
-                    !currentLocation.includes('/chat') &&
-                    isChatEnabled && (
-                        <ChatPanel
-                            isChatOpen={isChatOpen}
-                            onClose={() => {
-                                console.error('Function not implemented.');
-                            }}
-                            currentPool={currentPoolInfo}
-                            setIsChatOpen={setIsChatOpen}
-                            isFullScreen={false}
-                            userImageData={imageData}
-                            topPools={topPools}
-                            isChatEnabled={isChatEnabled}
-                            areSubscriptionsEnabled={areSubscriptionsEnabled}
-                        />
-                    )}
-            </div>
-            <SidebarFooter />
-            <GlobalModal
-                isGlobalModalOpen={isGlobalModalOpen}
-                closeGlobalModal={closeGlobalModal}
-                openGlobalModal={openGlobalModal}
-                currentContent={currentContent}
-                title={title}
-            />
-            <GlobalPopup
-                isGlobalPopupOpen={isGlobalPopupOpen}
-                openGlobalPopup={openGlobalPopup}
-                closeGlobalPopup={closeGlobalPopup}
-                popupContent={popupContent}
-                popupTitle={popupTitle}
-                placement={popupPlacement}
-            />
-            {isWagmiModalOpenWallet && (
-                <WalletModalWagmi closeModalWallet={closeWagmiModalWallet} />
-            )}
-        </UserPreferenceContext.Provider>
+                        )}
+                </div>
+                <SidebarFooter />
+                <GlobalModal />
+                <GlobalPopup />
+                <SnackbarComponent />
+                {isWagmiModalOpenWallet && (
+                    <WalletModalWagmi
+                        closeModalWallet={closeWagmiModalWallet}
+                    />
+                )}
+            </UserPreferenceContext.Provider>
+        </AppStateContext.Provider>
     );
 }

--- a/src/App/components/GlobalModal/GlobalModal.tsx
+++ b/src/App/components/GlobalModal/GlobalModal.tsx
@@ -1,18 +1,14 @@
+import { useContext } from 'react';
 import SimpleModal from '../../../components/Global/SimpleModal/SimpleModal';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
-interface GlobalModalProps {
-    isGlobalModalOpen: boolean;
-    openGlobalModal: (page: string) => void;
-    closeGlobalModal: () => void;
-    currentContent: React.ReactNode;
-
-    title?: string;
-}
-
-export default function GlobalModal(props: GlobalModalProps) {
-    const modalOrNull = props.isGlobalModalOpen ? (
-        <SimpleModal onClose={props.closeGlobalModal} title={props.title}>
-            {props.currentContent}
+export default function GlobalModal() {
+    const {
+        globalModal: { isOpen, close, title, currentContent },
+    } = useContext(AppStateContext);
+    const modalOrNull = isOpen ? (
+        <SimpleModal onClose={close} title={title}>
+            {currentContent}
         </SimpleModal>
     ) : null;
 

--- a/src/App/components/GlobalModal/useGlobalModal.ts
+++ b/src/App/components/GlobalModal/useGlobalModal.ts
@@ -1,37 +1,44 @@
-import React, { useState } from 'react';
+import { ReactNode, useState } from 'react';
+
+export interface globalModalMethodsIF {
+    isOpen: boolean;
+    open: (content: ReactNode, title?: string) => void;
+    close: () => void;
+    currentContent: ReactNode;
+    title: string;
+}
 
 export const useGlobalModal = (initialMode = false) => {
     // create a useState hook to track if the modal should be rendered
-    const [isGlobalModalOpen, setIsGlobalModalOpen] =
-        useState<boolean>(initialMode);
+    const [isOpen, setIsOpen] = useState<boolean>(initialMode);
 
-    const [currentContent, setCurrentContent] = useState<React.ReactNode>(
+    const [currentContent, setCurrentContent] = useState<ReactNode>(
         'I am example content',
     );
 
     const [title, setTitle] = useState<string>('');
 
     // click handlers to to open and close the modal
-    const openGlobalModal = (content: React.ReactNode, title?: string) => {
-        setIsGlobalModalOpen(true);
+    const open = (content: ReactNode, title?: string) => {
+        setIsOpen(true);
         setCurrentContent(content);
 
         if (title) {
             setTitle(title);
         }
     };
-    const closeGlobalModal = () => {
+    const close = () => {
         setCurrentContent('');
         setTitle('');
-        setIsGlobalModalOpen(false);
+        setIsOpen(false);
     };
 
     // return all data and functions needed for local use
-    return [
-        isGlobalModalOpen,
-        openGlobalModal,
-        closeGlobalModal,
+    return {
+        isOpen,
+        open,
+        close,
         currentContent,
         title,
-    ] as const;
+    };
 };

--- a/src/App/components/GlobalPopup/GlobalPopup.tsx
+++ b/src/App/components/GlobalPopup/GlobalPopup.tsx
@@ -1,25 +1,21 @@
 import styles from './GlobalPopup.module.css';
 import { VscClose } from 'react-icons/vsc';
+import { useContext } from 'react';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
-interface GlobalPopupProps {
-    isGlobalPopupOpen: boolean;
-    openGlobalPopup: (page: string) => void;
-    closeGlobalPopup: () => void;
-    popupContent: React.ReactNode;
-    popupTitle?: string;
-    placement: string | 'left' | 'center' | 'right';
-}
-
-export default function GlobalPopup(props: GlobalPopupProps) {
-    const showGlobalPopupStyle = props.isGlobalPopupOpen
+export default function GlobalPopup() {
+    const {
+        globalPopup: { isOpen, close, title, content, placement },
+    } = useContext(AppStateContext);
+    const showGlobalPopupStyle = isOpen
         ? styles.global_popup_active
         : styles.global_popup;
     const placementStyle =
-        props.placement === 'left'
+        placement === 'left'
             ? styles.popup_left
-            : props.placement === 'center'
+            : placement === 'center'
             ? styles.popup_center
-            : props.placement === 'right'
+            : placement === 'right'
             ? styles.popup_right
             : styles.popup_right;
 
@@ -29,12 +25,12 @@ export default function GlobalPopup(props: GlobalPopupProps) {
         >
             <header>
                 <p />
-                <h3>{props.popupTitle}</h3>
-                <div onClick={props.closeGlobalPopup}>
+                <h3>{title}</h3>
+                <div onClick={close}>
                     <VscClose size={18} />
                 </div>
             </header>
-            <section>{props.popupContent}</section>
+            <section>{content}</section>
         </div>
     );
 }

--- a/src/App/components/GlobalPopup/useGlobalPopup.ts
+++ b/src/App/components/GlobalPopup/useGlobalPopup.ts
@@ -1,45 +1,51 @@
-import React, { useState } from 'react';
+import { ReactNode, useState } from 'react';
 
-export const useGlobalPopup = (initialMode = false) => {
+export interface globalPopupMethodsIF {
+    isOpen: boolean;
+    open: (content: ReactNode, title: string, placement: string) => void;
+    close: () => void;
+    content: ReactNode;
+    title: string;
+    placement: string;
+}
+
+export const useGlobalPopup = (initialMode = false): globalPopupMethodsIF => {
     // create a useState hook to track if the modal should be rendered
-    const [isGlobalPopupOpen, setIsGlobalPopupOpen] =
-        useState<boolean>(initialMode);
+    const [isOpen, setIsOpen] = useState<boolean>(initialMode);
 
-    const [popupContent, setPopupContent] = useState<React.ReactNode>(
-        'I am example content',
-    );
+    const [content, setContent] = useState<ReactNode>('I am example content');
 
-    const [popupTitle, setPopupTitle] = useState<string>('');
-    const [popupPlacement, setPopupPlacement] = useState('center');
+    const [title, setTitle] = useState<string>('');
+    const [placement, setPlacement] = useState('center');
 
-    const openGlobalPopup = (
-        content: React.ReactNode,
+    const open = (
+        content: ReactNode,
         popupTitle?: string,
         popupPlacement?: string,
     ) => {
-        setIsGlobalPopupOpen(true);
-        setPopupContent(content);
+        setIsOpen(true);
+        setContent(content);
 
         if (popupTitle) {
-            setPopupTitle(popupTitle);
+            setTitle(popupTitle);
         }
         if (popupPlacement) {
-            setPopupPlacement(popupPlacement);
+            setPlacement(popupPlacement);
         }
     };
-    const closeGlobalPopup = () => {
-        setPopupContent('');
-        setPopupTitle('');
-        setIsGlobalPopupOpen(false);
+    const close = () => {
+        setPlacement('');
+        setTitle('');
+        setIsOpen(false);
     };
 
     // return all data and functions needed for local use
-    return [
-        isGlobalPopupOpen,
-        openGlobalPopup,
-        closeGlobalPopup,
-        popupContent,
-        popupTitle,
-        popupPlacement,
-    ] as const;
+    return {
+        isOpen,
+        open,
+        close,
+        content,
+        title,
+        placement,
+    };
 };

--- a/src/App/components/PageHeader/Account/Account.tsx
+++ b/src/App/components/PageHeader/Account/Account.tsx
@@ -1,8 +1,7 @@
-import { useState, Dispatch, SetStateAction, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useContext } from 'react';
 import { FiMoreHorizontal } from 'react-icons/fi';
 import styles from './Account.module.css';
 import useCopyToClipboard from '../../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../../components/Global/SnackbarComponent/SnackbarComponent';
 import DropdownMenu from '../NavbarDropdownMenu/NavbarDropdownMenu';
 import NavItem from '../NavItem/NavItem';
 import { MdAccountBalanceWallet } from 'react-icons/md';
@@ -14,6 +13,7 @@ import { ChainSpec } from '@crocswap-libs/sdk';
 import WalletDropdown from './WalletDropdown/WalletDropdown';
 import useKeyPress from '../../../hooks/useKeyPress';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface AccountPropsIF {
     isUserLoggedIn: boolean | undefined;
@@ -23,15 +23,7 @@ interface AccountPropsIF {
     clickLogout: () => void;
     ensName: string;
     chainId: string;
-    isAppOverlayActive: boolean;
     ethMainnetUsdPrice?: number;
-
-    setIsAppOverlayActive: Dispatch<SetStateAction<boolean>>;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
-
-    switchTheme: () => void;
-    theme: string;
     chainData: ChainSpec;
     lastBlockNumber: number;
 }
@@ -43,14 +35,13 @@ export default function Account(props: AccountPropsIF) {
         clickLogout,
         ensName,
         chainId,
-        isAppOverlayActive,
-        setIsAppOverlayActive,
-        switchTheme,
-        theme,
         lastBlockNumber,
         chainData,
     } = props;
 
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
     const { connector, isConnected } = useAccount();
 
     const ensOrAddressTruncated = useAppSelector(
@@ -59,23 +50,12 @@ export default function Account(props: AccountPropsIF) {
 
     const isUserLoggedIn = isConnected;
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    const [value, copy] = useCopyToClipboard();
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyAddress() {
         copy(props.accountAddressFull);
-        setOpenSnackbar(true);
+        openSnackbar(`${props.accountAddressFull} copied`, 'info');
     }
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
 
     const [openNavbarMenu, setOpenNavbarMenu] = useState(false);
     const [showWalletDropdown, setShowWalletDropdown] = useState(false);
@@ -200,16 +180,9 @@ export default function Account(props: AccountPropsIF) {
                     isUserLoggedIn={isUserLoggedIn}
                     clickLogout={clickLogout}
                     chainId={chainId}
-                    isAppOverlayActive={isAppOverlayActive}
-                    setIsAppOverlayActive={setIsAppOverlayActive}
                     setIsNavbarMenuOpen={setOpenNavbarMenu}
-                    switchTheme={switchTheme}
-                    theme={theme}
-                    isTutorialMode={props.isTutorialMode}
-                    setIsTutorialMode={props.setIsTutorialMode}
                 />
             </NavItem>
-            {snackbarContent}
         </div>
     );
 }

--- a/src/App/components/PageHeader/NavbarDropdownMenu/NavbarDropdownMenu.tsx
+++ b/src/App/components/PageHeader/NavbarDropdownMenu/NavbarDropdownMenu.tsx
@@ -1,5 +1,5 @@
 // START: Import React and Dongles
-import { ReactNode, useState, useRef, useEffect } from 'react';
+import { ReactNode, useState, useRef, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { motion } from 'framer-motion';
@@ -24,6 +24,7 @@ import { RiErrorWarningLine } from 'react-icons/ri';
 import '../../../App.css';
 import styles from './NavbarDropdownMenu.module.css';
 import useKeyPress from '../../../hooks/useKeyPress';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface NavbarDropdownItemPropsIF {
     goToMenu?: string;
@@ -42,25 +43,16 @@ interface NavbarDropdownMenuPropsIF {
     clickLogout: () => void;
     closeMenu?: () => void;
     chainId: string;
-    isAppOverlayActive: boolean;
-    setIsAppOverlayActive: React.Dispatch<React.SetStateAction<boolean>>;
-    isTutorialMode: boolean;
-    setIsTutorialMode: React.Dispatch<React.SetStateAction<boolean>>;
-
     setIsNavbarMenuOpen: React.Dispatch<React.SetStateAction<boolean>>;
-    switchTheme: () => void;
-    theme: string;
 }
 
 export default function NavbarDropdownMenu(props: NavbarDropdownMenuPropsIF) {
+    const { isUserLoggedIn, clickLogout, closeMenu, setIsNavbarMenuOpen } =
+        props;
+
     const {
-        isUserLoggedIn,
-        clickLogout,
-        closeMenu,
-        setIsNavbarMenuOpen,
-        isTutorialMode,
-        setIsTutorialMode,
-    } = props;
+        tutorial: { isActive: isTutorialMode, setIsActive: setIsTutorialMode },
+    } = useContext(AppStateContext);
 
     const navigate = useNavigate();
 

--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, Dispatch, SetStateAction } from 'react';
+import { useEffect, useState } from 'react';
 import { useLocation, Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
 import { motion, AnimateSharedLayout } from 'framer-motion';
@@ -28,19 +28,9 @@ interface HeaderPropsIF {
     isChainSupported: boolean;
     openWagmiModalWallet: () => void;
     ethMainnetUsdPrice?: number;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
-    isMobileSidebarOpen: boolean;
-    setIsMobileSidebarOpen: Dispatch<SetStateAction<boolean>>;
     lastBlockNumber: number;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
-    isAppOverlayActive: boolean;
     poolPriceDisplay: number | undefined;
-    setIsAppOverlayActive: Dispatch<SetStateAction<boolean>>;
     recentPools: recentPoolsMethodsIF;
-    switchTheme: () => void;
-    theme: string;
     chainData: ChainSpec;
     getTokenByAddress: (addr: string, chn: string) => TokenIF | undefined;
 }
@@ -52,15 +42,9 @@ export default function PageHeader(props: HeaderPropsIF) {
         isChainSupported,
         openWagmiModalWallet,
         lastBlockNumber,
-        isAppOverlayActive,
-        setIsAppOverlayActive,
-        switchTheme,
         recentPools,
-        theme,
         poolPriceDisplay,
         chainData,
-        isTutorialMode,
-        setIsTutorialMode,
         clickLogout,
     } = props;
 
@@ -87,16 +71,9 @@ export default function PageHeader(props: HeaderPropsIF) {
         isUserLoggedIn: isConnected,
         clickLogout: clickLogout,
         chainId: chainId,
-        isAppOverlayActive: isAppOverlayActive,
-        setIsAppOverlayActive: setIsAppOverlayActive,
         ethMainnetUsdPrice: ethMainnetUsdPrice,
-        switchTheme: switchTheme,
-        theme: theme,
         lastBlockNumber: lastBlockNumber,
         chainData: chainData,
-
-        isTutorialMode: isTutorialMode,
-        setIsTutorialMode: setIsTutorialMode,
     };
 
     const connectWagmiButton = (

--- a/src/App/components/Sidebar/Sidebar.tsx
+++ b/src/App/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,12 @@
 // START: Import React and Dongles
-import { SetStateAction, Dispatch, useState, useEffect, useRef } from 'react';
+import {
+    SetStateAction,
+    Dispatch,
+    useState,
+    useEffect,
+    useRef,
+    useContext,
+} from 'react';
 import { useLocation } from 'react-router-dom';
 import { BiSearch } from 'react-icons/bi';
 import { BsChevronBarDown } from 'react-icons/bs';
@@ -39,14 +46,13 @@ import { recentPoolsMethodsIF } from '../../hooks/useRecentPools';
 import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 import { ackTokensMethodsIF } from '../../hooks/useAckTokens';
 import { topPoolIF } from '../../hooks/useTopPools';
-import { sidebarMethodsIF } from '../../hooks/useSidebar';
 import { useAppSelector } from '../../../utils/hooks/reduxToolkit';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 const cachedPoolStatsFetch = memoizePoolStats();
 
 // interface for component props
 interface propsIF {
-    sidebar: sidebarMethodsIF;
     tradeData: tradeData;
     isDenomBase: boolean;
     chainId: string;
@@ -63,10 +69,6 @@ interface propsIF {
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
     tokenMap: Map<string, TokenIF>;
     lastBlockNumber: number;
-    selectedOutsideTab: number;
-    outsideControl: boolean;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     openModalWallet: () => void;
     poolList: TempPoolIF[];
     verifyToken: (addr: string, chn: string) => boolean;
@@ -79,7 +81,6 @@ interface propsIF {
 
 export default function Sidebar(props: propsIF) {
     const {
-        sidebar,
         tradeData,
         isDenomBase,
         chainId,
@@ -100,13 +101,11 @@ export default function Sidebar(props: propsIF) {
         tokenPair,
         recentPools,
         isConnected,
-        outsideControl,
-        setOutsideControl,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
         ackTokens,
         topPools,
     } = props;
+
+    const { sidebar } = useContext(AppStateContext);
 
     const location = useLocation();
 
@@ -168,11 +167,8 @@ export default function Sidebar(props: propsIF) {
                     chainId={chainId}
                     userPositions={mostRecentPositions}
                     isDenomBase={isDenomBase}
-                    setSelectedOutsideTab={setSelectedOutsideTab}
-                    setOutsideControl={setOutsideControl}
                     setCurrentPositionActive={setCurrentPositionActive}
                     setIsShowAllEnabled={setIsShowAllEnabled}
-                    closeSidebar={sidebar.close}
                     isUserLoggedIn={isConnected}
                 />
             ),
@@ -189,17 +185,12 @@ export default function Sidebar(props: propsIF) {
                     tokenMap={tokenMap}
                     chainId={chainId}
                     limitOrderByUser={mostRecentLimitOrders}
-                    selectedOutsideTab={selectedOutsideTab}
-                    setSelectedOutsideTab={setSelectedOutsideTab}
-                    outsideControl={outsideControl}
-                    setOutsideControl={setOutsideControl}
                     isShowAllEnabled={isShowAllEnabled}
                     setCurrentPositionActive={setCurrentPositionActive}
                     setIsShowAllEnabled={setIsShowAllEnabled}
                     expandTradeTable={expandTradeTable}
                     setExpandTradeTable={setExpandTradeTable}
                     isUserLoggedIn={isConnected}
-                    closeSidebar={sidebar.close}
                 />
             ),
         },
@@ -241,12 +232,7 @@ export default function Sidebar(props: propsIF) {
                     setIsShowAllEnabled={setIsShowAllEnabled}
                     expandTradeTable={expandTradeTable}
                     setExpandTradeTable={setExpandTradeTable}
-                    selectedOutsideTab={selectedOutsideTab}
-                    setSelectedOutsideTab={setSelectedOutsideTab}
-                    setOutsideControl={setOutsideControl}
-                    outsideControl={outsideControl}
                     isUserLoggedIn={isConnected}
-                    closeSidebar={sidebar.close}
                 />
             ),
         },
@@ -546,8 +532,6 @@ export default function Sidebar(props: propsIF) {
                             chainId={chainId}
                             isConnected={isConnected}
                             cachedPoolStatsFetch={cachedPoolStatsFetch}
-                            setOutsideControl={setOutsideControl}
-                            setSelectedOutsideTab={setSelectedOutsideTab}
                             setCurrentPositionActive={setCurrentPositionActive}
                             setCurrentTxActiveInTransactions={
                                 setCurrentTxActiveInTransactions

--- a/src/App/components/Sidebar/SidebarSearchResults/OrdersSearchResults/OrdersSearchResults.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/OrdersSearchResults/OrdersSearchResults.tsx
@@ -1,16 +1,15 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../SidebarSearchResults.module.css';
 import { LimitOrderIF } from '../../../../../utils/interfaces/exports';
 import getUnicodeCharacter from '../../../../../utils/functions/getUnicodeCharacter';
 import { getDisplayPrice, getValueUSD } from './functions/exports';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     chainId: string;
     searchedLimitOrders: LimitOrderIF[];
     isDenomBase: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
 }
@@ -60,17 +59,20 @@ export default function OrdersSearchResults(props: propsIF) {
         chainId,
         searchedLimitOrders,
         isDenomBase,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setCurrentPositionActive,
         setIsShowAllEnabled,
     } = props;
 
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+    } = useContext(AppStateContext);
+
     const navigate = useNavigate();
 
     const handleClick = (limitOrder: LimitOrderIF): void => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(1);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(1);
         setCurrentPositionActive(limitOrder.limitOrderIdentifier);
         setIsShowAllEnabled(false);
         navigate(

--- a/src/App/components/Sidebar/SidebarSearchResults/PositionsSearchResults/PositionsSearchResults.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/PositionsSearchResults/PositionsSearchResults.tsx
@@ -1,15 +1,14 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../SidebarSearchResults.module.css';
 import { PositionIF } from '../../../../../utils/interfaces/exports';
 import { getRangeDisplay, getValueUSD } from './functions/exports';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     chainId: string;
     searchedPositions: PositionIF[];
     isDenomBase: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
 }
@@ -49,17 +48,20 @@ export default function PositionsSearchResults(props: propsIF) {
         chainId,
         searchedPositions,
         isDenomBase,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setCurrentPositionActive,
         setIsShowAllEnabled,
     } = props;
 
     const navigate = useNavigate();
 
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+    } = useContext(AppStateContext);
+
     const handleClick = (position: PositionIF): void => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(2);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(2);
         setCurrentPositionActive(position.positionStorageSlot);
         setIsShowAllEnabled(false);
         navigate(

--- a/src/App/components/Sidebar/SidebarSearchResults/SidebarSearchResults.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/SidebarSearchResults.tsx
@@ -14,8 +14,6 @@ interface propsIF {
     isConnected: boolean;
     cachedPoolStatsFetch: PoolStatsFn;
     isDenomBase: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     setCurrentTxActiveInTransactions: Dispatch<SetStateAction<string>>;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
@@ -30,8 +28,6 @@ export default function SidebarSearchResults(props: propsIF) {
         isConnected,
         cachedPoolStatsFetch,
         isDenomBase,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setCurrentPositionActive,
         setCurrentTxActiveInTransactions,
         setIsShowAllEnabled,
@@ -51,8 +47,6 @@ export default function SidebarSearchResults(props: propsIF) {
                     <TxSearchResults
                         chainId={chainId}
                         searchedTxs={searchData.txs}
-                        setOutsideControl={setOutsideControl}
-                        setSelectedOutsideTab={setSelectedOutsideTab}
                         setCurrentTxActiveInTransactions={
                             setCurrentTxActiveInTransactions
                         }
@@ -62,8 +56,6 @@ export default function SidebarSearchResults(props: propsIF) {
                         chainId={chainId}
                         searchedLimitOrders={searchData.limits}
                         isDenomBase={isDenomBase}
-                        setOutsideControl={setOutsideControl}
-                        setSelectedOutsideTab={setSelectedOutsideTab}
                         setCurrentPositionActive={setCurrentPositionActive}
                         setIsShowAllEnabled={setIsShowAllEnabled}
                     />
@@ -71,8 +63,6 @@ export default function SidebarSearchResults(props: propsIF) {
                         chainId={chainId}
                         searchedPositions={searchData.positions}
                         isDenomBase={isDenomBase}
-                        setOutsideControl={setOutsideControl}
-                        setSelectedOutsideTab={setSelectedOutsideTab}
                         setCurrentPositionActive={setCurrentPositionActive}
                         setIsShowAllEnabled={setIsShowAllEnabled}
                     />

--- a/src/App/components/Sidebar/SidebarSearchResults/TxSearchResults/TxSearchResults.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/TxSearchResults/TxSearchResults.tsx
@@ -1,14 +1,13 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styles from '../SidebarSearchResults.module.css';
 import { TransactionIF } from '../../../../../utils/interfaces/exports';
 import TxLI from './TxLI';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     chainId: string;
     searchedTxs: TransactionIF[];
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
     setCurrentTxActiveInTransactions: Dispatch<SetStateAction<string>>;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
 }
@@ -17,17 +16,20 @@ export default function TxSearchResults(props: propsIF) {
     const {
         chainId,
         searchedTxs,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setCurrentTxActiveInTransactions,
         setIsShowAllEnabled,
     } = props;
 
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+    } = useContext(AppStateContext);
+
     const navigate = useNavigate();
 
     const handleClick = (tx: TransactionIF): void => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(0);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(0);
         setIsShowAllEnabled(false);
         setCurrentTxActiveInTransactions(tx.id);
         navigate(

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -7,6 +7,8 @@ export interface sidebarMethodsIF {
     open: (persist?: string) => void;
     close: (persist?: string) => void;
     toggle: (persist?: string) => void;
+    isMobileOpen: boolean;
+    setIsMobileOpen: (val: boolean) => void;
 }
 
 export const useSidebar = (pathname: string): sidebarMethodsIF => {
@@ -19,6 +21,8 @@ export const useSidebar = (pathname: string): sidebarMethodsIF => {
     const [sidebar, setSidebar] = useState<string>(
         localStorage.getItem(localStorageKey) || 'open',
     );
+
+    const [isMobileOpen, setIsMobileOpen] = useState(false);
 
     // reusable logic to update state and optionally persist data in local storage
     const changeSidebar = (newStatus: string, persist: string): void => {
@@ -66,5 +70,7 @@ export const useSidebar = (pathname: string): sidebarMethodsIF => {
         open: openSidebar,
         close: closeSidebar,
         toggle: toggleSidebar,
+        isMobileOpen,
+        setIsMobileOpen,
     };
 };

--- a/src/App/hooks/useSkin.ts
+++ b/src/App/hooks/useSkin.ts
@@ -5,7 +5,13 @@ import { useMemo, useState } from 'react';
 // TODO:   @Junior  ... to read the current value of `skin` & return the
 // TODO:   @Junior  ... correct JSON color set
 
-export const useSkin = (defaultSkin: string) => {
+export interface skinMethodsIF {
+    colors: Record<string, unknown>;
+    choosePurpleDark: () => void;
+    choosePurpleLight: () => void;
+}
+
+export const useSkin = (defaultSkin: string): skinMethodsIF => {
     // name of the current skin in use by the app
     // defaults to value in local storage, uses value from params as fallback
     const [skin, setSkin] = useState<string>(localStorage.skin ?? defaultSkin);

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -4,7 +4,7 @@ import DividerDark from '../Global/DividerDark/DividerDark';
 import MessageInput from './MessagePanel/InputBox/MessageInput';
 import Room from './MessagePanel/Room/Room';
 import { RiArrowDownSLine } from 'react-icons/ri';
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import { useContext, useEffect, useRef, useState } from 'react';
 import useSocket from './Service/useSocket';
 import { PoolIF, TokenIF } from '../../utils/interfaces/exports';
 import { useParams } from 'react-router-dom';
@@ -18,6 +18,7 @@ import trimString from '../../utils/functions/trimString';
 import NotFound from '../../pages/NotFound/NotFound';
 import { topPoolIF } from '../../App/hooks/useTopPools';
 import ExpandChatIcon from '../../assets/images/icons/expand.svg';
+import { AppStateContext } from '../../contexts/AppStateContext';
 
 interface currentPoolInfo {
     tokenA: TokenIF;
@@ -38,8 +39,6 @@ interface currentPoolInfo {
 }
 
 interface propsIF {
-    isChatOpen: boolean;
-    setIsChatOpen: Dispatch<SetStateAction<boolean>>;
     onClose: () => void;
     currentPool: currentPoolInfo;
     isFullScreen: boolean;
@@ -48,19 +47,18 @@ interface propsIF {
     appPage?: boolean;
     username?: string | null;
     topPools: topPoolIF[];
-    isChatEnabled: boolean;
-    areSubscriptionsEnabled: boolean;
 }
 
 export default function ChatPanel(props: propsIF) {
+    const { isFullScreen, currentPool, topPools } = props;
     const {
-        isChatEnabled,
-        areSubscriptionsEnabled,
-        isFullScreen,
-        currentPool,
-        setIsChatOpen,
-        topPools,
-    } = props;
+        chat: {
+            isEnabled: isChatEnabled,
+            isOpen: isChatOpen,
+            setIsOpen: setIsChatOpen,
+        },
+        subscriptions: { isEnabled: isSubscriptionsEnabled },
+    } = useContext(AppStateContext);
 
     if (!isChatEnabled) return <NotFound />;
 
@@ -86,8 +84,8 @@ export default function ChatPanel(props: propsIF) {
 
     const { messages, getMsg, lastMessage, messageUser } = useSocket(
         room,
-        areSubscriptionsEnabled,
-        props.isChatOpen,
+        isSubscriptionsEnabled,
+        isChatOpen,
     );
 
     const { getID, updateUser, updateMessageUser, saveUser } = useChatApi();
@@ -112,7 +110,7 @@ export default function ChatPanel(props: propsIF) {
     // eslint-disable-next-line
     function openChatPanel(e: any) {
         if (e.keyCode === 67 && e.ctrlKey && e.altKey) {
-            setIsChatOpen(!props.isChatOpen);
+            setIsChatOpen(!isChatOpen);
         }
     }
 
@@ -203,14 +201,14 @@ export default function ChatPanel(props: propsIF) {
         } else {
             setCurrentUser(undefined);
         }
-    }, [ens, address, props.isChatOpen, isFullScreen, setUserCurrentPool]);
+    }, [ens, address, isChatOpen, isFullScreen, setUserCurrentPool]);
 
     useEffect(() => {
         setIsScrollToBottomButtonPressed(false);
         scrollToBottom();
         setNotification(0);
         getMsg();
-    }, [room, props.isChatOpen === false]);
+    }, [room, isChatOpen === false]);
 
     useEffect(() => {
         if (isMessageDeleted === true) {
@@ -223,10 +221,10 @@ export default function ChatPanel(props: propsIF) {
         setIsScrollToBottomButtonPressed(false);
         scrollToBottom();
         setNotification(0);
-    }, [props.isChatOpen]);
+    }, [isChatOpen]);
 
     function handleCloseChatPanel() {
-        props.setIsChatOpen(false);
+        setIsChatOpen(false);
     }
 
     const scrollToBottomButton = async () => {
@@ -287,11 +285,11 @@ export default function ChatPanel(props: propsIF) {
     const header = (
         <div
             className={styles.chat_header}
-            onClick={() => setIsChatOpen(!props.isChatOpen)}
+            onClick={() => setIsChatOpen(!isChatOpen)}
         >
             <h2 className={styles.chat_title}>Chat</h2>
             <section style={{ paddingRight: '10px' }}>
-                {isFullScreen || !props.isChatOpen ? (
+                {isFullScreen || !isChatOpen ? (
                     <></>
                 ) : (
                     <div
@@ -307,7 +305,7 @@ export default function ChatPanel(props: propsIF) {
                         />
                     </div>
                 )}
-                {isFullScreen || !props.isChatOpen ? (
+                {isFullScreen || !isChatOpen ? (
                     <></>
                 ) : (
                     <IoIosArrowDown
@@ -319,7 +317,7 @@ export default function ChatPanel(props: propsIF) {
                         aria-label='hide chat button'
                     />
                 )}
-                {!props.isChatOpen && (
+                {!isChatOpen && (
                     <IoIosArrowUp
                         size={22}
                         role='button'
@@ -468,12 +466,10 @@ export default function ChatPanel(props: propsIF) {
             }
             ensName={ensName}
             appPage={props.appPage}
-            areSubscriptionsEnabled={areSubscriptionsEnabled}
-            isChatOpen={props.isChatOpen}
         />
     );
 
-    const contentHeight = props.isChatOpen ? '479px' : '30px';
+    const contentHeight = isChatOpen ? '479px' : '30px';
     if (props.appPage)
         return (
             <FullChat

--- a/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
+++ b/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
@@ -5,20 +5,25 @@ import { Message } from '../../Model/MessageModel';
 
 import Picker from 'emoji-picker-react';
 import styles from './MessageInput.module.css';
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useState,
+} from 'react';
 import PositionBox from '../PositionBox/PositionBox';
 import { PoolIF, TokenIF } from '../../../../utils/interfaces/exports';
 
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import { RiCloseFill, RiInformationLine } from 'react-icons/ri';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 interface MessageInputProps {
     message?: Message;
     room: string;
     currentUser: string;
     ensName: string;
     appPage?: boolean;
-    areSubscriptionsEnabled: boolean;
-    isChatOpen: boolean;
 }
 interface currentPoolInfo {
     tokenA: TokenIF;
@@ -58,11 +63,15 @@ export default function MessageInput(
     const [isInfoPressed, setIsInfoPressed] = useState(false);
     const { address, isConnected } = useAccount();
     const [isPosition, setIsPosition] = useState(false);
+    const {
+        chat: { isOpen: isChatOpen },
+        subscriptions: { isEnabled: isSubscriptionsEnabled },
+    } = useContext(AppStateContext);
 
     const { sendMsg } = useSocket(
         props.room.toUpperCase(),
-        props.areSubscriptionsEnabled,
-        props.isChatOpen,
+        isSubscriptionsEnabled,
+        isChatOpen,
     );
 
     const userData = useAppSelector((state) => state.userData);

--- a/src/components/Chat/MessagePanel/PositionBox/PositionBox.tsx
+++ b/src/components/Chat/MessagePanel/PositionBox/PositionBox.tsx
@@ -13,8 +13,6 @@ import {
 import styles from './PositionBox.module.css';
 import { motion } from 'framer-motion';
 
-import SnackbarComponent from '../../../Global/SnackbarComponent/SnackbarComponent';
-
 interface propsIF {
     message: string;
     isInput: boolean;
@@ -25,11 +23,9 @@ interface propsIF {
 }
 
 export default function PositionBox(props: propsIF) {
-    const [openSnackbar, setOpenSnackbar] = useState<boolean>(false);
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [isPoolPriceChangePositive] = useState<boolean>(false);
     const message = props.message;
-    const [hashMsg, setHashMsg] = useState('');
     const isInput = props.isInput;
     const [position, setPosition] = useState<TransactionIF | undefined>(
         undefined,
@@ -58,7 +54,6 @@ export default function PositionBox(props: propsIF) {
             const hashMsg = message
                 .split(' ')
                 .find((item) => item.includes('0x'));
-            setHashMsg(hashMsg as string);
             if (transactionsData.find((item) => item.tx === hashMsg)) {
                 setPosition(
                     transactionsData.find((item) => item.tx === hashMsg),
@@ -196,16 +191,6 @@ export default function PositionBox(props: propsIF) {
             return trimString(sPositions.positionStorageSlot, 6, 4, '…');
         }
     }
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {hashMsg && hashMsg.split(' ') && trimString(hashMsg, 6, 4, '…')}{' '}
-            copied
-        </SnackbarComponent>
-    );
 
     function getRestOfMessagesIfAny() {
         if (message.includes(' ')) {
@@ -307,7 +292,6 @@ export default function PositionBox(props: propsIF) {
                             <></>
                         )}
                     </div>
-                    {snackbarContent}
                 </div>
                 <p className={styles.position_message}>
                     {getRestOfMessagesIfAny()}
@@ -380,7 +364,6 @@ export default function PositionBox(props: propsIF) {
                             <></>
                         )}
                     </div>
-                    {snackbarContent}
                 </div>
                 <div>
                     <p className={styles.position_message}>
@@ -391,7 +374,6 @@ export default function PositionBox(props: propsIF) {
         ) : sPositions !== undefined && !isInput ? (
             <motion.div className={styles.animate_position_box}>
                 <div className={styles.position_main_box}>
-                    {snackbarContent}
                     <div className={styles.position_box}>
                         <div className={styles.position_info}>
                             <div className={styles.tokens_name}>
@@ -446,7 +428,6 @@ export default function PositionBox(props: propsIF) {
                 transition={{ duration: 0.8, ease: [0.04, 0.62, 0.23, 0.98] }}
             >
                 <div className={styles.position_main_box}>
-                    {snackbarContent}
                     <div className={styles.position_box}>
                         <div className={styles.position_info}>
                             <div className={styles.tokens_name}>

--- a/src/components/Global/AppOverlay/AppOverlay.tsx
+++ b/src/components/Global/AppOverlay/AppOverlay.tsx
@@ -1,22 +1,21 @@
 import styles from './AppOverlay.module.css';
-import { useState, Dispatch, SetStateAction } from 'react';
+import { useState, useContext } from 'react';
 import OverlayComponent from '../OverlayComponent/OverlayComponent';
 import {
     MdOutlineArrowBackIosNew,
     MdOutlineArrowForwardIos,
 } from 'react-icons/md';
 import { VscClose } from 'react-icons/vsc';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
-interface AppOverlayPropsIf {
-    isAppOverlayActive: boolean;
-
-    setIsAppOverlayActive: Dispatch<SetStateAction<boolean>>;
-}
-export default function AppOverlay(props: AppOverlayPropsIf) {
+export default function AppOverlay() {
     // const navigate = useNavigate();
-
-    const { isAppOverlayActive, setIsAppOverlayActive } = props;
-
+    const {
+        appOverlay: {
+            isActive: isAppOverlayActive,
+            setIsActive: setIsAppOverlayActive,
+        },
+    } = useContext(AppStateContext);
     const [page, setPage] = useState(0);
 
     const page1Overlays = (

--- a/src/components/Global/PoolCard/PoolCard.tsx
+++ b/src/components/Global/PoolCard/PoolCard.tsx
@@ -11,9 +11,9 @@ import { tradeData } from '../../../utils/state/tradeDataSlice';
 import { getMoneynessRank } from '../../../utils/functions/getMoneynessRank';
 import { topPoolIF } from '../../../App/hooks/useTopPools';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
-    isServerEnabled: boolean;
     isUserIdle: boolean;
     tradeData: tradeData;
     cachedQuerySpotPrice: SpotPriceFn;
@@ -25,7 +25,6 @@ interface propsIF {
 
 export default function PoolCard(props: propsIF) {
     const {
-        isServerEnabled,
         isUserIdle,
         lastBlockNumber,
         chainId,
@@ -35,6 +34,9 @@ export default function PoolCard(props: propsIF) {
     } = props;
 
     const crocEnv = useContext(CrocEnvContext);
+    const {
+        server: { isEnabled: isServerEnabled },
+    } = useContext(AppStateContext);
 
     const [poolPriceDisplay, setPoolPriceDisplay] = useState<
         string | undefined

--- a/src/components/Global/ShareModal/ShareModal.tsx
+++ b/src/components/Global/ShareModal/ShareModal.tsx
@@ -1,12 +1,12 @@
 import styles from './ShareModal.module.css';
 import { FiCopy } from 'react-icons/fi';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { FaDiscord, FaTelegram, FaFacebook } from 'react-icons/fa';
 import { AiFillTwitterCircle } from 'react-icons/ai';
 import { useLocation } from 'react-router-dom';
 import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../components/Global/SnackbarComponent/SnackbarComponent';
 import FocusTrap from 'focus-trap-react';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface SocialLinkPropsIF {
     // eslint-disable-next-line
@@ -38,6 +38,10 @@ export default function ShareModal() {
     // const currentUrl = location.href
     const currentPathname = location.pathname;
 
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
+
     const [linkToShare, setLinkToShare] = useState(
         `ambient-finance.netlify.app${currentPathname}`,
     );
@@ -66,24 +70,13 @@ export default function ShareModal() {
         },
     ];
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-
-    const [value, copy] = useCopyToClipboard();
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyAddress() {
         copy(linkToShare);
-        setOpenSnackbar(true);
+        openSnackbar(`${linkToShare} copied`, 'info');
     }
 
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
     // -------------------------Swap SHARE FUNCTIONALITY---------------------------
     // const [shareOptions, setShareOptions] = useState([
     //     { slug: 'first', name: 'Include Swap 1', checked: false },
@@ -166,7 +159,6 @@ export default function ShareModal() {
                         <FiCopy color='#cdc1ff' size={25} />
                     </button>
                 </p>
-                {snackbarContent}
             </div>
         </FocusTrap>
     );

--- a/src/components/Global/Sidebar/SidebarLimitOrders/SidebarLimitOrders.tsx
+++ b/src/components/Global/Sidebar/SidebarLimitOrders/SidebarLimitOrders.tsx
@@ -1,17 +1,14 @@
 import styles from './SidebarLimitOrders.module.css';
 import SidebarLimitOrdersCard from './SidebarLimitOrdersCard';
-import { SetStateAction, Dispatch } from 'react';
+import { SetStateAction, Dispatch, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import { LimitOrderIF, TokenIF } from '../../../../utils/interfaces/exports';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface propsIF {
     tokenMap: Map<string, TokenIF>;
     chainId: string;
     isDenomBase: boolean;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     limitOrderByUser?: LimitOrderIF[];
     isShowAllEnabled: boolean;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
@@ -19,7 +16,6 @@ interface propsIF {
     isUserLoggedIn: boolean | undefined;
     expandTradeTable: boolean;
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
-    closeSidebar: () => void;
 }
 export default function SidebarLimitOrders(props: propsIF) {
     const {
@@ -27,13 +23,16 @@ export default function SidebarLimitOrders(props: propsIF) {
         tokenMap,
         chainId,
         isDenomBase,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setCurrentPositionActive,
         setIsShowAllEnabled,
         isUserLoggedIn,
-        closeSidebar,
     } = props;
+
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+        sidebar: { close: closeSidebar },
+    } = useContext(AppStateContext);
 
     const location = useLocation();
     const navigate = useNavigate();
@@ -48,8 +47,8 @@ export default function SidebarLimitOrders(props: propsIF) {
     }
 
     const handleLimitOrderClick = (limitOrder: LimitOrderIF) => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(1);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(1);
         setCurrentPositionActive(limitOrder.limitOrderIdentifier);
         setIsShowAllEnabled(false);
         navigate(
@@ -64,8 +63,8 @@ export default function SidebarLimitOrders(props: propsIF) {
 
     const handleViewMoreClick = () => {
         redirectBasedOnRoute();
-        setOutsideControl(true);
-        setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(tabToSwitchToBasedOnRoute);
         closeSidebar();
     };
 

--- a/src/components/Global/Sidebar/SidebarRangePositions/SidebarRangePositions.tsx
+++ b/src/components/Global/Sidebar/SidebarRangePositions/SidebarRangePositions.tsx
@@ -1,19 +1,17 @@
 import styles from './SidebarRangePositions.module.css';
 import SidebarRangePositionsCard from './SidebarRangePositionsCard';
 import { PositionIF } from '../../../../utils/interfaces/exports';
-import { SetStateAction, Dispatch } from 'react';
+import { SetStateAction, Dispatch, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface propsIF {
     chainId: string;
     isDenomBase: boolean;
     userPositions?: PositionIF[];
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
     isUserLoggedIn: boolean | undefined;
-    closeSidebar: () => void;
 }
 
 export default function SidebarRangePositions(props: propsIF) {
@@ -23,11 +21,14 @@ export default function SidebarRangePositions(props: propsIF) {
         userPositions,
         setCurrentPositionActive,
         isUserLoggedIn,
-        closeSidebar,
-        setOutsideControl,
-        setSelectedOutsideTab,
         setIsShowAllEnabled,
     } = props;
+
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+        sidebar: { close: closeSidebar },
+    } = useContext(AppStateContext);
 
     const location = useLocation();
     const navigate = useNavigate();
@@ -43,8 +44,8 @@ export default function SidebarRangePositions(props: propsIF) {
     }
 
     const handleRangePositionClick = (pos: PositionIF): void => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(tabToSwitchToBasedOnRoute);
         setCurrentPositionActive(pos.positionStorageSlot);
         setIsShowAllEnabled(false);
         navigate(
@@ -59,8 +60,8 @@ export default function SidebarRangePositions(props: propsIF) {
 
     const handleViewMoreClick = () => {
         redirectBasedOnRoute();
-        setOutsideControl(true);
-        setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(tabToSwitchToBasedOnRoute);
         closeSidebar();
     };
 

--- a/src/components/Global/Sidebar/SidebarRecentTransactions/SidebarRecentTransactions.tsx
+++ b/src/components/Global/Sidebar/SidebarRecentTransactions/SidebarRecentTransactions.tsx
@@ -1,6 +1,7 @@
 // START: Import React and Dongles
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // START: Import Local Files
 import { TokenIF, TransactionIF } from '../../../../utils/interfaces/exports';
@@ -19,12 +20,7 @@ interface propsIF {
     setIsShowAllEnabled: Dispatch<SetStateAction<boolean>>;
     expandTradeTable: boolean;
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     isUserLoggedIn: boolean | undefined;
-    closeSidebar: () => void;
 }
 
 export default function SidebarRecentTransactions(props: propsIF) {
@@ -33,11 +29,14 @@ export default function SidebarRecentTransactions(props: propsIF) {
         chainId,
         setCurrentTxActiveInTransactions,
         setIsShowAllEnabled,
-        setOutsideControl,
-        setSelectedOutsideTab,
         isUserLoggedIn,
-        closeSidebar,
     } = props;
+
+    const {
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+        sidebar: { close: closeSidebar },
+    } = useContext(AppStateContext);
 
     const location = useLocation();
     const navigate = useNavigate();
@@ -53,8 +52,8 @@ export default function SidebarRecentTransactions(props: propsIF) {
     }
 
     const handleCardClick = (tx: TransactionIF): void => {
-        setOutsideControl(true);
-        setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(tabToSwitchToBasedOnRoute);
         setIsShowAllEnabled(false);
         setCurrentTxActiveInTransactions(tx.id);
         navigate(
@@ -69,8 +68,8 @@ export default function SidebarRecentTransactions(props: propsIF) {
 
     const handleViewMoreClick = (): void => {
         redirectBasedOnRoute();
-        setOutsideControl(true);
-        setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
+        setOutsideControlActive(true);
+        setOutsideTabSelected(tabToSwitchToBasedOnRoute);
         closeSidebar();
     };
 

--- a/src/components/Global/SnackbarComponent/SNACKBAR.MD
+++ b/src/components/Global/SnackbarComponent/SNACKBAR.MD
@@ -18,23 +18,4 @@ Alert: https://mui.com/material-ui/react-alert/
 
 # Developer Notes
 
-To call a Snackbar anywhere in the app, you should:
-1. Import the React functional component from `SnackbarComponent.tsx`
-2. Import the `.ts` file housing the data for the snackbar you want to create
-3. Import the `useState` hook from react
-4. Create a local state in the file you want to call the snackbar in with a default boolean of `false`.
-Ex: `const [openSnackbar, setOpenSnackbar] = useState<boolean>(false)`
-5. Call the Snackbar component in your return statement and assign it a prop of `setOpenSnackbar` and `openSnackbar`. 
-6. Give the SnackbarComponent a prop for severity. You have the option between `error`, `warning`, `info`, `success`. The default is success. 
-7. The snackbar component takes content to render as a child component.
-Full example of usablity:
-` <SnackbarComponent severity='success' setOpenSnackbar={setOpenSnackbar} openSnackbar={openSnackbar}>
-    I am snackbar
-</SnackbarComponent>` 
-
-To open the snackbar component, create a function that toggles the `SetOpenSnackbar` to `true`. To test the snackbar out, I suggest you create a button with an onclick that handles this functionality.
-
-
-
-
-
+The snackbar has been updated to be a global component (like globalModal and globalPopup). It can be accessed via the `appStateContext` and passing in `content` and `severity` into the `open` function. 

--- a/src/components/Global/SnackbarComponent/SnackbarComponent.tsx
+++ b/src/components/Global/SnackbarComponent/SnackbarComponent.tsx
@@ -1,14 +1,9 @@
 // START: Import React and Dongles
-import {
-    forwardRef,
-    Dispatch,
-    SetStateAction,
-    ReactNode,
-    SyntheticEvent,
-} from 'react';
+import { forwardRef, SyntheticEvent, useContext } from 'react';
 import { Snackbar } from '@material-ui/core';
-import { Alert, AlertProps, AlertColor } from '@mui/material';
+import { Alert, AlertProps } from '@mui/material';
 import { motion } from 'framer-motion';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 const SnackbarAlert = forwardRef<HTMLDivElement, AlertProps>(
     function SnackbarAlert(props, ref) {
@@ -26,32 +21,27 @@ const SnackbarAlert = forwardRef<HTMLDivElement, AlertProps>(
     },
 );
 
-// interface for React functional component props
-interface SnackbarPropsIF {
-    children: ReactNode;
-    severity: AlertColor;
-    setOpenSnackbar: Dispatch<SetStateAction<boolean>>;
-    openSnackbar: boolean;
-}
-
 // React functional component
-export default function SnackbarComponent(props: SnackbarPropsIF) {
-    const { openSnackbar, setOpenSnackbar, children, severity } = props;
+export default function SnackbarComponent() {
+    const {
+        snackbar: { isOpen: isSnackbarOpen, close, content, severity },
+    } = useContext(AppStateContext);
 
     const handleClose = (event?: SyntheticEvent | Event, reason?: string) => {
         if (reason === 'clickaway') {
             return;
         }
-        setOpenSnackbar(false);
+        close();
     };
 
     return (
         <motion.div>
             <Snackbar
-                open={openSnackbar}
+                open={isSnackbarOpen}
                 autoHideDuration={8000}
                 onClose={handleClose}
-                style={{ width: '900px' }}
+                // z-index needs to be greater than globalModal and globalPopup
+                style={{ width: '900px', zIndex: 10000000 }}
             >
                 <motion.div
                     initial={{ scale: 0.5 }}
@@ -59,7 +49,7 @@ export default function SnackbarComponent(props: SnackbarPropsIF) {
                     transition={{ duration: 0.3 }}
                 >
                     <SnackbarAlert onClose={handleClose} severity={severity}>
-                        {children}
+                        {content}
                     </SnackbarAlert>
                 </motion.div>
             </Snackbar>

--- a/src/components/Global/SnackbarComponent/useSnackbar.ts
+++ b/src/components/Global/SnackbarComponent/useSnackbar.ts
@@ -1,0 +1,44 @@
+import { useState } from 'react';
+
+export interface snackbarMethodsIF {
+    isOpen: boolean;
+    open: (content: string, severity?: snackbarSeverityType) => void;
+    close: () => void;
+    content: string;
+    severity: snackbarSeverityType;
+}
+
+export type snackbarSeverityType = 'error' | 'warning' | 'info' | 'success';
+
+export const useSnackbar = (initialMode = false) => {
+    const [isOpen, setIsOpen] = useState<boolean>(initialMode);
+
+    const [content, setContent] = useState<string>('');
+
+    const [severity, setSeverity] = useState<snackbarSeverityType>('success');
+
+    const open = (
+        content: string,
+        severity: snackbarSeverityType = 'success',
+    ) => {
+        // close current snackbar if open, then reopen with new message
+        setIsOpen(false);
+        setContent(content);
+        setSeverity(severity);
+        setIsOpen(true);
+    };
+    const close = () => {
+        console.log('closing');
+        setIsOpen(false);
+        setContent('');
+        setSeverity('success');
+    };
+
+    return {
+        isOpen,
+        open,
+        close,
+        content,
+        severity,
+    };
+};

--- a/src/components/Global/TabComponent/TabComponent.tsx
+++ b/src/components/Global/TabComponent/TabComponent.tsx
@@ -7,6 +7,7 @@ import {
     cloneElement,
     ReactNode,
     ReactElement,
+    useContext,
 } from 'react';
 import { motion, AnimateSharedLayout } from 'framer-motion';
 
@@ -14,6 +15,7 @@ import { motion, AnimateSharedLayout } from 'framer-motion';
 import styles from './TabComponent.module.css';
 import '../../../App/App.css';
 import { DefaultTooltip } from '../StyledTooltip/StyledTooltip';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 type tabData = {
     label: string;
@@ -26,10 +28,6 @@ interface TabPropsIF {
     data: tabData[];
     setSelectedInsideTab?: Dispatch<SetStateAction<number>>;
     rightTabOptions?: ReactNode;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     showPositionsOnlyToggle?: boolean;
     setShowPositionsOnlyToggle?: Dispatch<SetStateAction<boolean>>;
 
@@ -40,13 +38,17 @@ export default function TabComponent(props: TabPropsIF) {
     const {
         data,
         setSelectedInsideTab,
-        selectedOutsideTab,
         rightTabOptions,
-        outsideControl,
-        setOutsideControl,
         // showPositionsOnlyToggle,
         setShowPositionsOnlyToggle,
     } = props;
+    const {
+        outsideControl: {
+            isActive: isOutsideControlActive,
+            setIsActive: setOutsideControlActive,
+        },
+        outsideTab: { selected: outsideTabSelected },
+    } = useContext(AppStateContext);
 
     const [selectedTab, setSelectedTab] = useState(data[0]);
 
@@ -66,7 +68,7 @@ export default function TabComponent(props: TabPropsIF) {
                     break;
             }
         }
-        setOutsideControl(false);
+        setOutsideControlActive(false);
         setSelectedTab(item);
     }
 
@@ -87,15 +89,15 @@ export default function TabComponent(props: TabPropsIF) {
         ) {
             setShowPositionsOnlyToggle(true);
         }
-    }, [data, outsideControl]);
+    }, [data, isOutsideControlActive]);
 
     function handleOutside2() {
-        if (!outsideControl) {
+        if (!isOutsideControlActive) {
             return;
         } else {
-            if (outsideControl) {
-                if (data[selectedOutsideTab]) {
-                    setSelectedTab(data[selectedOutsideTab]);
+            if (isOutsideControlActive) {
+                if (data[outsideTabSelected]) {
+                    setSelectedTab(data[outsideTabSelected]);
                 } else {
                     setSelectedTab(data[0]);
                 }
@@ -105,7 +107,7 @@ export default function TabComponent(props: TabPropsIF) {
 
     useEffect(() => {
         handleOutside2();
-    }, [selectedTab, selectedOutsideTab, outsideControl]);
+    }, [selectedTab, outsideTabSelected, isOutsideControlActive]);
 
     function handleMobileMenuIcon(icon: string, label: string) {
         return (

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/OrdersMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/OrdersMenu.tsx
@@ -26,17 +26,15 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { IS_LOCAL_ENV } from '../../../../../constants';
 import { CrocEnvContext } from '../../../../../contexts/CrocEnvContext';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 // interface for React functional component props
 interface propsIF {
     chainData: ChainSpec;
     tradeData: tradeData;
     limitOrder: LimitOrderIF;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     isOwnerActiveAccount?: boolean;
     isShowAllEnabled: boolean;
-    isSidebarOpen: boolean;
     isOrderFilled: boolean;
     handlePulseAnimation?: (type: string) => void;
     account: string;
@@ -56,17 +54,19 @@ export default function OrdersMenu(props: propsIF) {
         chainData,
         tradeData,
         limitOrder,
-        openGlobalModal,
         isOrderFilled,
         isOwnerActiveAccount,
-        closeGlobalModal,
-        isSidebarOpen,
         handlePulseAnimation,
         lastBlockNumber,
         account,
         isBaseTokenMoneynessGreaterOrEqual,
         isOnPortfolioPage,
     } = props;
+
+    const {
+        globalModal: { open: openGlobalModal, close: closeGlobalModal },
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const [
         isModalOpen,

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -6,7 +6,6 @@ import { FiMoreHorizontal, FiExternalLink } from 'react-icons/fi';
 // START: Import JSX Functional Components
 import RemoveRange from '../../../../RemoveRange/RemoveRange';
 import RangeDetails from '../../../../RangeDetails/RangeDetails';
-import SnackbarComponent from '../../../../../components/Global/SnackbarComponent/SnackbarComponent';
 
 // START: Import Local Files
 import styles from './TableMenus.module.css';
@@ -39,7 +38,6 @@ interface propsIF {
     // eslint-disable-next-line
     rangeDetailsProps: any;
     position: PositionIF;
-    posHash: string;
     isOnPortfolioPage: boolean;
     isPositionEmpty: boolean;
     handlePulseAnimation?: (type: string) => void;
@@ -64,7 +62,6 @@ export default function RangesMenu(props: propsIF) {
         isPositionEmpty,
         userMatchesConnectedAccount,
         rangeDetailsProps,
-        posHash,
         position,
         handlePulseAnimation,
         setSimpleRangeWidth,
@@ -77,7 +74,6 @@ export default function RangesMenu(props: propsIF) {
     const { openGlobalModal } = rangeDetailsProps;
 
     const { isAmbient } = rangeDetailsProps;
-    const [openSnackbar, setOpenSnackbar] = useState<boolean>(false);
 
     const dispatch = useAppDispatch();
 
@@ -129,19 +125,6 @@ export default function RangesMenu(props: propsIF) {
         }
         setShowDropdownMenu(false);
     };
-
-    // -----------------SNACKBAR----------------
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {posHash} copied
-        </SnackbarComponent>
-    );
-    // -----------------END OF SNACKBAR----------------
 
     const repositionButton = (
         <Link
@@ -310,7 +293,6 @@ export default function RangesMenu(props: propsIF) {
         <div className={styles.main_container}>
             {rangesMenu}
             {dropdownRangesMenu}
-            {snackbarContent}
             {isHarvestModalOpen && (
                 <Modal onClose={handleModalClose} title='Harvest Fees' noHeader>
                     <HarvestPosition

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
@@ -1,16 +1,21 @@
 // START: Import React and Dongles
-import { useState, useRef, useEffect, Dispatch, SetStateAction } from 'react';
+import {
+    useState,
+    useRef,
+    useEffect,
+    Dispatch,
+    SetStateAction,
+    useContext,
+} from 'react';
 // import { Link } from 'react-router-dom';
 import { FiExternalLink, FiMoreHorizontal } from 'react-icons/fi';
 
 // START: Import JSX Functional Components
 // import Modal from '../../../../Global/Modal/Modal';
-// import SnackbarComponent from '../../../../../components/Global/SnackbarComponent/SnackbarComponent';
 
 // START: Import Local Files
 import styles from './TableMenus.module.css';
 // import { useModal } from '../../../../Global/Modal/useModal';
-// import useCopyToClipboard from '../../../../../utils/hooks/useCopyToClipboard';
 import UseOnClickOutside from '../../../../../utils/hooks/useOnClickOutside';
 import useMediaQuery from '../../../../../utils/hooks/useMediaQuery';
 import TransactionDetails from '../../../TransactionDetails/TransactionDetails';
@@ -30,6 +35,7 @@ import { useNavigate } from 'react-router-dom';
 import { TransactionIF } from '../../../../../utils/interfaces/exports';
 import { ChainSpec } from '@crocswap-libs/sdk';
 import { IS_LOCAL_ENV } from '../../../../../constants';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 // interface for React functional component props
 interface propsIF {
@@ -39,9 +45,6 @@ interface propsIF {
     isTokenABase: boolean;
     tx: TransactionIF;
     blockExplorer?: string;
-    isSidebarOpen: boolean;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     handlePulseAnimation?: (type: string) => void;
     isBaseTokenMoneynessGreaterOrEqual: boolean;
     isOnPortfolioPage: boolean;
@@ -59,14 +62,15 @@ export default function TransactionsMenu(props: propsIF) {
         isBaseTokenMoneynessGreaterOrEqual,
         tx,
         blockExplorer,
-        isSidebarOpen,
-        openGlobalModal,
-        closeGlobalModal,
         handlePulseAnimation,
         isOnPortfolioPage,
         setSimpleRangeWidth,
         chainData,
     } = props;
+    const {
+        globalModal: { open: openGlobalModal, close: closeGlobalModal },
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const menuItemRef = useRef<HTMLDivElement>(null);
 

--- a/src/components/Global/TransactionDetails/TransactionDetails.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetails.tsx
@@ -1,5 +1,5 @@
 import styles from './TransactionDetails.module.css';
-import { useState, useRef } from 'react';
+import { useState, useRef, useContext } from 'react';
 import printDomToImage from '../../../utils/functions/printDomToImage';
 import TransactionDetailsHeader from './TransactionDetailsHeader/TransactionDetailsHeader';
 import TransactionDetailsPriceInfo from './TransactionDetailsPriceInfo/TransactionDetailsPriceInfo';
@@ -7,8 +7,8 @@ import TransactionDetailsGraph from './TransactionDetailsGraph/TransactionDetail
 import { TransactionIF } from '../../../utils/interfaces/exports';
 import TransactionDetailsSimplify from './TransactionDetailsSimplify/TransactionDetailsSimplify';
 import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../SnackbarComponent/SnackbarComponent';
 import { ChainSpec } from '@crocswap-libs/sdk';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
     account: string;
@@ -27,6 +27,9 @@ export default function TransactionDetails(props: propsIF) {
         isOnPortfolioPage,
         chainData,
     } = props;
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
     const [showSettings, setShowSettings] = useState(false);
     const [showShareComponent, setShowShareComponent] = useState(true);
@@ -44,24 +47,13 @@ export default function TransactionDetails(props: propsIF) {
         { slug: 'value', name: 'Show value', checked: true },
     ]);
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyAddress() {
         const txHash = tx.tx;
         copy(txHash);
-        setOpenSnackbar(true);
+        openSnackbar(`${txHash} copied`, 'info');
     }
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
 
     // const handleChange = (slug: string) => {
     //     const copyControlItems = [...controlItems];
@@ -133,7 +125,6 @@ export default function TransactionDetails(props: propsIF) {
                     isOnPortfolioPage={isOnPortfolioPage}
                 />
             )}
-            {snackbarContent}
         </div>
     );
 }

--- a/src/components/Global/TransactionDetails/TransactionDetailsHeader/TransactionDetailsHeader.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsHeader/TransactionDetailsHeader.tsx
@@ -5,7 +5,6 @@ import { FiCopy } from 'react-icons/fi';
 import { CgClose } from 'react-icons/cg';
 import { TransactionIF } from '../../../../utils/interfaces/TransactionIF';
 import IconWithTooltip from '../../IconWithTooltip/IconWithTooltip';
-// import SnackbarComponent from '../../../../components/Global/SnackbarComponent/SnackbarComponent';
 interface TransactionDetailsHeaderPropsIF {
     onClose: () => void;
     downloadAsImage: () => void;

--- a/src/components/Home/Stats/AmbientStats.tsx
+++ b/src/components/Home/Stats/AmbientStats.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useContext, useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 import { getChainStatsFresh } from '../../../utils/functions/getChainStats';
 import { formatAmountOld } from '../../../utils/numbers';
 import { userData } from '../../../utils/state/userDataSlice';
@@ -11,7 +12,6 @@ interface StatCardProps {
 }
 
 interface StatsProps {
-    isServerEnabled: boolean;
     userData: userData;
     lastBlockNumber: number;
     chainId: string;
@@ -33,7 +33,10 @@ function StatCard(props: StatCardProps) {
 }
 
 export default function Stats(props: StatsProps) {
-    const { isServerEnabled, userData, lastBlockNumber, chainId } = props;
+    const { userData, lastBlockNumber, chainId } = props;
+    const {
+        server: { isEnabled: isServerEnabled },
+    } = useContext(AppStateContext);
 
     const isUserIdle = userData.isUserIdle;
 

--- a/src/components/Home/TopPools/TopPools.tsx
+++ b/src/components/Home/TopPools/TopPools.tsx
@@ -10,7 +10,6 @@ import { topPoolIF } from '../../../App/hooks/useTopPools';
 import { PoolStatsFn } from '../../../App/functions/getPoolStats';
 
 interface propsIF {
-    isServerEnabled: boolean;
     tradeData: tradeData;
     userData: userData;
     cachedQuerySpotPrice: SpotPriceFn;
@@ -23,7 +22,6 @@ interface propsIF {
 
 export default function TopPools(props: propsIF) {
     const {
-        isServerEnabled,
         tradeData,
         userData,
         lastBlockNumber,
@@ -54,7 +52,6 @@ export default function TopPools(props: propsIF) {
             <div className={styles.content}>
                 {topPools.map((pool, idx) => (
                     <PoolCard
-                        isServerEnabled={isServerEnabled}
                         isUserIdle={isUserIdle}
                         tradeData={tradeData}
                         cachedQuerySpotPrice={cachedQuerySpotPrice}

--- a/src/components/OrderDetails/OrderDetails.tsx
+++ b/src/components/OrderDetails/OrderDetails.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect } from 'react';
+import { useState, useRef, useEffect, useContext } from 'react';
 
 import styles from './OrderDetails.module.css';
 import OrderDetailsHeader from './OrderDetailsHeader/OrderDetailsHeader';
@@ -12,9 +12,9 @@ import OrderDetailsSimplify from './OrderDetailsSimplify/OrderDetailsSimplify';
 import TransactionDetailsGraph from '../Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph';
 import { formatAmountOld } from '../../utils/numbers';
 import useCopyToClipboard from '../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../Global/SnackbarComponent/SnackbarComponent';
 import { ChainSpec } from '@crocswap-libs/sdk';
 import { GRAPHCACHE_URL, IS_LOCAL_ENV } from '../../constants';
+import { AppStateContext } from '../../contexts/AppStateContext';
 
 interface propsIF {
     account: string;
@@ -28,6 +28,9 @@ interface propsIF {
 
 export default function OrderDetails(props: propsIF) {
     const [showShareComponent, setShowShareComponent] = useState(true);
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
     const {
         limitOrder,
@@ -56,23 +59,12 @@ export default function OrderDetails(props: propsIF) {
 
     const [isClaimable, setIsClaimable] = useState<boolean>(isOrderFilled);
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyPositionId() {
         copy(posHash);
-        setOpenSnackbar(true);
+        openSnackbar(`${posHash} copied`, 'info');
     }
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
 
     const [usdValue, setUsdValue] = useState<string>('...');
     // const [usdValue, setUsdValue] = useState<string>(limitOrder.totalValueUSD.toString());
@@ -394,7 +386,6 @@ export default function OrderDetails(props: propsIF) {
                     isOnPortfolioPage={isOnPortfolioPage}
                 />
             )}
-            {snackbarContent}
         </div>
     );
 }

--- a/src/components/OrderDetails/OrderDetailsHeader/OrderDetailsHeader.tsx
+++ b/src/components/OrderDetails/OrderDetailsHeader/OrderDetailsHeader.tsx
@@ -1,9 +1,8 @@
 import styles from './OrderDetailsHeader.module.css';
-import { Dispatch, SetStateAction, useState } from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import ambientLogo from '../../../assets/images/logos/ambient_logo.svg';
 import { FiCopy } from 'react-icons/fi';
 import { CgClose } from 'react-icons/cg';
-import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
 import IconWithTooltip from '../../Global/IconWithTooltip/IconWithTooltip';
 import { LimitOrderIF } from '../../../utils/interfaces/LimitOrderIF';
 interface OrderDetailsPropsIF {
@@ -25,12 +24,9 @@ export default function OrderDetailsHeader(props: OrderDetailsPropsIF) {
         setShowShareComponent,
     } = props;
     // eslint-disable-next-line
-    const [openSnackbar, setOpenSnackbar] = useState(false);
     const phIcon = (
         <FiCopy size={25} color='var(--text3)' style={{ opacity: '0' }} />
     );
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
 
     const copyIconWithTooltip = (
         <IconWithTooltip
@@ -49,16 +45,6 @@ export default function OrderDetailsHeader(props: OrderDetailsPropsIF) {
     //             <FiDownload size={25} color='var(--text3)' />
     //         </div>
     //     </IconWithTooltip>
-    // );
-
-    // const snackbarContent = (
-    //     <SnackbarComponent
-    //         severity='info'
-    //         setOpenSnackbar={setOpenSnackbar}
-    //         openSnackbar={openSnackbar}
-    //     >
-    //         {value} copied
-    //     </SnackbarComponent>
     // );
 
     return (

--- a/src/components/OrderDetails/OrderDetailsSimplify/OrderDetailsSimplify.tsx
+++ b/src/components/OrderDetails/OrderDetailsSimplify/OrderDetailsSimplify.tsx
@@ -6,9 +6,9 @@ import { useProcessOrder } from '../../../utils/hooks/useProcessOrder';
 import TooltipComponent from '../../Global/TooltipComponent/TooltipComponent';
 import moment from 'moment';
 import { FiCopy } from 'react-icons/fi';
-import { useState } from 'react';
+import { useContext } from 'react';
 import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../Global/SnackbarComponent/SnackbarComponent';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface ItemRowPropsIF {
     title: string;
@@ -107,25 +107,17 @@ export default function OrderDetailsSimplify(
         // positionLiquidity,
     } = useProcessOrder(limitOrder, account, isOnPortfolioPage);
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
-    const [value, copy] = useCopyToClipboard();
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyPositionHash() {
         copy(posHash.toString());
         // setCopiedData(posHash.toString());
 
-        setOpenSnackbar(true);
+        openSnackbar(`${posHash.toString()} copied`, 'info');
     }
 
     function handleOpenWallet() {
@@ -358,7 +350,6 @@ export default function OrderDetailsSimplify(
                         ))}
                 </section>
             </div>
-            {snackbarContent}
         </div>
     );
 }

--- a/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/EchangeBalance/Deposit/Deposit.tsx
@@ -24,8 +24,6 @@ import useDebounce from '../../../../App/hooks/useDebounce';
 interface propsIF {
     crocEnv: CrocEnv | undefined;
     connectedAccount: string;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     selectedToken: TokenIF;
     tokenAllowance: string;
     tokenWalletBalance: string;

--- a/src/components/Portfolio/EchangeBalance/ExchangeBalance.tsx
+++ b/src/components/Portfolio/EchangeBalance/ExchangeBalance.tsx
@@ -23,10 +23,6 @@ interface propsIF {
     crocEnv: CrocEnv | undefined;
     mainnetProvider: ethers.providers.Provider | undefined;
     connectedAccount: string;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     selectedToken: TokenIF;
     tokenAllowance: string;
     tokenWalletBalance: string;
@@ -47,10 +43,6 @@ export default function ExchangeBalance(props: propsIF) {
         crocEnv,
         mainnetProvider,
         connectedAccount,
-        openGlobalModal,
-        closeGlobalModal,
-        setSelectedOutsideTab,
-        setOutsideControl,
         selectedToken,
         tokenAllowance,
         tokenWalletBalance,
@@ -144,8 +136,6 @@ export default function ExchangeBalance(props: propsIF) {
                 <Deposit
                     crocEnv={crocEnv}
                     connectedAccount={connectedAccount}
-                    openGlobalModal={openGlobalModal}
-                    closeGlobalModal={closeGlobalModal}
                     selectedToken={selectedToken}
                     tokenAllowance={tokenAllowance}
                     tokenWalletBalance={tokenWalletBalance}
@@ -166,8 +156,6 @@ export default function ExchangeBalance(props: propsIF) {
                 <Withdraw
                     crocEnv={crocEnv}
                     connectedAccount={connectedAccount}
-                    openGlobalModal={openGlobalModal}
-                    closeGlobalModal={closeGlobalModal}
                     selectedToken={selectedToken}
                     tokenWalletBalance={tokenWalletBalance}
                     tokenDexBalance={tokenDexBalance}
@@ -190,8 +178,6 @@ export default function ExchangeBalance(props: propsIF) {
                 <Transfer
                     crocEnv={crocEnv}
                     // connectedAccount={connectedAccount}
-                    openGlobalModal={openGlobalModal}
-                    closeGlobalModal={closeGlobalModal}
                     selectedToken={selectedToken}
                     tokenDexBalance={tokenDexBalance}
                     lastBlockNumber={lastBlockNumber}
@@ -243,10 +229,6 @@ export default function ExchangeBalance(props: propsIF) {
                         <TabComponent
                             data={accountData}
                             rightTabOptions={false}
-                            setSelectedOutsideTab={setSelectedOutsideTab}
-                            setOutsideControl={setOutsideControl}
-                            outsideControl={false}
-                            selectedOutsideTab={0}
                         />
                     )}
                     {exchangeControl}

--- a/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
+++ b/src/components/Portfolio/EchangeBalance/Transfer/Transfer.tsx
@@ -6,14 +6,7 @@ import TransferButton from './TransferButton/TransferButton';
 import TransferCurrencySelector from './TransferCurrencySelector/TransferCurrencySelector';
 // import { defaultTokens } from '../../../../utils/data/defaultTokens';
 import { useAppDispatch } from '../../../../utils/hooks/reduxToolkit';
-import {
-    Dispatch,
-    ReactNode,
-    SetStateAction,
-    useEffect,
-    useMemo,
-    useState,
-} from 'react';
+import { Dispatch, SetStateAction, useEffect, useMemo, useState } from 'react';
 // import { setToken } from '../../../../utils/state/temp';
 import {
     addPendingTx,
@@ -35,8 +28,6 @@ import useDebounce from '../../../../App/hooks/useDebounce';
 interface propsIF {
     crocEnv: CrocEnv | undefined;
     // connectedAccount: string;
-    openGlobalModal: (content: ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     selectedToken: TokenIF;
     tokenDexBalance: string;
     setRecheckTokenBalances: Dispatch<SetStateAction<boolean>>;
@@ -53,8 +44,6 @@ interface propsIF {
 export default function Transfer(props: propsIF) {
     const {
         crocEnv,
-        // openGlobalModal,
-        // closeGlobalModal,
         selectedToken,
         // tokenAllowance,
         tokenDexBalance,

--- a/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
+++ b/src/components/Portfolio/EchangeBalance/Withdraw/Withdraw.tsx
@@ -29,8 +29,6 @@ import useDebounce from '../../../../App/hooks/useDebounce';
 interface propsIF {
     crocEnv: CrocEnv | undefined;
     connectedAccount: string;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     selectedToken: TokenIF;
     tokenWalletBalance: string;
     tokenDexBalance: string;
@@ -49,8 +47,6 @@ export default function Withdraw(props: propsIF) {
     const {
         crocEnv,
         connectedAccount,
-        // openGlobalModal,
-        // closeGlobalModal,
         selectedToken,
         // tokenAllowance,
         // tokenWalletBalance,

--- a/src/components/Portfolio/PortfolioBanner/PortfolioBannerAccount/PortfolioBannerAccount.tsx
+++ b/src/components/Portfolio/PortfolioBanner/PortfolioBannerAccount/PortfolioBannerAccount.tsx
@@ -1,7 +1,6 @@
 // import noAvatarImage from '../../../../assets/images/icons/avatar.svg';
 import useCopyToClipboard from '../../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../../components/Global/SnackbarComponent/SnackbarComponent';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import { motion } from 'framer-motion';
 import ambientLogo from '../../../../assets/images/logos/ambient_logo.png';
 interface IPortfolioBannerAccountPropsIF {
@@ -18,6 +17,7 @@ interface IPortfolioBannerAccountPropsIF {
 import styles from './PortfolioBannerAccount.module.css';
 import { FiCopy, FiExternalLink } from 'react-icons/fi';
 import { ChainSpec } from '@crocswap-libs/sdk';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 export default function PortfolioBannerAccount(
     props: IPortfolioBannerAccountPropsIF,
@@ -34,6 +34,10 @@ export default function PortfolioBannerAccount(
         chainData,
     } = props;
 
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
+
     const blockExplorer = chainData.blockExplorer;
 
     const ensNameToDisplay = ensNameAvailable
@@ -46,10 +50,7 @@ export default function PortfolioBannerAccount(
         ? truncatedAccountAddress
         : activeAccount;
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
-    const [copiedData, setCopiedData] = useState('');
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyEnsName() {
         copy(
@@ -59,32 +60,20 @@ export default function PortfolioBannerAccount(
                 ? resolvedAddress
                 : activeAccount,
         );
-        setCopiedData(
-            ensNameAvailable
-                ? ensName
-                : resolvedAddress
-                ? resolvedAddress
-                : activeAccount,
-        );
+        const copiedData = ensNameAvailable
+            ? ensName
+            : resolvedAddress
+            ? resolvedAddress
+            : activeAccount;
 
-        setOpenSnackbar(true);
+        openSnackbar(`${copiedData} copied`, 'info');
     }
     function handleCopyAddress() {
         copy(resolvedAddress ? resolvedAddress : activeAccount);
-        setCopiedData(resolvedAddress ? resolvedAddress : activeAccount);
+        const copiedData = resolvedAddress ? resolvedAddress : activeAccount;
 
-        setOpenSnackbar(true);
+        openSnackbar(`${copiedData} copied`, 'info');
     }
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {copiedData} copied
-        </SnackbarComponent>
-    );
 
     const iconVariants = {
         open: {
@@ -149,7 +138,6 @@ export default function PortfolioBannerAccount(
                     </span>
                 </div>
             </div>
-            {snackbarContent}
         </motion.main>
     );
 }

--- a/src/components/Portfolio/PortfolioTabs/PortfolioTabs.tsx
+++ b/src/components/Portfolio/PortfolioTabs/PortfolioTabs.tsx
@@ -65,19 +65,12 @@ interface propsIF {
     chainId: string;
     tokenList: TokenIF[];
     tokenMap: Map<string, TokenIF>;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     searchableTokens: TokenIF[];
     openTokenModal: () => void;
     chainData: ChainSpec;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     account: string;
-    isSidebarOpen: boolean;
     isUserLoggedIn: boolean | undefined;
     baseTokenBalance: string;
     quoteTokenBalance: string;
@@ -111,10 +104,6 @@ export default function PortfolioTabs(props: propsIF) {
         connectedAccountActive,
         chainId,
         tokenList,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
-        outsideControl,
-        setOutsideControl,
         openTokenModal,
         baseTokenBalance,
         quoteTokenBalance,
@@ -126,7 +115,6 @@ export default function PortfolioTabs(props: propsIF) {
         setSimpleRangeWidth,
         gasPriceInGwei,
         ethMainnetUsdPrice,
-        isSidebarOpen,
     } = props;
 
     const dispatch = useAppDispatch();
@@ -376,11 +364,8 @@ export default function PortfolioTabs(props: propsIF) {
         chainData: props.chainData,
         isShowAllEnabled: false,
         account: account,
-        openGlobalModal: props.openGlobalModal,
         currentPositionActive: props.currentPositionActive,
-        closeGlobalModal: props.closeGlobalModal,
         setCurrentPositionActive: props.setCurrentPositionActive,
-        isSidebarOpen: isSidebarOpen,
         activeAccountPositionData: activeAccountPositionData,
         isOnPortfolioPage: true,
         connectedAccountActive: connectedAccountActive,
@@ -417,9 +402,6 @@ export default function PortfolioTabs(props: propsIF) {
             props.setCurrentTxActiveInTransactions,
         expandTradeTable: false,
         isCandleSelected: false,
-        closeGlobalModal: props.closeGlobalModal,
-        openGlobalModal: props.openGlobalModal,
-        isSidebarOpen: isSidebarOpen,
         handlePulseAnimation: handlePulseAnimation,
         isOnPortfolioPage: true,
         tokenMap: tokenMap,
@@ -437,11 +419,8 @@ export default function PortfolioTabs(props: propsIF) {
         chainData: props.chainData,
         isShowAllEnabled: false,
         account: account,
-        openGlobalModal: props.openGlobalModal,
         currentPositionActive: props.currentPositionActive,
-        closeGlobalModal: props.closeGlobalModal,
         setCurrentPositionActive: props.setCurrentPositionActive,
-        isSidebarOpen: isSidebarOpen,
         isOnPortfolioPage: true,
         handlePulseAnimation: handlePulseAnimation,
         lastBlockNumber: lastBlockNumber,
@@ -514,10 +493,6 @@ export default function PortfolioTabs(props: propsIF) {
                         : accountTabDataWithoutTokens
                 }
                 rightTabOptions={false}
-                selectedOutsideTab={selectedOutsideTab}
-                setSelectedOutsideTab={setSelectedOutsideTab}
-                outsideControl={outsideControl}
-                setOutsideControl={setOutsideControl}
             />
         </div>
     );

--- a/src/components/Portfolio/ProfileSettings/ProfileSettings.tsx
+++ b/src/components/Portfolio/ProfileSettings/ProfileSettings.tsx
@@ -1,4 +1,10 @@
-import React, { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import React, {
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useState,
+} from 'react';
 import styles from './ProfileSettings.module.css';
 import { BiArrowBack } from 'react-icons/bi';
 import ProfileSettingsTheme from './ProfileSettingsTheme/ProfileSettingsTheme';
@@ -7,8 +13,8 @@ import noAvatarImage from '../../../assets/images/icons/avatar.svg';
 
 import { motion } from 'framer-motion';
 import useChatApi from '../../Chat/Service/ChatApi';
-import SnackbarComponent from '../../Global/SnackbarComponent/SnackbarComponent';
 import { IS_LOCAL_ENV } from '../../../constants';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 const pageVariant3D = {
     initial: {
@@ -38,14 +44,16 @@ interface ProfileSettingsPropsIF {
     setShowProfileSettings: Dispatch<SetStateAction<boolean>>;
     ensName: string;
     imageData: string[];
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
 }
 
 export default function ProfileSettings(props: ProfileSettingsPropsIF) {
     const [name, setName] = useState('');
     const [id, setId] = useState('');
-    const { setShowProfileSettings, imageData, openGlobalModal } = props;
-    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const { setShowProfileSettings, imageData } = props;
+    const {
+        globalModal: { open: openGlobalModal },
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
     const host = 'https://ambichat.link:5000';
     const nameDisplay = (
         <div className={styles.row}>
@@ -128,16 +136,6 @@ export default function ProfileSettings(props: ProfileSettingsPropsIF) {
         </div>
     );
 
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {name} has been set as a name.
-        </SnackbarComponent>
-    );
-
     const { getID } = useChatApi();
 
     useEffect(() => {
@@ -159,7 +157,7 @@ export default function ProfileSettings(props: ProfileSettingsPropsIF) {
         const data = await response.json();
         if (data.status === 'OK') {
             IS_LOCAL_ENV && console.debug('aaaa', data);
-            setOpenSnackbar(true);
+            openSnackbar(`${name} has been set as a name.`, 'info');
         } else {
             IS_LOCAL_ENV && console.debug('bbb', data.status);
         }
@@ -196,7 +194,6 @@ export default function ProfileSettings(props: ProfileSettingsPropsIF) {
                     >
                         Save
                     </button>
-                    {snackbarContent}
                 </div>
             </div>
         </motion.div>

--- a/src/components/RangeDetails/RangeDetails.tsx
+++ b/src/components/RangeDetails/RangeDetails.tsx
@@ -16,9 +16,9 @@ import RangeDetailsSimplify from './RangeDetailsSimplify/RangeDetailsSimplify';
 import TransactionDetailsGraph from '../Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph';
 import { useProcessRange } from '../../utils/hooks/useProcessRange';
 import useCopyToClipboard from '../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../Global/SnackbarComponent/SnackbarComponent';
 import { CrocEnvContext } from '../../contexts/CrocEnvContext';
 import { GRAPHCACHE_URL } from '../../constants';
+import { AppStateContext } from '../../contexts/AppStateContext';
 
 interface propsIF {
     cachedQuerySpotPrice: SpotPriceFn;
@@ -47,7 +47,6 @@ interface propsIF {
     isBaseTokenMoneynessGreaterOrEqual: boolean;
     minRangeDenomByMoneyness: string;
     maxRangeDenomByMoneyness: string;
-    closeGlobalModal: () => void;
     chainData: ChainSpec;
 }
 
@@ -69,7 +68,6 @@ export default function RangeDetails(props: propsIF) {
         askTick,
         position,
         positionApy,
-        closeGlobalModal,
         // isPositionInRange,
         isAmbient,
         cachedQuerySpotPrice,
@@ -81,6 +79,10 @@ export default function RangeDetails(props: propsIF) {
         chainData,
     } = props;
 
+    const {
+        globalModal: { close: closeGlobalModal },
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
     const crocEnv = useContext(CrocEnvContext);
 
     const detailsRef = useRef(null);
@@ -120,23 +122,12 @@ export default function RangeDetails(props: propsIF) {
 
     const { posHash } = useProcessRange(position, account);
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyPositionId() {
         copy(posHash.toString());
-        setOpenSnackbar(true);
+        openSnackbar(`${posHash.toString()} copied`, 'info');
     }
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
 
     useEffect(() => {
         const positionStatsCacheEndpoint =
@@ -400,7 +391,6 @@ export default function RangeDetails(props: propsIF) {
                     isOnPortfolioPage={isOnPortfolioPage}
                 />
             )}
-            {snackbarContent}
         </div>
     );
 }

--- a/src/components/RangeDetails/RangeDetailsHeader/RangeDetailsHeader.tsx
+++ b/src/components/RangeDetails/RangeDetailsHeader/RangeDetailsHeader.tsx
@@ -3,8 +3,6 @@ import ambientLogo from '../../../assets/images/logos/ambient_logo.svg';
 import { FiCopy } from 'react-icons/fi';
 import { CgClose } from 'react-icons/cg';
 import { Dispatch, SetStateAction } from 'react';
-// import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
-// import SnackbarComponent from '../../../components/Global/SnackbarComponent/SnackbarComponent';
 import { PositionIF } from '../../../utils/interfaces/PositionIF';
 import IconWithTooltip from '../../Global/IconWithTooltip/IconWithTooltip';
 
@@ -26,18 +24,10 @@ export default function RangeDetailsHeader(props: RangeDetailsPropsIF) {
         showShareComponent,
         setShowShareComponent,
     } = props;
-    // const [openSnackbar, setOpenSnackbar] = useState(false);
+
     const phIcon = (
         <FiCopy size={25} color='var(--text3)' style={{ opacity: '0' }} />
     );
-
-    // const [value, copy] = useCopyToClipboard();
-
-    //    function handleCopyAddress() {
-    //        const txHash = position.tx;
-    //        copy(txHash);
-    //        setOpenSnackbar(true);
-    //    }
 
     const copyIconWithTooltip = (
         <IconWithTooltip
@@ -56,17 +46,6 @@ export default function RangeDetailsHeader(props: RangeDetailsPropsIF) {
     //             <FiDownload size={25} color='var(--text3)' />
     //         </div>
     //     </IconWithTooltip>
-    // );
-
-    // eslint-disable-next-line
-    // const snackbarContent = (
-    //     <SnackbarComponent
-    //         severity='info'
-    //         setOpenSnackbar={setOpenSnackbar}
-    //         openSnackbar={openSnackbar}
-    //     >
-    //         {value} copied
-    //     </SnackbarComponent>
     // );
 
     return (

--- a/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
+++ b/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
@@ -7,9 +7,9 @@ import moment from 'moment';
 // import Apy from '../../Global/Tabs/Apy/Apy';
 import TooltipComponent from '../../Global/TooltipComponent/TooltipComponent';
 import useCopyToClipboard from '../../../utils/hooks/useCopyToClipboard';
-import { useState } from 'react';
-import SnackbarComponent from '../../Global/SnackbarComponent/SnackbarComponent';
+import { useContext } from 'react';
 import { FiCopy } from 'react-icons/fi';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface ItemRowPropsIF {
     title: string;
@@ -61,20 +61,11 @@ export default function RangeDetailsSimplify(
         quoteDisplayFrontend,
     } = useProcessRange(position, account, isOnPortfolioPage);
 
-    const [openSnackbar, setOpenSnackbar] = useState(false);
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
-    const [value, copy] = useCopyToClipboard();
-    // const [copiedData, setCopiedData] = useState('');
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
+    const [_, copy] = useCopyToClipboard();
 
     function handleOpenWallet() {
         const walletUrl = isOwnerActiveAccount
@@ -91,9 +82,7 @@ export default function RangeDetailsSimplify(
 
     function handleCopyPositionHash() {
         copy(posHash.toString());
-        // setCopiedData(posHash.toString());
-
-        setOpenSnackbar(true);
+        openSnackbar(`${posHash.toString()} copied`, 'info');
     }
 
     function handleOpenBaseAddress() {
@@ -342,7 +331,6 @@ export default function RangeDetailsSimplify(
                         ))}
                 </section>
             </div>
-            {snackbarContent}
         </div>
     );
 }

--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -75,11 +75,6 @@ interface propsIF {
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
     priceImpact: CrocImpact | undefined;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     lastBlockNumber: number;
     setTokenAQtyCoveredByWalletBalance: Dispatch<SetStateAction<number>>;
     ackTokens: ackTokensMethodsIF;
@@ -127,7 +122,6 @@ export default function CurrencyConverter(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         setTokenAQtyCoveredByWalletBalance,
         ackTokens,
     } = props;
@@ -803,7 +797,6 @@ export default function CurrencyConverter(props: propsIF) {
                 validatedInput={validatedInput}
                 setInput={setInput}
                 searchType={searchType}
-                openGlobalPopup={openGlobalPopup}
                 setDisableReverseTokens={setDisableReverseTokens}
                 ackTokens={ackTokens}
                 setUserOverrodeSurplusWithdrawalDefault={
@@ -868,7 +861,6 @@ export default function CurrencyConverter(props: propsIF) {
                     validatedInput={validatedInput}
                     setInput={setInput}
                     searchType={searchType}
-                    openGlobalPopup={openGlobalPopup}
                     setDisableReverseTokens={setDisableReverseTokens}
                     ackTokens={ackTokens}
                     setUserOverrodeSurplusWithdrawalDefault={

--- a/src/components/Swap/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.tsx
@@ -27,6 +27,7 @@ import ExchangeBalanceExplanation from '../../Global/Informational/ExchangeBalan
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import WalletBalanceExplanation from '../../Global/Informational/WalletBalanceExplanation';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
     provider: ethers.providers.Provider | undefined;
@@ -81,11 +82,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     setDisableReverseTokens: Dispatch<SetStateAction<boolean>>;
     ackTokens: ackTokensMethodsIF;
     setUserOverrodeSurplusWithdrawalDefault: Dispatch<SetStateAction<boolean>>;
@@ -130,7 +126,6 @@ export default function CurrencySelector(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         ackTokens,
         setUserOverrodeSurplusWithdrawalDefault,
         setUserClickedCombinedMax,
@@ -138,6 +133,9 @@ export default function CurrencySelector(props: propsIF) {
     } = props;
 
     const { dexBalSwap } = useContext(UserPreferenceContext);
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const isSellTokenSelector = fieldId === 'sell';
     const thisToken = isSellTokenSelector

--- a/src/components/Swap/SwapHeader/SwapHeader.tsx
+++ b/src/components/Swap/SwapHeader/SwapHeader.tsx
@@ -16,21 +16,24 @@ import IconWithTooltip from '../../Global/IconWithTooltip/IconWithTooltip';
 import { AiOutlineShareAlt } from 'react-icons/ai';
 import ShareModal from '../../Global/ShareModal/ShareModal';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 // interface for props
 interface propsIF {
     isPairStable: boolean;
     isOnTradeRoute?: boolean;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
     shareOptionsDisplay: JSX.Element;
 }
 
 // main react functional component
 export default function SwapHeader(props: propsIF) {
-    const { isPairStable, isOnTradeRoute, openGlobalModal } = props;
+    const { isPairStable, isOnTradeRoute } = props;
     const { swapSlippage, bypassConfirmSwap } = useContext(
         UserPreferenceContext,
     );
+    const {
+        globalModal: { open: openGlobalModal },
+    } = useContext(AppStateContext);
     const [isModalOpen, openModal, closeModal] = useModal();
 
     const dispatch = useAppDispatch();

--- a/src/components/Trade/Limit/LimitCurrencyConverter/LimitCurrencyConverter.tsx
+++ b/src/components/Trade/Limit/LimitCurrencyConverter/LimitCurrencyConverter.tsx
@@ -92,11 +92,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     ackTokens: ackTokensMethodsIF;
     isOrderValid: boolean;
 }
@@ -147,7 +142,6 @@ export default function LimitCurrencyConverter(props: propsIF) {
         setInput,
         searchType,
         setResetLimitTick,
-        openGlobalPopup,
         ackTokens,
         isOrderValid,
     } = props;
@@ -553,7 +547,6 @@ export default function LimitCurrencyConverter(props: propsIF) {
                 validatedInput={validatedInput}
                 setInput={setInput}
                 searchType={searchType}
-                openGlobalPopup={openGlobalPopup}
                 ackTokens={ackTokens}
                 setUserOverrodeSurplusWithdrawalDefault={
                     setUserOverrodeSurplusWithdrawalDefault
@@ -626,7 +619,6 @@ export default function LimitCurrencyConverter(props: propsIF) {
                     validatedInput={validatedInput}
                     setInput={setInput}
                     searchType={searchType}
-                    openGlobalPopup={openGlobalPopup}
                     ackTokens={ackTokens}
                     setUserOverrodeSurplusWithdrawalDefault={
                         setUserOverrodeSurplusWithdrawalDefault

--- a/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
+++ b/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
@@ -29,6 +29,7 @@ import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { DefaultTooltip } from '../../../Global/StyledTooltip/StyledTooltip';
 import { ackTokensMethodsIF } from '../../../../App/hooks/useAckTokens';
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // interface for component props
 interface propsIF {
@@ -80,11 +81,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     ackTokens: ackTokensMethodsIF;
     setUserOverrodeSurplusWithdrawalDefault: Dispatch<SetStateAction<boolean>>;
 }
@@ -121,12 +117,14 @@ export default function LimitCurrencySelector(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         ackTokens,
         setUserOverrodeSurplusWithdrawalDefault,
     } = props;
 
     const { dexBalLimit } = useContext(UserPreferenceContext);
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const thisToken =
         fieldId === 'sell' ? tokenPair.dataTokenA : tokenPair.dataTokenB;

--- a/src/components/Trade/Limit/LimitHeader/LimitHeader.tsx
+++ b/src/components/Trade/Limit/LimitHeader/LimitHeader.tsx
@@ -19,21 +19,24 @@ import {
 import { toggleDidUserFlipDenom } from '../../../../utils/state/tradeDataSlice';
 import { useContext } from 'react';
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // interface for component props
 interface propsIF {
     chainId: string;
     isPairStable: boolean;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
     shareOptionsDisplay: JSX.Element;
 }
 
 // central react functional component
 export default function LimitHeader(props: propsIF) {
-    const { isPairStable, openGlobalModal } = props;
+    const { isPairStable } = props;
     const { mintSlippage, bypassConfirmLimit } = useContext(
         UserPreferenceContext,
     );
+    const {
+        globalModal: { open: openGlobalModal },
+    } = useContext(AppStateContext);
 
     const [isModalOpen, openModal, closeModal] = useModal();
 

--- a/src/components/Trade/Range/RangeCurrencyConverter/RangeCurrencyConverter.tsx
+++ b/src/components/Trade/Range/RangeCurrencyConverter/RangeCurrencyConverter.tsx
@@ -91,11 +91,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     poolExists: boolean | undefined;
     ackTokens: ackTokensMethodsIF;
 }
@@ -148,7 +143,6 @@ export default function RangeCurrencyConverter(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         ackTokens,
     } = props;
 
@@ -758,7 +752,6 @@ export default function RangeCurrencyConverter(props: propsIF) {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
         ackTokens: ackTokens,
         setUserOverrodeSurplusWithdrawalDefault:
             setUserOverrodeSurplusWithdrawalDefault,

--- a/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
+++ b/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
@@ -1,4 +1,10 @@
-import { ChangeEvent, Dispatch, SetStateAction, useState } from 'react';
+import {
+    ChangeEvent,
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useState,
+} from 'react';
 import { ethers } from 'ethers';
 import styles from './RangeCurrencySelector.module.css';
 import RangeCurrencyQuantity from '../RangeCurrencyQuantity/RangeCurrencyQuantity';
@@ -18,6 +24,7 @@ import ExchangeBalanceExplanation from '../../../Global/Informational/ExchangeBa
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import { IS_LOCAL_ENV } from '../../../../constants';
 import { ackTokensMethodsIF } from '../../../../App/hooks/useAckTokens';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface propsIF {
     provider?: ethers.providers.Provider;
@@ -76,11 +83,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
     ackTokens: ackTokensMethodsIF;
     setUserOverrodeSurplusWithdrawalDefault: Dispatch<SetStateAction<boolean>>;
 }
@@ -124,10 +126,12 @@ export default function RangeCurrencySelector(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         ackTokens,
         setUserOverrodeSurplusWithdrawalDefault,
     } = props;
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const isTokenASelector = fieldId === 'A';
 

--- a/src/components/Trade/Range/RangeHeader/RangeHeader.tsx
+++ b/src/components/Trade/Range/RangeHeader/RangeHeader.tsx
@@ -1,5 +1,5 @@
 // START: Import React and Dongles
-import { ReactNode, useContext } from 'react';
+import { useContext } from 'react';
 
 // START: Import JSX Components
 import ContentHeader from '../../../Global/ContentHeader/ContentHeader';
@@ -18,6 +18,7 @@ import { AiOutlineShareAlt } from 'react-icons/ai';
 import ShareModal from '../../../Global/ShareModal/ShareModal';
 import { SlippageMethodsIF } from '../../../../App/hooks/useSlippage';
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // interface for component props
 interface propsIF {
@@ -27,22 +28,18 @@ interface propsIF {
     isPairStable: boolean;
     isDenomBase: boolean;
     isTokenABase: boolean;
-    openGlobalModal: (content: ReactNode, title?: string) => void;
     shareOptionsDisplay: JSX.Element;
 }
 
 // central react functional component
 export default function RangeHeader(props: propsIF) {
-    const {
-        tokenPair,
-        mintSlippage,
-        isPairStable,
-        isDenomBase,
-        isTokenABase,
-        openGlobalModal,
-    } = props;
+    const { tokenPair, mintSlippage, isPairStable, isDenomBase, isTokenABase } =
+        props;
 
     const { bypassConfirmRange } = useContext(UserPreferenceContext);
+    const {
+        globalModal: { open: openGlobalModal },
+    } = useContext(AppStateContext);
 
     const [isModalOpen, openModal, closeModal] = useModal();
 

--- a/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
+++ b/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
@@ -6,7 +6,7 @@ import { TokenIF, TokenPairIF } from '../../../../utils/interfaces/exports';
 import { useLocation } from 'react-router-dom';
 import { useAppDispatch } from '../../../../utils/hooks/reduxToolkit';
 import { toggleDidUserFlipDenom } from '../../../../utils/state/tradeDataSlice';
-import { useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import { TokenPriceFn } from '../../../../App/functions/fetchTokenPrice';
 import { testTokenMap } from '../../../../utils/data/testTokenMap';
 import { formatAmountOld } from '../../../../utils/numbers';
@@ -15,6 +15,7 @@ import { DefaultTooltip } from '../../../Global/StyledTooltip/StyledTooltip';
 import { isStableToken } from '../../../../utils/data/stablePairs';
 import AprExplanation from '../../../Global/Informational/AprExplanation';
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // interface for component props
 interface propsIF {
@@ -49,11 +50,6 @@ interface propsIF {
           }
         | undefined;
     isAmbient: boolean;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
 }
 
 // central react functional component
@@ -73,8 +69,10 @@ export default function RangePriceInfo(props: propsIF) {
         baseToken,
         quoteToken,
         isAmbient,
-        openGlobalPopup,
     } = props;
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const { pathname } = useLocation();
 

--- a/src/components/Trade/Range/RangeWidth/RangeWidth.tsx
+++ b/src/components/Trade/Range/RangeWidth/RangeWidth.tsx
@@ -1,8 +1,9 @@
 // START: Import React and Dongles
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, useContext } from 'react';
 import { AiOutlineInfoCircle } from 'react-icons/ai';
 import { FiMinus } from 'react-icons/fi';
 import { MdAdd } from 'react-icons/md';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // START: Import Local Files
 import styles from './RangeWidth.module.css';
@@ -17,11 +18,6 @@ interface RangeWidthPropsIF {
     setRangeWidthPercentage: Dispatch<SetStateAction<number>>;
     isRangeCopied: boolean;
     setRescaleRangeBoundariesWithSlider: Dispatch<SetStateAction<boolean>>;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
 }
 
 // React functional component
@@ -30,9 +26,11 @@ export default function RangeWidth(props: RangeWidthPropsIF) {
         rangeWidthPercentage,
         setRangeWidthPercentage,
         isRangeCopied,
-        openGlobalPopup,
         setRescaleRangeBoundariesWithSlider,
     } = props;
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const PercentageOptionContent = (
         <>

--- a/src/components/Trade/Reposition/RepositionPriceInfo/RepositionPriceInfo.tsx
+++ b/src/components/Trade/Reposition/RepositionPriceInfo/RepositionPriceInfo.tsx
@@ -18,6 +18,7 @@ import TooltipComponent from '../../../Global/TooltipComponent/TooltipComponent'
 import { AiOutlineQuestionCircle } from 'react-icons/ai';
 import AprExplanation from '../../../Global/Informational/AprExplanation';
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // import truncateDecimals from '../../../../utils/data/truncateDecimals';
 // import makeCurrentPrice from './makeCurrentPrice';
@@ -63,12 +64,6 @@ interface IRepositionPriceInfoProps {
 
     currentMinPrice: string;
     currentMaxPrice: string;
-
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
 }
 
 // todo : take a look at RangePriceInfo.tsx. Should follow a similar approach.
@@ -92,11 +87,13 @@ export default function RepositionPriceInfo(props: IRepositionPriceInfoProps) {
 
         currentMinPrice,
         currentMaxPrice,
-        openGlobalPopup,
         // isPairStable
     } = props;
 
     const { repoSlippage } = useContext(UserPreferenceContext);
+    const {
+        globalPopup: { open: openGlobalPopup },
+    } = useContext(AppStateContext);
 
     const baseSymbol = position?.baseSymbol;
     const quoteSymbol = position?.quoteSymbol;

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -1,6 +1,13 @@
 /* eslint-disable no-irregular-whitespace */
 // START: Import React and Dongles
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 
 // START: Import JSX Elements
 import styles from './Orders.module.css';
@@ -20,6 +27,7 @@ import NoTableData from '../NoTableData/NoTableData';
 import Pagination from '../../../Global/Pagination/Pagination';
 import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 import { diffHashSig } from '../../../../utils/functions/diffHashSig';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // import OrderAccordions from './OrderAccordions/OrderAccordions';
 
@@ -33,8 +41,6 @@ interface propsIF {
     account: string;
     isShowAllEnabled: boolean;
     setIsShowAllEnabled?: Dispatch<SetStateAction<boolean>>;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     isOnPortfolioPage: boolean;
@@ -43,7 +49,6 @@ interface propsIF {
         candleData: CandleData | undefined,
     ) => void;
     lastBlockNumber: number;
-    isSidebarOpen: boolean;
     handlePulseAnimation?: (type: string) => void;
     isAccountView: boolean;
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
@@ -60,7 +65,6 @@ export default function Orders(props: propsIF) {
         isShowAllEnabled,
         setCurrentPositionActive,
         currentPositionActive,
-        isSidebarOpen,
         isOnPortfolioPage,
         handlePulseAnimation,
         setIsShowAllEnabled,
@@ -69,6 +73,9 @@ export default function Orders(props: propsIF) {
         isAccountView,
         setExpandTradeTable,
     } = props;
+    const {
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const graphData = useAppSelector((state) => state?.graphData);
 
@@ -391,14 +398,11 @@ export default function Orders(props: propsIF) {
             tradeData={tradeData}
             expandTradeTable={expandTradeTable}
             showPair={showPair}
-            isSidebarOpen={isSidebarOpen}
             showColumns={showColumns}
             ipadView={ipadView}
             view2={view2}
             key={idx}
             limitOrder={order}
-            openGlobalModal={props.openGlobalModal}
-            closeGlobalModal={props.closeGlobalModal}
             currentPositionActive={currentPositionActive}
             setCurrentPositionActive={setCurrentPositionActive}
             isShowAllEnabled={isShowAllEnabled}
@@ -415,14 +419,11 @@ export default function Orders(props: propsIF) {
             tradeData={tradeData}
             expandTradeTable={expandTradeTable}
             showPair={showPair}
-            isSidebarOpen={isSidebarOpen}
             showColumns={showColumns}
             ipadView={ipadView}
             view2={view2}
             key={idx}
             limitOrder={order}
-            openGlobalModal={props.openGlobalModal}
-            closeGlobalModal={props.closeGlobalModal}
             currentPositionActive={currentPositionActive}
             setCurrentPositionActive={setCurrentPositionActive}
             isShowAllEnabled={isShowAllEnabled}

--- a/src/components/Trade/TradeTabs/Ranges/Leaderboard.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Leaderboard.tsx
@@ -2,7 +2,13 @@
 // todo: Commented out code were commented out on 10/14/2022 for a new refactor. If not uncommented by 12/14/2022, they can be safely removed from the file. -Jr
 
 // START: Import React and Dongles
-import { Dispatch, SetStateAction, useEffect, useState } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useState,
+} from 'react';
 import { ethers } from 'ethers';
 
 // START: Import Local Files
@@ -23,6 +29,7 @@ import RangesRow from './RangesTable/RangesRow';
 import { SpotPriceFn } from '../../../../App/functions/querySpotPrice';
 import { PositionUpdateFn } from '../../../../App/functions/getPositionData';
 import { diffHashSig } from '../../../../utils/functions/diffHashSig';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 // interface for props
 interface propsIF {
@@ -42,9 +49,6 @@ interface propsIF {
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     portfolio?: boolean;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
-    isSidebarOpen: boolean;
     setLeader?: Dispatch<SetStateAction<string>>;
     setLeaderOwnerId?: Dispatch<SetStateAction<string>>;
     handlePulseAnimation?: (type: string) => void;
@@ -75,11 +79,13 @@ export default function Leaderboard(props: propsIF) {
         handlePulseAnimation,
         cachedQuerySpotPrice,
         cachedPositionUpdateQuery,
-        isSidebarOpen,
         setSimpleRangeWidth,
         gasPriceInGwei,
         ethMainnetUsdPrice,
     } = props;
+    const {
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const graphData = useAppSelector((state) => state?.graphData);
     const tradeData = useAppSelector((state) => state.tradeData);
@@ -343,8 +349,6 @@ export default function Leaderboard(props: propsIF) {
             }
             currentPositionActive={currentPositionActive}
             setCurrentPositionActive={setCurrentPositionActive}
-            openGlobalModal={props.openGlobalModal}
-            closeGlobalModal={props.closeGlobalModal}
             isShowAllEnabled={isShowAllEnabled}
             ipadView={ipadView}
             showColumns={showColumns}

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -5,10 +5,10 @@
 import {
     Dispatch,
     SetStateAction,
-    ReactNode,
     useEffect,
     useState,
     useMemo,
+    useContext,
 } from 'react';
 import { ethers } from 'ethers';
 
@@ -38,6 +38,7 @@ import NoTableData from '../NoTableData/NoTableData';
 import { SpotPriceFn } from '../../../../App/functions/querySpotPrice';
 import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 import { diffHashSig } from '../../../../utils/functions/diffHashSig';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 const NUM_RANGES_WHEN_COLLAPSED = 10; // Number of ranges we show when the table is collapsed (i.e. half page)
 // NOTE: this is done to improve rendering speed for this page.
@@ -64,9 +65,6 @@ interface propsIF {
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     portfolio?: boolean;
-    openGlobalModal: (content: ReactNode) => void;
-    closeGlobalModal: () => void;
-    isSidebarOpen: boolean;
     isOnPortfolioPage: boolean; // when viewing from /account: fullscreen and not paginated
     setLeader?: Dispatch<SetStateAction<string>>;
     setLeaderOwnerId?: Dispatch<SetStateAction<string>>;
@@ -101,13 +99,15 @@ export default function Ranges(props: propsIF) {
         isOnPortfolioPage,
         handlePulseAnimation,
         setIsShowAllEnabled,
-        isSidebarOpen,
         cachedQuerySpotPrice,
         setSimpleRangeWidth,
         gasPriceInGwei,
         ethMainnetUsdPrice,
         cachedPositionUpdateQuery,
     } = props;
+    const {
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const graphData = useAppSelector((state) => state?.graphData);
     const tradeData = useAppSelector((state) => state.tradeData);
@@ -494,8 +494,6 @@ export default function Ranges(props: propsIF) {
             position={position}
             currentPositionActive={currentPositionActive}
             setCurrentPositionActive={setCurrentPositionActive}
-            openGlobalModal={props.openGlobalModal}
-            closeGlobalModal={props.closeGlobalModal}
             isShowAllEnabled={isShowAllEnabled}
             ipadView={ipadView}
             showColumns={showColumns}
@@ -526,8 +524,6 @@ export default function Ranges(props: propsIF) {
             position={position}
             currentPositionActive={currentPositionActive}
             setCurrentPositionActive={setCurrentPositionActive}
-            openGlobalModal={props.openGlobalModal}
-            closeGlobalModal={props.closeGlobalModal}
             isShowAllEnabled={isShowAllEnabled}
             ipadView={ipadView}
             showColumns={showColumns}

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -1,4 +1,11 @@
-import { useEffect, Dispatch, SetStateAction, useRef, useState } from 'react';
+import {
+    useEffect,
+    Dispatch,
+    SetStateAction,
+    useRef,
+    useState,
+    useContext,
+} from 'react';
 import { PositionIF } from '../../../../../utils/interfaces/exports';
 import { ChainSpec } from '@crocswap-libs/sdk';
 import { ethers } from 'ethers';
@@ -15,8 +22,8 @@ import useOnClickOutside from '../../../../../utils/hooks/useOnClickOutside';
 import { SpotPriceFn } from '../../../../../App/functions/querySpotPrice';
 import useMediaQuery from '../../../../../utils/hooks/useMediaQuery';
 import useCopyToClipboard from '../../../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../../Global/SnackbarComponent/SnackbarComponent';
 import rangeRowConstants from '../rangeRowConstants';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     isUserLoggedIn: boolean | undefined;
@@ -37,8 +44,6 @@ interface propsIF {
     rank?: number;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
     isOnPortfolioPage: boolean;
     isLeaderboard?: boolean;
     idx: number;
@@ -61,7 +66,6 @@ export default function RangesRow(props: propsIF) {
         position,
         currentPositionActive,
         setCurrentPositionActive,
-        openGlobalModal,
         isOnPortfolioPage,
         isLeaderboard,
         handlePulseAnimation,
@@ -69,6 +73,10 @@ export default function RangesRow(props: propsIF) {
         gasPriceInGwei,
         ethMainnetUsdPrice,
     } = props;
+    const {
+        globalModal: { open: openGlobalModal },
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
     const {
         posHash,
@@ -127,15 +135,12 @@ export default function RangesRow(props: propsIF) {
         quoteTokenAddress: props.position.quote,
         lastBlockNumber: props.lastBlockNumber,
         positionApy: position.apy,
-        closeGlobalModal: props.closeGlobalModal,
-        openGlobalModal: props.openGlobalModal,
         minRangeDenomByMoneyness: minRangeDenomByMoneyness,
         maxRangeDenomByMoneyness: maxRangeDenomByMoneyness,
     };
 
     const rangeMenuProps = {
         chainData: props.chainData,
-        posHash: posHash as string,
         rangeDetailsProps: rangeDetailsProps,
         userMatchesConnectedAccount: userMatchesConnectedAccount,
         isPositionEmpty: isPositionEmpty,
@@ -199,32 +204,16 @@ export default function RangesRow(props: propsIF) {
             inline: 'nearest',
         });
     }
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
-    const [valueToCopy, setValueToCopy] = useState('');
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {valueToCopy} copied
-        </SnackbarComponent>
-    );
+    const [_, copy] = useCopyToClipboard();
 
     function handleWalletCopy() {
-        setValueToCopy(ownerId);
         copy(ownerId);
-
-        setOpenSnackbar(true);
+        openSnackbar(`${ownerId} copied`, 'info');
     }
 
     function handleCopyPosHash() {
-        setValueToCopy(posHash.toString());
         copy(posHash.toString());
-
-        setOpenSnackbar(true);
+        openSnackbar(`${posHash.toString()} copied`, 'info');
     }
 
     useEffect(() => {
@@ -391,7 +380,6 @@ export default function RangesRow(props: propsIF) {
                     />
                 </li>
             </ul>
-            {snackbarContent}
         </>
     );
 }

--- a/src/components/Trade/TradeTabs/TradeTabs2.tsx
+++ b/src/components/Trade/TradeTabs/TradeTabs2.tsx
@@ -4,7 +4,7 @@ import {
     Dispatch,
     SetStateAction,
     useRef,
-    ReactNode,
+    useContext,
 } from 'react';
 
 import {
@@ -39,6 +39,7 @@ import { SpotPriceFn } from '../../../App/functions/querySpotPrice';
 import { candleTimeIF } from '../../../App/hooks/useChartSettings';
 import { IS_LOCAL_ENV } from '../../../constants';
 import { PositionUpdateFn } from '../../../App/functions/getPositionData';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
     isUserLoggedIn: boolean | undefined;
@@ -64,16 +65,9 @@ interface propsIF {
     filter: CandleData | undefined;
     setIsCandleSelected: Dispatch<SetStateAction<boolean | undefined>>;
     setTransactionFilter: Dispatch<SetStateAction<CandleData | undefined>>;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
-    openGlobalModal: (content: ReactNode) => void;
-    closeGlobalModal: () => void;
     searchableTokens: TokenIF[];
-    isSidebarOpen: boolean;
     handlePulseAnimation: (type: string) => void;
     changeState: (
         isOpen: boolean | undefined,
@@ -126,12 +120,7 @@ export default function TradeTabs2(props: propsIF) {
         setCurrentPositionActive,
         currentTxActiveInTransactions,
         setCurrentTxActiveInTransactions,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
-        outsideControl,
-        setOutsideControl,
         searchableTokens,
-        isSidebarOpen,
         handlePulseAnimation,
         changeState,
         selectedDate,
@@ -151,6 +140,13 @@ export default function TradeTabs2(props: propsIF) {
         ethMainnetUsdPrice,
         candleTime,
     } = props;
+    const {
+        outsideTab: { selected: outsideTabSelected },
+        outsideControl: {
+            isActive: outsideControlActive,
+            setIsActive: setOutsideControlActive,
+        },
+    } = useContext(AppStateContext);
 
     const graphData = useAppSelector((state) => state?.graphData);
     const tradeData = useAppSelector((state) => state?.tradeData);
@@ -225,8 +221,8 @@ export default function TradeTabs2(props: propsIF) {
             userPositionsDataReceived
         ) {
             if (
-                (outsideControl && selectedOutsideTab === 0) ||
-                (!outsideControl && selectedInsideTab === 0)
+                (outsideControlActive && outsideTabSelected === 0) ||
+                (!outsideControlActive && selectedInsideTab === 0)
             ) {
                 if (isCandleSelected) {
                     setIsShowAllEnabled(false);
@@ -243,8 +239,8 @@ export default function TradeTabs2(props: propsIF) {
                     setIsShowAllEnabled(false);
                 }
             } else if (
-                (outsideControl && selectedOutsideTab === 1) ||
-                (!outsideControl && selectedInsideTab === 1)
+                (outsideControlActive && outsideTabSelected === 1) ||
+                (!outsideControlActive && selectedInsideTab === 1)
             ) {
                 if (
                     !isUserLoggedIn ||
@@ -262,8 +258,8 @@ export default function TradeTabs2(props: propsIF) {
                     setIsShowAllEnabled(false);
                 }
             } else if (
-                (outsideControl && selectedOutsideTab === 2) ||
-                (!outsideControl && selectedInsideTab === 2)
+                (outsideControlActive && outsideTabSelected === 2) ||
+                (!outsideControlActive && selectedInsideTab === 2)
             ) {
                 if (
                     !isUserLoggedIn ||
@@ -289,9 +285,9 @@ export default function TradeTabs2(props: propsIF) {
         isUserLoggedIn,
         hasInitialized,
         isCandleSelected,
-        outsideControl,
+        outsideControlActive,
         selectedInsideTab,
-        selectedOutsideTab,
+        outsideTabSelected,
         isShowAllEnabled,
         matchingUserPositionsLength,
         matchingUserChangesLength,
@@ -368,7 +364,7 @@ export default function TradeTabs2(props: propsIF) {
                             selectedCandleChangesWithoutFills,
                         );
                     }
-                    setOutsideControl(true);
+                    setOutsideControlActive(true);
                     setSelectedInsideTab(0);
                 })
                 .catch(console.error);
@@ -400,9 +396,6 @@ export default function TradeTabs2(props: propsIF) {
         setExpandTradeTable: setExpandTradeTable,
         currentPositionActive: currentPositionActive,
         setCurrentPositionActive: setCurrentPositionActive,
-        openGlobalModal: props.openGlobalModal,
-        closeGlobalModal: props.closeGlobalModal,
-        isSidebarOpen: isSidebarOpen,
         isOnPortfolioPage: false,
         setLeader: setLeader,
         setLeaderOwnerId: setLeaderOwnerId,
@@ -431,10 +424,7 @@ export default function TradeTabs2(props: propsIF) {
         setIsCandleSelected: setIsCandleSelected,
         isCandleSelected: isCandleSelected,
         filter: filter,
-        closeGlobalModal: props.closeGlobalModal,
         changeState: changeState,
-        openGlobalModal: props.openGlobalModal,
-        isSidebarOpen: isSidebarOpen,
         setSelectedDate: setSelectedDate,
         isOnPortfolioPage: false,
         handlePulseAnimation: handlePulseAnimation,
@@ -450,11 +440,8 @@ export default function TradeTabs2(props: propsIF) {
         chainData: chainData,
         isShowAllEnabled: isShowAllEnabled,
         account: account,
-        openGlobalModal: props.openGlobalModal,
         currentPositionActive: currentPositionActive,
-        closeGlobalModal: props.closeGlobalModal,
         setCurrentPositionActive: setCurrentPositionActive,
-        isSidebarOpen: isSidebarOpen,
         isOnPortfolioPage: false,
         handlePulseAnimation: handlePulseAnimation,
         setIsShowAllEnabled: setIsShowAllEnabled,
@@ -532,12 +519,7 @@ export default function TradeTabs2(props: propsIF) {
               },
               {
                   label: 'Leaderboard',
-                  content: (
-                      <Leaderboard
-                          {...rangesProps}
-                          isSidebarOpen={isSidebarOpen}
-                      />
-                  ),
+                  content: <Leaderboard {...rangesProps} />,
                   icon: leaderboard,
                   showRightSideOption: false,
               },
@@ -623,10 +605,6 @@ export default function TradeTabs2(props: propsIF) {
                 rightTabOptions={
                     <PositionsOnlyToggle {...positionsOnlyToggleProps} />
                 }
-                selectedOutsideTab={selectedOutsideTab}
-                setSelectedOutsideTab={setSelectedOutsideTab}
-                outsideControl={outsideControl}
-                setOutsideControl={setOutsideControl}
                 setSelectedInsideTab={setSelectedInsideTab}
                 showPositionsOnlyToggle={showPositionsOnlyToggle}
                 setShowPositionsOnlyToggle={setShowPositionsOnlyToggle}

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -10,7 +10,14 @@ import {
     useAppDispatch,
     useAppSelector,
 } from '../../../../utils/hooks/reduxToolkit';
-import { Dispatch, SetStateAction, useState, useEffect, useRef } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useState,
+    useEffect,
+    useRef,
+    useContext,
+} from 'react';
 
 import TransactionsSkeletons from '../TableSkeletons/TableSkeletons';
 import Pagination from '../../../Global/Pagination/Pagination';
@@ -22,6 +29,7 @@ import useDebounce from '../../../../App/hooks/useDebounce';
 import NoTableData from '../NoTableData/NoTableData';
 import useWindowDimensions from '../../../../utils/hooks/useWindowDimensions';
 import { diffHashSig } from '../../../../utils/functions/diffHashSig';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface propsIF {
     isTokenABase: boolean;
@@ -45,10 +53,7 @@ interface propsIF {
         isOpen: boolean | undefined,
         candleData: CandleData | undefined,
     ) => void;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
     handlePulseAnimation?: (type: string) => void;
-    isSidebarOpen: boolean;
     isOnPortfolioPage: boolean;
     setSelectedDate?: Dispatch<Date | undefined>;
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
@@ -68,9 +73,6 @@ export default function Transactions(props: propsIF) {
         setCurrentTxActiveInTransactions,
         expandTradeTable,
         isCandleSelected,
-        isSidebarOpen,
-        openGlobalModal,
-        closeGlobalModal,
         isOnPortfolioPage,
         handlePulseAnimation,
         setIsShowAllEnabled,
@@ -80,6 +82,9 @@ export default function Transactions(props: propsIF) {
         setSimpleRangeWidth,
         isAccountView,
     } = props;
+    const {
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const NUM_TRANSACTIONS_WHEN_COLLAPSED = isAccountView ? 13 : 10; // Number of transactions we show when the table is collapsed (i.e. half page)
     // NOTE: this is done to improve rendering speed for this page.
@@ -431,15 +436,12 @@ export default function Transactions(props: propsIF) {
             isTokenABase={isTokenABase}
             currentTxActiveInTransactions={currentTxActiveInTransactions}
             setCurrentTxActiveInTransactions={setCurrentTxActiveInTransactions}
-            openGlobalModal={openGlobalModal}
             isShowAllEnabled={isShowAllEnabled}
             ipadView={ipadView}
             showColumns={showColumns}
             view2={view2}
             showPair={showPair}
-            isSidebarOpen={isSidebarOpen}
             blockExplorer={blockExplorer}
-            closeGlobalModal={closeGlobalModal}
             isOnPortfolioPage={isOnPortfolioPage}
             handlePulseAnimation={handlePulseAnimation}
             setSimpleRangeWidth={setSimpleRangeWidth}
@@ -455,15 +457,12 @@ export default function Transactions(props: propsIF) {
             isTokenABase={isTokenABase}
             currentTxActiveInTransactions={currentTxActiveInTransactions}
             setCurrentTxActiveInTransactions={setCurrentTxActiveInTransactions}
-            openGlobalModal={openGlobalModal}
             isShowAllEnabled={isShowAllEnabled}
             ipadView={ipadView}
             showColumns={showColumns}
             view2={view2}
             showPair={showPair}
-            isSidebarOpen={isSidebarOpen}
             blockExplorer={blockExplorer}
-            closeGlobalModal={closeGlobalModal}
             isOnPortfolioPage={isOnPortfolioPage}
             handlePulseAnimation={handlePulseAnimation}
             setSimpleRangeWidth={setSimpleRangeWidth}

--- a/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
@@ -1,6 +1,13 @@
 import styles from '../Transactions.module.css';
 import { setDataLoadingStatus } from '../../../../../utils/state/graphDataSlice';
-import { Dispatch, SetStateAction, useEffect, useRef, useState } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 import { useProcessTransaction } from '../../../../../utils/hooks/useProcessTransaction';
 import TransactionsMenu from '../../../../Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu';
 
@@ -12,8 +19,8 @@ import useOnClickOutside from '../../../../../utils/hooks/useOnClickOutside';
 import { TransactionIF } from '../../../../../utils/interfaces/exports';
 import { ChainSpec } from '@crocswap-libs/sdk';
 import useCopyToClipboard from '../../../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../../Global/SnackbarComponent/SnackbarComponent';
 import { txRowConstants } from '../txRowConstants';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     account: string;
@@ -23,15 +30,12 @@ interface propsIF {
     currentTxActiveInTransactions: string;
     setCurrentTxActiveInTransactions: Dispatch<SetStateAction<string>>;
     isShowAllEnabled: boolean;
-    isSidebarOpen: boolean;
     ipadView: boolean;
     showPair: boolean;
     view2: boolean;
     showColumns: boolean;
     blockExplorer: string | undefined;
-    closeGlobalModal: () => void;
     handlePulseAnimation?: (type: string) => void;
-    openGlobalModal: (content: React.ReactNode) => void;
     isOnPortfolioPage: boolean;
     setSimpleRangeWidth: Dispatch<SetStateAction<number>>;
     chainData: ChainSpec;
@@ -50,12 +54,9 @@ export default function TransactionRow(props: propsIF) {
         setCurrentTxActiveInTransactions,
         isShowAllEnabled,
         isOnPortfolioPage,
-        closeGlobalModal,
-        openGlobalModal,
         showPair,
         setSimpleRangeWidth,
         chainData,
-        isSidebarOpen,
     } = props;
 
     const {
@@ -92,6 +93,11 @@ export default function TransactionRow(props: propsIF) {
         isBuy,
         elapsedTimeString,
     } = useProcessTransaction(tx, account, isOnPortfolioPage);
+
+    const {
+        globalModal: { open: openGlobalModal, close: closeGlobalModal },
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
     const dispatch = useAppDispatch();
 
@@ -160,27 +166,11 @@ export default function TransactionRow(props: propsIF) {
             window.open(explorerUrl);
         }
     }
-    // eslint-disable-next-line
-    const [value, copy] = useCopyToClipboard();
-    const [valueToCopy, setValueToCopy] = useState('');
-
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {valueToCopy} copied
-        </SnackbarComponent>
-    );
+    const [_, copy] = useCopyToClipboard();
 
     function handleCopyTxHash() {
-        setValueToCopy(txHash);
         copy(txHash);
-
-        setOpenSnackbar(true);
+        openSnackbar(`${txHash} copied`, 'info');
     }
 
     const [highlightRow, setHighlightRow] = useState(false);
@@ -189,10 +179,8 @@ export default function TransactionRow(props: propsIF) {
     const handleRowMouseOut = () => setHighlightRow(false);
 
     function handleWalletCopy() {
-        setValueToCopy(ownerId);
         copy(ownerId);
-
-        setOpenSnackbar(true);
+        openSnackbar(`${ownerId} copied`, 'info');
     }
 
     const handleWalletClick = () => {
@@ -323,9 +311,6 @@ export default function TransactionRow(props: propsIF) {
                     tradeData={tradeData}
                     isTokenABase={isTokenABase}
                     blockExplorer={blockExplorer}
-                    isSidebarOpen={isSidebarOpen}
-                    openGlobalModal={props.openGlobalModal}
-                    closeGlobalModal={props.closeGlobalModal}
                     isOnPortfolioPage={props.isOnPortfolioPage}
                     handlePulseAnimation={handlePulseAnimation}
                     isBaseTokenMoneynessGreaterOrEqual={
@@ -337,7 +322,6 @@ export default function TransactionRow(props: propsIF) {
                     isShowAllEnabled={isShowAllEnabled}
                 />
             </li>
-            {snackbarContent}
         </ul>
     );
 }

--- a/src/contexts/AppStateContext.tsx
+++ b/src/contexts/AppStateContext.tsx
@@ -1,0 +1,40 @@
+import { createContext } from 'react';
+import { globalModalMethodsIF } from '../App/components/GlobalModal/useGlobalModal';
+import { globalPopupMethodsIF } from '../App/components/GlobalPopup/useGlobalPopup';
+import { sidebarMethodsIF } from '../App/hooks/useSidebar';
+import { skinMethodsIF } from '../App/hooks/useSkin';
+import { tosMethodsIF } from '../App/hooks/useTermsOfService';
+import { snackbarMethodsIF } from '../components/Global/SnackbarComponent/useSnackbar';
+
+interface AppStateIF {
+    appOverlay: { isActive: boolean; setIsActive: (val: boolean) => void };
+    globalModal: globalModalMethodsIF;
+    globalPopup: globalPopupMethodsIF;
+    sidebar: sidebarMethodsIF;
+    snackbar: snackbarMethodsIF;
+    tutorial: { isActive: boolean; setIsActive: (val: boolean) => void };
+    skin: skinMethodsIF;
+    walletToS: tosMethodsIF;
+    chatToS: tosMethodsIF;
+    theme: {
+        selected: 'dark' | 'light';
+        setSelected: (val: 'dark' | 'light') => void;
+    };
+    outsideTab: { selected: number; setSelected: (val: number) => void };
+    outsideControl: { isActive: boolean; setIsActive: (val: boolean) => void };
+    chat: {
+        isOpen: boolean;
+        setIsOpen: (val: boolean) => void;
+        isEnabled: boolean;
+        setIsEnabled: (val: boolean) => void;
+    };
+    chart: {
+        isFullScreen: boolean;
+        setIsFullScreen: (val: boolean) => void;
+        isEnabled: boolean;
+    };
+    server: { isEnabled: boolean };
+    subscriptions: { isEnabled: boolean };
+}
+
+export const AppStateContext = createContext<AppStateIF>({} as AppStateIF);

--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -56,6 +56,7 @@ import useHandleSwipeBack from '../../utils/hooks/useHandleSwipeBack';
 import { candleTimeIF } from '../../App/hooks/useChartSettings';
 import { IS_LOCAL_ENV } from '../../constants';
 import { diffHashSig } from '../../utils/functions/diffHashSig';
+import { AppStateContext } from '../../contexts/AppStateContext';
 
 declare global {
     // eslint-disable-next-line @typescript-eslint/no-namespace
@@ -158,7 +159,6 @@ interface propsIF {
     rescaleRangeBoundariesWithSlider: boolean;
     setRescaleRangeBoundariesWithSlider: Dispatch<SetStateAction<boolean>>;
     setCandleDomains: Dispatch<SetStateAction<candleDomain>>;
-    showSidebar: boolean;
     setRangeSimpleRangeWidth: Dispatch<SetStateAction<number>>;
     rangeSimpleRangeWidth: number | undefined;
     setRepositionRangeWidth: Dispatch<SetStateAction<number>>;
@@ -216,7 +216,6 @@ export default function Chart(props: propsIF) {
         setMinPrice,
         rescaleRangeBoundariesWithSlider,
         setRescaleRangeBoundariesWithSlider,
-        showSidebar,
         setRangeSimpleRangeWidth,
         rangeSimpleRangeWidth,
         setRepositionRangeWidth,
@@ -227,6 +226,9 @@ export default function Chart(props: propsIF) {
     } = props;
 
     const pool = useContext(PoolContext);
+    const {
+        sidebar: { isOpen: isSidebarOpen },
+    } = useContext(AppStateContext);
 
     const tradeData = useAppSelector((state) => state.tradeData);
 
@@ -5566,7 +5568,7 @@ export default function Chart(props: propsIF) {
         denomInBase,
         liqTooltip,
         selectedDate,
-        showSidebar,
+        isSidebarOpen,
         liqMode,
     ]);
 

--- a/src/pages/Home/Home.tsx
+++ b/src/pages/Home/Home.tsx
@@ -11,7 +11,6 @@ import { topPoolIF } from '../../App/hooks/useTopPools';
 import { PoolStatsFn } from '../../App/functions/getPoolStats';
 
 interface propsIF {
-    isServerEnabled: boolean;
     cachedQuerySpotPrice: SpotPriceFn;
     tokenMap: Map<string, TokenIF>;
     lastBlockNumber: number;
@@ -21,7 +20,6 @@ interface propsIF {
 }
 export default function Home(props: propsIF) {
     const {
-        isServerEnabled,
         tokenMap,
         lastBlockNumber,
         chainId,
@@ -38,7 +36,6 @@ export default function Home(props: propsIF) {
             <HomeSlider />
             <div className={styles.pools_container}>
                 <TopPools
-                    isServerEnabled={isServerEnabled}
                     tradeData={tradeData}
                     userData={userData}
                     cachedQuerySpotPrice={cachedQuerySpotPrice}
@@ -50,7 +47,6 @@ export default function Home(props: propsIF) {
                 />
                 <DividerDark />
                 <Stats
-                    isServerEnabled={isServerEnabled}
                     lastBlockNumber={lastBlockNumber}
                     userData={userData}
                     chainId={chainId}

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -72,20 +72,13 @@ interface propsIF {
     userImageData: string[];
     chainId: string;
     tokensOnActiveLists: Map<string, TokenIF>;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     userAccount?: boolean;
-    openGlobalModal: (content: React.ReactNode, title?: string) => void;
-    closeGlobalModal: () => void;
     openModalWallet: () => void;
     searchableTokens: TokenIF[];
     chainData: ChainSpec;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
     account: string;
-    isSidebarOpen: boolean;
     isUserLoggedIn: boolean | undefined;
     baseTokenBalance: string;
     quoteTokenBalance: string;
@@ -125,20 +118,13 @@ export default function Portfolio(props: propsIF) {
         lastBlockNumber,
         userImageData,
         tokensOnActiveLists,
-        openGlobalModal,
-        closeGlobalModal,
         userAccount,
-        outsideControl,
-        setOutsideControl,
-        selectedOutsideTab,
-        setSelectedOutsideTab,
         baseTokenBalance,
         quoteTokenBalance,
         baseTokenDexBalance,
         quoteTokenDexBalance,
         currentTxActiveInTransactions,
         setCurrentTxActiveInTransactions,
-        isSidebarOpen,
         handlePulseAnimation,
         openModalWallet,
         outputTokens,
@@ -357,10 +343,6 @@ export default function Portfolio(props: propsIF) {
                 mainnetProvider={mainnetProvider}
                 ethMainnetUsdPrice={ethMainnetUsdPrice}
                 connectedAccount={connectedAccount || ''}
-                setSelectedOutsideTab={setSelectedOutsideTab}
-                setOutsideControl={setOutsideControl}
-                openGlobalModal={openGlobalModal}
-                closeGlobalModal={closeGlobalModal}
                 selectedToken={selectedToken}
                 tokenAllowance={tokenAllowance}
                 tokenWalletBalance={tokenWalletBalance}
@@ -574,14 +556,7 @@ export default function Portfolio(props: propsIF) {
         connectedAccountActive: connectedAccountActive,
         chainId: chainData.chainId,
         tokenMap: tokensOnActiveLists,
-        selectedOutsideTab: selectedOutsideTab,
-        setSelectedOutsideTab: setSelectedOutsideTab,
-        setOutsideControl: setOutsideControl,
-        outsideControl: outsideControl,
         openTokenModal: openTokenModal,
-        openGlobalModal: openGlobalModal,
-        closeGlobalModal: closeGlobalModal,
-        isSidebarOpen: isSidebarOpen,
         account: props.account,
         chainData: chainData,
         currentPositionActive: props.currentPositionActive,
@@ -620,7 +595,6 @@ export default function Portfolio(props: propsIF) {
         setShowProfileSettings: setShowProfileSettings,
         ensName: secondaryEnsName ? secondaryEnsName : ensName ?? '',
         imageData: connectedAccountActive ? userImageData : secondaryImageData,
-        openGlobalModal: openGlobalModal,
     };
 
     const mobilePortfolio = (

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -54,6 +54,7 @@ import { useUrlParams } from '../../utils/hooks/useUrlParams';
 import { ackTokensMethodsIF } from '../../App/hooks/useAckTokens';
 import { CrocEnvContext } from '../../contexts/CrocEnvContext';
 import { UserPreferenceContext } from '../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../contexts/AppStateContext';
 
 interface propsIF {
     isUserLoggedIn: boolean | undefined;
@@ -78,14 +79,6 @@ interface propsIF {
     isInitialized: boolean;
     poolExists: boolean | undefined;
     setTokenPairLocal?: Dispatch<SetStateAction<string[] | null>>;
-
-    openGlobalModal: (content: React.ReactNode) => void;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
-
     isSwapCopied?: boolean;
     verifyToken: (addr: string, chn: string) => boolean;
     getTokensByName: (
@@ -103,8 +96,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
     tokenPairLocal: string[] | null;
     ackTokens: ackTokensMethodsIF;
     chainData: ChainSpec;
@@ -144,7 +135,6 @@ export default function Swap(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         lastBlockNumber,
         tokenPairLocal,
         ackTokens,
@@ -731,11 +721,14 @@ export default function Swap(props: propsIF) {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
         lastBlockNumber: lastBlockNumber,
         setTokenAQtyCoveredByWalletBalance: setTokenAQtyCoveredByWalletBalance,
         ackTokens: ackTokens,
     };
+
+    const {
+        tutorial: { isActive: isTutorialActive },
+    } = useContext(AppStateContext);
 
     const handleSwapButtonClickWithBypass = () => {
         IS_LOCAL_ENV && console.debug('setting to true');
@@ -870,7 +863,7 @@ export default function Swap(props: propsIF) {
             }}
         >
             <section data-testid={'swap'} className={swapPageStyle}>
-                {props.isTutorialMode && (
+                {isTutorialActive && (
                     <div className={styles.tutorial_button_container}>
                         <button
                             className={styles.tutorial_button}
@@ -888,7 +881,6 @@ export default function Swap(props: propsIF) {
                         <SwapHeader
                             isPairStable={isPairStable}
                             isOnTradeRoute={isOnTradeRoute}
-                            openGlobalModal={props.openGlobalModal}
                             shareOptionsDisplay={shareOptionsDisplay}
                         />
                         {navigationMenu}

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -71,6 +71,7 @@ import { useUrlParams } from '../../../utils/hooks/useUrlParams';
 import { ackTokensMethodsIF } from '../../../App/hooks/useAckTokens';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
     account: string | undefined;
@@ -93,8 +94,6 @@ interface propsIF {
     setRecheckTokenAApproval: Dispatch<SetStateAction<boolean>>;
     chainId: string;
     openModalWallet: () => void;
-    openGlobalModal: (content: React.ReactNode) => void;
-    closeGlobalModal: () => void;
     poolExists: boolean | undefined;
     chainData: ChainSpec;
     isOrderCopied: boolean;
@@ -115,13 +114,6 @@ interface propsIF {
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
     setResetLimitTick: Dispatch<SetStateAction<boolean>>;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
     ackTokens: ackTokensMethodsIF;
 }
 
@@ -161,7 +153,6 @@ export default function Limit(props: propsIF) {
         setInput,
         searchType,
         setResetLimitTick,
-        openGlobalPopup,
         ackTokens,
     } = props;
 
@@ -173,6 +164,9 @@ export default function Limit(props: propsIF) {
     const { dexBalLimit, bypassConfirmLimit } = useContext(
         UserPreferenceContext,
     );
+    const {
+        tutorial: { isActive: isTutorialActive },
+    } = useContext(AppStateContext);
 
     const [isModalOpen, openModal, closeModal] = useModal();
     const [limitAllowed, setLimitAllowed] = useState<boolean>(false);
@@ -871,7 +865,6 @@ export default function Limit(props: propsIF) {
         setInput: setInput,
         searchType: searchType,
         setResetLimitTick: setResetLimitTick,
-        openGlobalPopup: openGlobalPopup,
         ackTokens: ackTokens,
         isOrderValid: isOrderValid,
     };
@@ -941,7 +934,7 @@ export default function Limit(props: propsIF) {
             }}
         >
             <section className={styles.scrollable_container}>
-                {props.isTutorialMode && (
+                {isTutorialActive && (
                     <div className={styles.tutorial_button_container}>
                         <button
                             className={styles.tutorial_button}
@@ -955,7 +948,6 @@ export default function Limit(props: propsIF) {
                     <LimitHeader
                         chainId={chainId}
                         isPairStable={isPairStable}
-                        openGlobalModal={props.openGlobalModal}
                         shareOptionsDisplay={shareOptionsDisplay}
                     />
                     {navigationMenu}

--- a/src/pages/Trade/Range/Range.tsx
+++ b/src/pages/Trade/Range/Range.tsx
@@ -6,7 +6,6 @@ import {
     useMemo,
     Dispatch,
     SetStateAction,
-    ReactNode,
     useContext,
 } from 'react';
 import { ethers } from 'ethers';
@@ -85,6 +84,7 @@ import { useUrlParams } from '../../../utils/hooks/useUrlParams';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
 import { diffHashSig } from '../../../utils/functions/diffHashSig';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 interface propsIF {
     account: string | undefined;
@@ -110,7 +110,6 @@ interface propsIF {
     openModalWallet: () => void;
     ambientApy: number | undefined;
     dailyVol: number | undefined;
-    openGlobalModal: (content: ReactNode, title?: string) => void;
     poolExists: boolean | undefined;
     isRangeCopied: boolean;
     tokenAQtyLocal: number;
@@ -133,13 +132,6 @@ interface propsIF {
     validatedInput: string;
     setInput: Dispatch<SetStateAction<string>>;
     searchType: string;
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
     setSimpleRangeWidth: Dispatch<SetStateAction<number>>;
     simpleRangeWidth: number;
     setMaxPrice: Dispatch<SetStateAction<number>>;
@@ -179,7 +171,6 @@ export default function Range(props: propsIF) {
         openModalWallet,
         ambientApy,
         dailyVol,
-        openGlobalModal,
         poolExists,
         isRangeCopied,
         tokenAQtyLocal,
@@ -196,7 +187,6 @@ export default function Range(props: propsIF) {
         validatedInput,
         setInput,
         searchType,
-        openGlobalPopup,
         setSimpleRangeWidth,
         simpleRangeWidth,
         setMaxPrice,
@@ -214,6 +204,9 @@ export default function Range(props: propsIF) {
     const { mintSlippage, dexBalRange, bypassConfirmRange } = useContext(
         UserPreferenceContext,
     );
+    const {
+        tutorial: { isActive: isTutorialActive },
+    } = useContext(AppStateContext);
 
     const [
         isConfirmationModalOpen,
@@ -1246,7 +1239,6 @@ export default function Range(props: propsIF) {
         cachedFetchTokenPrice: cachedFetchTokenPrice,
         chainId: chainId,
         isAmbient: isAmbient,
-        openGlobalPopup,
     };
 
     const pinnedMinPriceDisplayTruncatedInBase = useMemo(
@@ -1389,7 +1381,6 @@ export default function Range(props: propsIF) {
         validatedInput: validatedInput,
         setInput: setInput,
         searchType: searchType,
-        openGlobalPopup: openGlobalPopup,
         ackTokens: ackTokens,
     };
 
@@ -1398,7 +1389,6 @@ export default function Range(props: propsIF) {
         rangeWidthPercentage: rangeWidthPercentage,
         setRangeWidthPercentage: setRangeWidthPercentage,
         isRangeCopied: isRangeCopied,
-        openGlobalPopup: openGlobalPopup,
         setRescaleRangeBoundariesWithSlider:
             setRescaleRangeBoundariesWithSlider,
     };
@@ -1708,7 +1698,7 @@ export default function Range(props: propsIF) {
                 data-testid={'range'}
                 className={styles.scrollable_container}
             >
-                {props.isTutorialMode && (
+                {isTutorialActive && (
                     <div className={styles.tutorial_button_container}>
                         <button
                             className={styles.tutorial_button}
@@ -1727,7 +1717,6 @@ export default function Range(props: propsIF) {
                         isPairStable={isPairStable}
                         isDenomBase={tradeData.isDenomBase}
                         isTokenABase={isTokenABase}
-                        openGlobalModal={openGlobalModal}
                         shareOptionsDisplay={shareOptionsDisplay}
                     />
                     {navigationMenu}

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -78,12 +78,6 @@ interface propsIF {
     gasPriceInGwei: number | undefined;
     ethMainnetUsdPrice: number | undefined;
     chainData: ChainSpec;
-
-    openGlobalPopup: (
-        content: React.ReactNode,
-        popupTitle?: string,
-        popupPlacement?: string,
-    ) => void;
 }
 
 export default function Reposition(props: propsIF) {
@@ -105,7 +99,6 @@ export default function Reposition(props: propsIF) {
         gasPriceInGwei,
         ethMainnetUsdPrice,
         chainData,
-        openGlobalPopup,
     } = props;
 
     // current URL parameter string
@@ -819,7 +812,6 @@ export default function Reposition(props: propsIF) {
                     isDenomBase={isDenomBase}
                     currentMinPrice={position?.lowRangeDisplayInBase}
                     currentMaxPrice={position?.highRangeDisplayInBase}
-                    openGlobalPopup={openGlobalPopup}
                 />
                 <div className={styles.button_container}>
                     {!showBypassConfirmButton ? (

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -3,9 +3,9 @@
 import {
     Dispatch,
     SetStateAction,
-    ReactNode,
     useEffect,
     useState,
+    useContext,
 } from 'react';
 import {
     useParams,
@@ -45,6 +45,7 @@ import { chartSettingsMethodsIF } from '../../App/hooks/useChartSettings';
 import { IS_LOCAL_ENV } from '../../constants';
 import { formSlugForPairParams } from '../../App/functions/urlSlugs';
 import { PositionUpdateFn } from '../../App/functions/getPositionData';
+import { AppStateContext } from '../../contexts/AppStateContext';
 // import { useCandleTime } from './useCandleTime';
 
 // interface for React functional component props
@@ -74,25 +75,16 @@ interface propsIF {
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
     setLimitRate: Dispatch<SetStateAction<string>>;
     limitRate: string;
-    selectedOutsideTab: number;
-    setSelectedOutsideTab: Dispatch<SetStateAction<number>>;
-    outsideControl: boolean;
-    setOutsideControl: Dispatch<SetStateAction<boolean>>;
     currentPositionActive: string;
     setCurrentPositionActive: Dispatch<SetStateAction<string>>;
-    openGlobalModal: (content: ReactNode) => void;
-    closeGlobalModal: () => void;
     isInitialized: boolean;
     poolPriceNonDisplay: number | undefined;
     searchableTokens: TokenIF[];
     poolExists: boolean | undefined;
-    isSidebarOpen: boolean;
     setTokenPairLocal: Dispatch<SetStateAction<string[] | null>>;
     handlePulseAnimation: (type: string) => void;
     isCandleSelected: boolean | undefined;
     setIsCandleSelected: Dispatch<SetStateAction<boolean | undefined>>;
-    fullScreenChart: boolean;
-    setFullScreenChart: Dispatch<SetStateAction<boolean>>;
     cachedQuerySpotPrice: SpotPriceFn;
     fetchingCandle: boolean;
     setFetchingCandle: Dispatch<SetStateAction<boolean>>;
@@ -104,8 +96,6 @@ interface propsIF {
     setMinPrice: Dispatch<SetStateAction<number>>;
     rescaleRangeBoundariesWithSlider: boolean;
     setRescaleRangeBoundariesWithSlider: Dispatch<SetStateAction<boolean>>;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
     setCandleDomains: Dispatch<SetStateAction<candleDomain>>;
     tokenList: TokenIF[];
     setSimpleRangeWidth: Dispatch<SetStateAction<number>>;
@@ -156,14 +146,9 @@ export default function Trade(props: propsIF) {
         currentTxActiveInTransactions,
         setCurrentTxActiveInTransactions,
         poolExists,
-        isSidebarOpen,
         handlePulseAnimation,
-        setOutsideControl,
-        setSelectedOutsideTab,
         isCandleSelected,
         setIsCandleSelected,
-        fullScreenChart,
-        setFullScreenChart,
         fetchingCandle,
         setFetchingCandle,
         isCandleDataNull,
@@ -185,6 +170,11 @@ export default function Trade(props: propsIF) {
     } = props;
 
     const { params } = useParams();
+    const {
+        chart: { isFullScreen: isChartFullScreen },
+        outsideControl: { setIsActive: setOutsideControlActive },
+        outsideTab: { setSelected: setOutsideTabSelected },
+    } = useContext(AppStateContext);
 
     const [transactionFilter, setTransactionFilter] = useState<CandleData>();
     const [isCandleArrived, setIsCandleDataArrived] = useState(false);
@@ -280,7 +270,7 @@ export default function Trade(props: propsIF) {
         </div>
     );
     const expandGraphStyle = expandTradeTable ? styles.hide_graph : '';
-    const fullScreenStyle = fullScreenChart
+    const fullScreenStyle = isChartFullScreen
         ? styles.chart_full_screen
         : styles.main__chart;
 
@@ -294,8 +284,8 @@ export default function Trade(props: propsIF) {
         setHasInitialized(false);
         setTransactionFilter(candleData);
         if (isOpen) {
-            setOutsideControl(true);
-            setSelectedOutsideTab(0);
+            setOutsideControlActive(true);
+            setOutsideTabSelected(0);
         }
     };
     const [chartBg, setChartBg] = useState('transparent');
@@ -498,8 +488,6 @@ export default function Trade(props: propsIF) {
         expandTradeTable: expandTradeTable,
         setExpandTradeTable: setExpandTradeTable,
         isTokenABase: isTokenABase,
-        fullScreenChart: fullScreenChart,
-        setFullScreenChart: setFullScreenChart,
         changeState: changeState,
         candleData: candleData,
         liquidityData: liquidityData,
@@ -528,10 +516,7 @@ export default function Trade(props: propsIF) {
         rescaleRangeBoundariesWithSlider: rescaleRangeBoundariesWithSlider,
         setRescaleRangeBoundariesWithSlider:
             setRescaleRangeBoundariesWithSlider,
-        isSidebarOpen: isSidebarOpen,
         TradeSettingsColor: <TradeSettingsColor {...tradeSettingsColorProps} />,
-        isTutorialMode: props.isTutorialMode,
-        setIsTutorialMode: props.setIsTutorialMode,
         setCandleDomains: setCandleDomains,
         setSimpleRangeWidth: setSimpleRangeWidth,
         setRepositionRangeWidth: setRepositionRangeWidth,
@@ -566,16 +551,9 @@ export default function Trade(props: propsIF) {
         setIsCandleSelected: setIsCandleSelected,
         filter: transactionFilter,
         setTransactionFilter: setTransactionFilter,
-        selectedOutsideTab: props.selectedOutsideTab,
-        setSelectedOutsideTab: props.setSelectedOutsideTab,
-        outsideControl: props.outsideControl,
-        setOutsideControl: props.setOutsideControl,
         currentPositionActive: props.currentPositionActive,
         setCurrentPositionActive: props.setCurrentPositionActive,
-        openGlobalModal: props.openGlobalModal,
-        closeGlobalModal: props.closeGlobalModal,
         searchableTokens: searchableTokens,
-        isSidebarOpen: isSidebarOpen,
         handlePulseAnimation: handlePulseAnimation,
         changeState: changeState,
         selectedDate: selectedDate,

--- a/src/pages/Trade/TradeCharts/TradeCandleStickChart.tsx
+++ b/src/pages/Trade/TradeCharts/TradeCandleStickChart.tsx
@@ -104,7 +104,6 @@ interface propsIF {
     setRescaleRangeBoundariesWithSlider: React.Dispatch<
         React.SetStateAction<boolean>
     >;
-    showSidebar: boolean;
     setCandleDomains: React.Dispatch<React.SetStateAction<candleDomain>>;
     setSimpleRangeWidth: React.Dispatch<React.SetStateAction<number>>;
     setRepositionRangeWidth: React.Dispatch<React.SetStateAction<number>>;
@@ -149,7 +148,6 @@ export default function TradeCandleStickChart(props: propsIF) {
         setMinPrice,
         rescaleRangeBoundariesWithSlider,
         setRescaleRangeBoundariesWithSlider,
-        showSidebar,
         setCandleDomains,
         setSimpleRangeWidth,
         setRepositionRangeWidth,
@@ -911,7 +909,6 @@ export default function TradeCandleStickChart(props: propsIF) {
                         setRescaleRangeBoundariesWithSlider={
                             setRescaleRangeBoundariesWithSlider
                         }
-                        showSidebar={showSidebar}
                         setCandleDomains={setCandleDomains}
                         setRangeSimpleRangeWidth={setSimpleRangeWidth}
                         setRepositionRangeWidth={setRepositionRangeWidth}

--- a/src/pages/Trade/TradeCharts/TradeCharts.tsx
+++ b/src/pages/Trade/TradeCharts/TradeCharts.tsx
@@ -1,5 +1,12 @@
 // START: Import React and Dongles
-import { Dispatch, SetStateAction, useState, useEffect, useRef } from 'react';
+import {
+    Dispatch,
+    SetStateAction,
+    useState,
+    useEffect,
+    useRef,
+    useContext,
+} from 'react';
 import {
     AiOutlineCamera,
     AiOutlineFullscreen,
@@ -35,6 +42,7 @@ import { useLocation } from 'react-router-dom';
 import TutorialOverlay from '../../../components/Global/TutorialOverlay/TutorialOverlay';
 import { tradeChartTutorialSteps } from '../../../utils/tutorial/TradeChart';
 import { chartSettingsMethodsIF } from '../../../App/hooks/useChartSettings';
+import { AppStateContext } from '../../../contexts/AppStateContext';
 
 // interface for React functional component props
 interface propsIF {
@@ -47,8 +55,6 @@ interface propsIF {
     expandTradeTable: boolean;
     setExpandTradeTable: Dispatch<SetStateAction<boolean>>;
     isTokenABase: boolean;
-    fullScreenChart: boolean;
-    setFullScreenChart: Dispatch<SetStateAction<boolean>>;
     changeState: (
         isOpen: boolean | undefined,
         candleData: CandleData | undefined,
@@ -85,9 +91,6 @@ interface propsIF {
     setRescaleRangeBoundariesWithSlider: React.Dispatch<
         React.SetStateAction<boolean>
     >;
-    isSidebarOpen: boolean;
-    isTutorialMode: boolean;
-    setIsTutorialMode: Dispatch<SetStateAction<boolean>>;
     setCandleDomains: React.Dispatch<React.SetStateAction<candleDomain>>;
     chartSettings: chartSettingsMethodsIF;
     setSimpleRangeWidth: React.Dispatch<React.SetStateAction<number>>;
@@ -158,8 +161,6 @@ export default function TradeCharts(props: propsIF) {
         isUserLoggedIn,
         chainData,
         poolPriceDisplay,
-        fullScreenChart,
-        setFullScreenChart,
         chainId,
         expandTradeTable,
         selectedDate,
@@ -181,8 +182,15 @@ export default function TradeCharts(props: propsIF) {
         chartSettings,
         setChartTriggeredBy,
         chartTriggeredBy,
-        isSidebarOpen,
     } = props;
+
+    const {
+        chart: {
+            isFullScreen: isChartFullScreen,
+            setIsFullScreen: setIsChartFullScreen,
+        },
+        tutorial: { isActive: isTutorialActive },
+    } = useContext(AppStateContext);
 
     const { pathname } = useLocation();
 
@@ -245,7 +253,7 @@ export default function TradeCharts(props: propsIF) {
 
     // eslint-disable-next-line
     function closeOnEscapeKeyDown(e: any) {
-        if ((e.charCode || e.keyCode) === 27) setFullScreenChart(false);
+        if ((e.charCode || e.keyCode) === 27) setIsChartFullScreen(false);
     }
 
     useEffect(() => {
@@ -342,7 +350,7 @@ export default function TradeCharts(props: propsIF) {
                 title={
                     <div
                         className={styles.save_image_content}
-                        onClick={() => setFullScreenChart(!fullScreenChart)}
+                        onClick={() => setIsChartFullScreen(!isChartFullScreen)}
                     >
                         Toggle Full Screen Chart
                     </div>
@@ -350,7 +358,7 @@ export default function TradeCharts(props: propsIF) {
                 enterDelay={500}
             >
                 <button
-                    onClick={() => setFullScreenChart(!fullScreenChart)}
+                    onClick={() => setIsChartFullScreen(!isChartFullScreen)}
                     className={styles.fullscreen_button}
                 >
                     <AiOutlineFullscreen
@@ -495,14 +503,14 @@ export default function TradeCharts(props: propsIF) {
         <div
             className={styles.main_container_chart}
             style={{
-                padding: fullScreenChart ? '1rem' : '0',
-                background: fullScreenChart ? 'var(--dark2)' : '',
+                padding: isChartFullScreen ? '1rem' : '0',
+                background: isChartFullScreen ? 'var(--dark2)' : '',
             }}
             ref={canvasRef}
         >
             {mainChartSettingsContent}
             <div className={`${styles.graph_style} ${expandGraphStyle}  `}>
-                {props.isTutorialMode && (
+                {isTutorialActive && (
                     <div className={styles.tutorial_button_container}>
                         <button
                             className={styles.tutorial_button}
@@ -580,7 +588,6 @@ export default function TradeCharts(props: propsIF) {
                         setRescaleRangeBoundariesWithSlider={
                             setRescaleRangeBoundariesWithSlider
                         }
-                        showSidebar={isSidebarOpen}
                         setCandleDomains={setCandleDomains}
                         setSimpleRangeWidth={setSimpleRangeWidth}
                         setRepositionRangeWidth={props.setRepositionRangeWidth}

--- a/src/pages/Trade/TradeCharts/TradeChartsComponents/TradeChartsTokenInfo.tsx
+++ b/src/pages/Trade/TradeCharts/TradeChartsComponents/TradeChartsTokenInfo.tsx
@@ -8,16 +8,16 @@ import {
     useAppDispatch,
 } from '../../../../utils/hooks/reduxToolkit';
 import NoTokenIcon from '../../../../components/Global/NoTokenIcon/NoTokenIcon';
-import { useContext, useState } from 'react';
+import { useContext } from 'react';
 import getUnicodeCharacter from '../../../../utils/functions/getUnicodeCharacter';
 import { toggleDidUserFlipDenom } from '../../../../utils/state/tradeDataSlice';
 import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import { IS_LOCAL_ENV, ZERO_ADDRESS } from '../../../../constants';
 import { FiCopy, FiExternalLink } from 'react-icons/fi';
 import useCopyToClipboard from '../../../../utils/hooks/useCopyToClipboard';
-import SnackbarComponent from '../../../../components/Global/SnackbarComponent/SnackbarComponent';
 import { ChainSpec } from '@crocswap-libs/sdk';
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
+import { AppStateContext } from '../../../../contexts/AppStateContext';
 
 interface propsIF {
     isPoolPriceChangePositive: boolean;
@@ -41,6 +41,9 @@ export default function TradeChartsTokenInfo(props: propsIF) {
 
     const { tradeData } = useAppSelector((state) => state);
     const { favePools } = useContext(UserPreferenceContext);
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
 
     const denomInBase = tradeData.isDenomBase;
 
@@ -202,27 +205,15 @@ export default function TradeChartsTokenInfo(props: propsIF) {
             }
         </button>
     );
-    const [value, copy] = useCopyToClipboard();
-    const [openSnackbar, setOpenSnackbar] = useState(false);
-    const snackbarContent = (
-        <SnackbarComponent
-            severity='info'
-            setOpenSnackbar={setOpenSnackbar}
-            openSnackbar={openSnackbar}
-        >
-            {value} copied
-        </SnackbarComponent>
-    );
+    const [_, copy] = useCopyToClipboard();
 
     function handleBaseCopy() {
         copy(tradeData.baseToken.address);
-
-        setOpenSnackbar(true);
+        openSnackbar(`${tradeData.baseToken.address} copied`);
     }
     function handleQuoteCopy() {
         copy(tradeData.quoteToken.address);
-
-        setOpenSnackbar(true);
+        openSnackbar(`${tradeData.quoteToken.address} copied`);
     }
     const handleLinkOut = (address: string) => {
         const addressLink = `${chainData.blockExplorer}token/${address}`;
@@ -322,7 +313,6 @@ export default function TradeChartsTokenInfo(props: propsIF) {
             {denomToggleButton}
             {currentAmountDisplay}
             {poolPriceChange}
-            {snackbarContent}
         </div>
     );
 }


### PR DESCRIPTION
### Describe your changes 

Continuation of #2012 with app state context that contains: 
- appOverlay
- globalModal
- globalPopup
- sidebar
- snackbar
- tutorial
- skin
- walletToS
- chatToS
- theme
- outsideTab
- outsideControl
- chat
- chart
- server
- subscriptions

**Known Issue:** After discussing with @benwolski and @Jadessu, we decided to turn snackbar into a global component, similar to globalPopup and globalModal. Unfortunately that has created a bug where when a global modal is open and a snackbar appears, the close button on the snackbar doesn't function as expected. This issue was found to be caused by the `FocusTrap` on the globalModal, which disables the user from clicking anywhere but inside that component. 

Possible solutions: 
- To the best of my understanding, focusTrap helps with accessibility services and the only visible benefit I can see is preventing the user from tabbing on components outside the focus. Removing it would solve the problem (but we'd obviously lose the benefits that come with focusTrap)
- Adding a separate snackbar inside globalModal (and possibly globalPopup as well), but the downside to that is complication and feels unnecessary 
- Not a solution but an option, leave it as is - users can close the snackbar after they close the globalModal, or it will disappear on its own in 8 seconds anyway
cc: @miyuki-eto

*Issue generated from this ticket:* #2034: Wallet ToS and Chat Tos unused

### Link the related issue

_Linked to #1854_

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
