### PR TITLE
refactor item length being passed to pagination component

### DIFF
--- a/src/components/Global/Pagination/Pagination.tsx
+++ b/src/components/Global/Pagination/Pagination.tsx
@@ -158,13 +158,7 @@ export default function Pagination(props: PaginationPropsIF) {
                             </li>
                         ))}
                     </div>
-                    {/* {expandPaginationContainer && (
-                        <div className={styles.dot}>
-                            <BiDotsHorizontal />
-                        </div>
-                    )} */}
 
-                    {/* {expandPaginationContainer && currentPage !== totalPages && lastPageClick} */}
                     {currentPage !== totalPages && rightButton}
                 </motion.div>
             </nav>

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -367,7 +367,11 @@ export default function Orders(props: propsIF) {
                 (!isAccountView && tradePageCheck)) && (
                 <Pagination
                     itemsPerPage={limitsPerPage}
-                    totalItems={limitOrderData.length}
+                    totalItems={
+                        limitOrderData.filter(
+                            (limitOrder) => limitOrder.totalValueUSD !== 0,
+                        ).length
+                    }
                     paginate={paginate}
                     currentPage={currentPage}
                 />


### PR DESCRIPTION
### Describe your changes 
An issue was identified with the pagination functionality within the table component. Specifically, the pagination was displaying inaccurate item counts. For instance, the pagination would indicate that it was showing 1-7 of 7 items, even when only 6 items were being rendered.

Initially, it was suspected that the pagination logic was flawed. However, a thorough investigation revealed that the root cause was a discrepancy between the content being rendered and the content being passed to the pagination component.

To ensure that the table was not displaying empty orders, we implemented a filter. Regrettably, this filter was not being applied to the pagination component, which was accepting the entire dataset, including empty positions.

To address the issue, we modified the pagination component to exclude empty positions, thereby correcting the item count discrepancies.
_Describe the purpose + content of these changes_
<img width="760" alt="image" src="https://user-images.githubusercontent.com/83131501/236540130-aaf4694b-972b-4f0b-a153-c80e439e7863.png">

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
