### PR TITLE
Add loading to currency qtys

### DIFF
--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -160,6 +160,9 @@ export default function CurrencyConverter(props: propsIF) {
         tradeData.tokenB.symbol,
     );
 
+    const [isSellLoading, setIsSellLoading] = useState(false);
+    const [isBuyLoading, setIsBuyLoading] = useState(false);
+
     const isSellTokenEth = tradeData.tokenA.address === ZERO_ADDRESS;
 
     useEffect(() => {
@@ -195,7 +198,15 @@ export default function CurrencyConverter(props: propsIF) {
     );
 
     useEffect(() => {
-        console.log({ tokenAQtyLocal });
+        if (isTokenAPrimaryLocal) {
+            if (tokenAQtyLocal !== '') {
+                setIsBuyLoading(true);
+            }
+        } else {
+            if (tokenBQtyLocal !== '') {
+                setIsSellLoading(true);
+            }
+        }
     }, []);
 
     const navigate = useNavigate();
@@ -780,9 +791,6 @@ export default function CurrencyConverter(props: propsIF) {
         if (truncatedTokenAQty !== sellQtyString)
             setSellQtyString(truncatedTokenAQty);
     };
-
-    const [isSellLoading, setIsSellLoading] = useState(false);
-    const [isBuyLoading, setIsBuyLoading] = useState(false);
 
     return (
         <section

--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -194,6 +194,10 @@ export default function CurrencyConverter(props: propsIF) {
         !tradeData.isTokenAPrimary ? tradeData?.primaryQuantity : '',
     );
 
+    useEffect(() => {
+        console.log({ tokenAQtyLocal });
+    }, []);
+
     const navigate = useNavigate();
 
     const { pathname } = useLocation();
@@ -317,8 +321,12 @@ export default function CurrencyConverter(props: propsIF) {
             setSwitchBoxes(!switchBoxes);
 
             isTokenAPrimaryLocal
-                ? setIsSellLoading(true)
-                : setIsBuyLoading(true);
+                ? tokenAQtyLocal !== ''
+                    ? setIsSellLoading(true)
+                    : null
+                : tokenBQtyLocal !== ''
+                ? setIsBuyLoading(true)
+                : null;
 
             setTokenALocal(tokenBLocal);
             setTokenBLocal(tokenALocal);

--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -750,6 +750,9 @@ export default function CurrencyConverter(props: propsIF) {
             setSellQtyString(truncatedTokenAQty);
     };
 
+    const [isSellLoading, setIsSellLoading] = useState(false);
+    const [isBuyLoading, setIsBuyLoading] = useState(false);
+
     return (
         <section
             className={`${styles.currency_converter} ${
@@ -767,6 +770,7 @@ export default function CurrencyConverter(props: propsIF) {
                 chainId={chainId}
                 direction={isLiq ? 'Select Pair' : 'From:'}
                 fieldId='sell'
+                isLoading={isSellLoading}
                 tokenAorB={'A'}
                 sellToken
                 handleChangeEvent={handleTokenAChangeEvent}
@@ -815,6 +819,8 @@ export default function CurrencyConverter(props: propsIF) {
                 }
                 setUserClickedCombinedMax={setUserClickedCombinedMax}
                 userClickedCombinedMax={userClickedCombinedMax}
+                setIsSellLoading={setIsSellLoading}
+                setIsBuyLoading={setIsBuyLoading}
             />
             <div
                 className={
@@ -839,6 +845,7 @@ export default function CurrencyConverter(props: propsIF) {
                     chainId={chainId}
                     direction={isLiq ? '' : 'To:'}
                     fieldId='buy'
+                    isLoading={isBuyLoading}
                     tokenAorB={'B'}
                     handleChangeEvent={handleTokenBChangeEvent}
                     tokenABalance={tokenABalance}
@@ -881,6 +888,8 @@ export default function CurrencyConverter(props: propsIF) {
                     }
                     setUserClickedCombinedMax={setUserClickedCombinedMax}
                     userClickedCombinedMax={userClickedCombinedMax}
+                    setIsSellLoading={setIsSellLoading}
+                    setIsBuyLoading={setIsBuyLoading}
                 />
             </div>
         </section>

--- a/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
+++ b/src/components/Swap/CurrencyConverter/CurrencyConverter.tsx
@@ -316,6 +316,10 @@ export default function CurrencyConverter(props: propsIF) {
             setDisableReverseTokens(true);
             setSwitchBoxes(!switchBoxes);
 
+            isTokenAPrimaryLocal
+                ? setIsSellLoading(true)
+                : setIsBuyLoading(true);
+
             setTokenALocal(tokenBLocal);
             setTokenBLocal(tokenALocal);
             setTokenASymbolLocal(tokenBSymbolLocal);
@@ -480,6 +484,10 @@ export default function CurrencyConverter(props: propsIF) {
 
                 setPriceImpact(impact);
 
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
+
                 rawTokenBQty = impact ? parseFloat(impact.buyQty) : undefined;
                 setIsLiquidityInsufficient(false);
             } catch (error) {
@@ -526,6 +534,9 @@ export default function CurrencyConverter(props: propsIF) {
                           )
                         : undefined;
                 setPriceImpact(impact);
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
 
                 rawTokenBQty = impact ? parseFloat(impact.buyQty) : undefined;
                 setIsLiquidityInsufficient(false);
@@ -579,6 +590,9 @@ export default function CurrencyConverter(props: propsIF) {
                           )
                         : undefined;
                 setPriceImpact(impact);
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
 
                 rawTokenBQty = impact ? parseFloat(impact.buyQty) : undefined;
                 setIsLiquidityInsufficient(false);
@@ -609,6 +623,9 @@ export default function CurrencyConverter(props: propsIF) {
                         : undefined;
 
                 setPriceImpact(impact);
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
 
                 rawTokenBQty = impact ? parseFloat(impact.buyQty) : undefined;
                 setIsLiquidityInsufficient(false);
@@ -676,6 +693,9 @@ export default function CurrencyConverter(props: propsIF) {
                         : undefined;
 
                 setPriceImpact(impact);
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
 
                 rawTokenAQty = impact ? parseFloat(impact.sellQty) : undefined;
                 setIsLiquidityInsufficient(false);
@@ -724,6 +744,9 @@ export default function CurrencyConverter(props: propsIF) {
                         : undefined;
 
                 setPriceImpact(impact);
+                isTokenAPrimaryLocal
+                    ? setIsBuyLoading(false)
+                    : setIsSellLoading(false);
 
                 rawTokenAQty = impact ? parseFloat(impact.sellQty) : undefined;
                 setIsLiquidityInsufficient(false);

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.module.css
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.module.css
@@ -41,6 +41,8 @@
     background-repeat: no-repeat;
     background: var(--title-gradient);
     background: var(--shimmer);
+    background:  linear-gradient(to right, #141e30, #7371FC,  var(--dark2));
+
     z-index: 2;
     animation: shimmer 1.5s infinite;
 }

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.module.css
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.module.css
@@ -19,10 +19,47 @@
         box-shadow var(--animation-speed) ease-in-out;
 
     font-family: var(--mono);
+
+
+
 }
+
+/* shimmer animation effects */
+
+
 .currency_quantity::placeholder {
     color: var(--text3);
     font-weight: 200;
     font-size: 18px;
     line-height: 22px;
 }
+
+.shimmer_wrapper {
+    color: grey;
+    -webkit-mask: linear-gradient(-60deg, #000 30%, #0005, #000 70%) right/300%
+      100%;
+    background-repeat: no-repeat;
+    background: var(--title-gradient);
+    background: var(--shimmer);
+    z-index: 2;
+    animation: shimmer 1.5s infinite;
+}
+
+
+@keyframes loading {
+    0% {
+        transform: translateX(-150%);
+    }
+    50% {
+        transform: translateX(-60%);
+    }
+    100% {
+        transform: translateX(30%);
+    }
+}
+
+@keyframes shimmer {
+    100% {
+      -webkit-mask-position: left;
+    }
+  }

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
@@ -126,7 +126,6 @@ export default function CurrencyQuantity(props: propsIF) {
                 isLoading && styles.shimmer_wrapper
             }`}
         >
-            {/* <h1>{fieldId === 'sell' && isbuyLoading && 'loading'}{ fieldId}</h1> */}
             <input
                 id={`${fieldId}-quantity`}
                 autoFocus={fieldId === 'sell'}

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
@@ -138,7 +138,7 @@ export default function CurrencyQuantity(props: propsIF) {
                 onChange={(event) => {
                     handleOnChange(event);
                 }}
-                value={displayValue}
+                value={isLoading ? '' : displayValue}
                 type='text'
                 inputMode='decimal'
                 autoComplete='off'

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
@@ -60,39 +60,26 @@ export default function CurrencyQuantity(props: propsIF) {
     }, [debouncedLastEvent]);
 
     const handleEventLocal = (event: ChangeEvent<HTMLInputElement>) => {
-        // clear the previous timeout if it exists
-        if (timeoutId) {
-            clearTimeout(timeoutId);
-        }
-        if (event && fieldId === 'sell') {
+        if (timeoutId) clearTimeout(timeoutId);
+
+        const { value } = event.target;
+        const inputValue = value.startsWith('.') ? '0' + value : value;
+
+        if (fieldId === 'sell') {
             setIsBuyLoading(true);
             setBuyQtyString('');
-            const valueWithLeadingZero = event.target.value.startsWith('.')
-                ? '0' + event.target.value
-                : event.target.value;
-            setSellQtyString(valueWithLeadingZero);
+            setSellQtyString(inputValue);
 
-            timeoutId = setTimeout(() => {
-                setIsBuyLoading(false);
-            }, 1000);
-        } else if (event && fieldId === 'buy') {
+            timeoutId = setTimeout(() => setIsBuyLoading(false), 1000);
+        } else if (fieldId === 'buy') {
             setIsSellLoading(true);
             setSellQtyString('');
-            const valueWithLeadingZero = event.target.value.startsWith('.')
-                ? '0' + event.target.value
-                : event.target.value;
-            setBuyQtyString(valueWithLeadingZero);
-            timeoutId = setTimeout(() => {
-                setIsSellLoading(false);
-            }, 1000);
+            setBuyQtyString(inputValue);
+
+            timeoutId = setTimeout(() => setIsSellLoading(false), 1000);
         }
 
-        const input = event.target.value.startsWith('.')
-            ? '0' + event.target.value
-            : event.target.value;
-
-        setDisplayValue(input);
-
+        setDisplayValue(inputValue);
         setDisableReverseTokens(true);
         setLastEvent(event);
     };

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
@@ -18,6 +18,10 @@ interface propsIF {
     setBuyQtyString: Dispatch<SetStateAction<string>>;
     thisToken: TokenIF;
     setDisableReverseTokens: Dispatch<SetStateAction<boolean>>;
+
+    setIsSellLoading: Dispatch<SetStateAction<boolean>>;
+    setIsBuyLoading: Dispatch<SetStateAction<boolean>>;
+    isLoading: boolean;
 }
 
 export default function CurrencyQuantity(props: propsIF) {
@@ -30,7 +34,11 @@ export default function CurrencyQuantity(props: propsIF) {
         setSellQtyString,
         setBuyQtyString,
         setDisableReverseTokens,
+        setIsBuyLoading,
+        setIsSellLoading,
+        isLoading,
     } = props;
+    let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const [displayValue, setDisplayValue] = useState<string>('');
 
@@ -52,18 +60,31 @@ export default function CurrencyQuantity(props: propsIF) {
     }, [debouncedLastEvent]);
 
     const handleEventLocal = (event: ChangeEvent<HTMLInputElement>) => {
+        // clear the previous timeout if it exists
+        if (timeoutId) {
+            clearTimeout(timeoutId);
+        }
         if (event && fieldId === 'sell') {
+            setIsBuyLoading(true);
             setBuyQtyString('');
             const valueWithLeadingZero = event.target.value.startsWith('.')
                 ? '0' + event.target.value
                 : event.target.value;
             setSellQtyString(valueWithLeadingZero);
+
+            timeoutId = setTimeout(() => {
+                setIsBuyLoading(false);
+            }, 1000);
         } else if (event && fieldId === 'buy') {
+            setIsSellLoading(true);
             setSellQtyString('');
             const valueWithLeadingZero = event.target.value.startsWith('.')
                 ? '0' + event.target.value
                 : event.target.value;
             setBuyQtyString(valueWithLeadingZero);
+            timeoutId = setTimeout(() => {
+                setIsSellLoading(false);
+            }, 1000);
         }
 
         const input = event.target.value.startsWith('.')
@@ -113,12 +134,17 @@ export default function CurrencyQuantity(props: propsIF) {
 
     const ariaLive = fieldId === 'sell' ? 'polite' : 'off';
     return (
-        <div className={styles.token_amount}>
+        <div
+            className={`${styles.token_amount} ${
+                isLoading && styles.shimmer_wrapper
+            }`}
+        >
+            {/* <h1>{fieldId === 'sell' && isbuyLoading && 'loading'}{ fieldId}</h1> */}
             <input
                 id={`${fieldId}-quantity`}
                 autoFocus={fieldId === 'sell'}
                 className={styles.currency_quantity}
-                placeholder='0.0'
+                placeholder={isLoading ? '' : '0.0'}
                 tabIndex={0}
                 aria-live={ariaLive}
                 aria-label={`Enter ${fieldId} amount`}

--- a/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
+++ b/src/components/Swap/CurrencyQuantity/CurrencyQuantity.tsx
@@ -38,7 +38,7 @@ export default function CurrencyQuantity(props: propsIF) {
         setIsSellLoading,
         isLoading,
     } = props;
-    let timeoutId: ReturnType<typeof setTimeout> | null = null;
+    // let timeoutId: ReturnType<typeof setTimeout> | null = null;
 
     const [displayValue, setDisplayValue] = useState<string>('');
 
@@ -60,23 +60,27 @@ export default function CurrencyQuantity(props: propsIF) {
     }, [debouncedLastEvent]);
 
     const handleEventLocal = (event: ChangeEvent<HTMLInputElement>) => {
-        if (timeoutId) clearTimeout(timeoutId);
+        // if (timeoutId) clearTimeout(timeoutId);
 
         const { value } = event.target;
         const inputValue = value.startsWith('.') ? '0' + value : value;
 
         if (fieldId === 'sell') {
-            setIsBuyLoading(true);
             setBuyQtyString('');
-            setSellQtyString(inputValue);
+            if (inputValue) {
+                setIsBuyLoading(true);
+                setSellQtyString(inputValue);
+            }
 
-            timeoutId = setTimeout(() => setIsBuyLoading(false), 1000);
+            // timeoutId = setTimeout(() => setIsBuyLoading(false), 1000);
         } else if (fieldId === 'buy') {
-            setIsSellLoading(true);
             setSellQtyString('');
-            setBuyQtyString(inputValue);
+            if (inputValue) {
+                setIsSellLoading(true);
+                setBuyQtyString(inputValue);
+            }
 
-            timeoutId = setTimeout(() => setIsSellLoading(false), 1000);
+            // timeoutId = setTimeout(() => setIsSellLoading(false), 1000);
         }
 
         setDisplayValue(inputValue);

--- a/src/components/Swap/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.tsx
@@ -57,6 +57,8 @@ interface propsIF {
     tokenBSurplusPlusTokenBQtyNum: number;
     isWithdrawFromDexChecked: boolean;
     setIsWithdrawFromDexChecked: Dispatch<SetStateAction<boolean>>;
+    setIsSellLoading: Dispatch<SetStateAction<boolean>>;
+    setIsBuyLoading: Dispatch<SetStateAction<boolean>>;
     isSaveAsDexSurplusChecked: boolean;
     setIsSaveAsDexSurplusChecked: Dispatch<SetStateAction<boolean>>;
     handleChangeEvent: (evt: ChangeEvent<HTMLInputElement>) => void;
@@ -91,6 +93,7 @@ interface propsIF {
     setUserOverrodeSurplusWithdrawalDefault: Dispatch<SetStateAction<boolean>>;
     setUserClickedCombinedMax: Dispatch<SetStateAction<boolean>>;
     userClickedCombinedMax: boolean;
+    isLoading: boolean;
 }
 
 export default function CurrencySelector(props: propsIF) {
@@ -136,6 +139,9 @@ export default function CurrencySelector(props: propsIF) {
         setUserOverrodeSurplusWithdrawalDefault,
         setUserClickedCombinedMax,
         userClickedCombinedMax,
+        setIsSellLoading,
+        setIsBuyLoading,
+        isLoading,
     } = props;
 
     const isSellTokenSelector = fieldId === 'sell';
@@ -569,6 +575,9 @@ export default function CurrencySelector(props: propsIF) {
                         fieldId={fieldId}
                         handleChangeEvent={handleChangeEvent}
                         setDisableReverseTokens={setDisableReverseTokens}
+                        setIsSellLoading={setIsSellLoading}
+                        setIsBuyLoading={setIsBuyLoading}
+                        isLoading={isLoading}
                     />
                 </div>
                 <button


### PR DESCRIPTION
### Describe your changes 
Add loading attributes to currency quantities when calculating price
Refactor handleEventLocal function to trigger loading
Cleanup handleEventLocal function.
_Describe the purpose + content of these changes_
To test: Simply enter an amount in either the sell or buy qty and there should be a loading shimmer while the price is being calculated.
PS: this isn't how it will look or function in the deploy preview. It is just impossible to trigger that animation and capture the screenshot at the same time.


<img width="709" alt="image" src="https://user-images.githubusercontent.com/83131501/236288169-e85f3ed7-8877-4064-89ab-58f64f33405f.png">

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
