### PR TITLE
remove non-wagmi retrieval of connected user's ens name

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -95,7 +95,6 @@ import {
     setAdvancedMode,
 } from '../utils/state/tradeDataSlice';
 import { memoizeQuerySpotPrice } from './functions/querySpotPrice';
-import { memoizeFetchAddress } from './functions/fetchAddress';
 import {
     memoizeFetchErc20TokenBalances,
     memoizeFetchNativeTokenBalance,
@@ -107,8 +106,6 @@ import {
     resetUserAddresses,
     setAddressAtLogin,
     setAddressCurrent,
-    setEnsNameCurrent,
-    setEnsOrAddressTruncated,
     setErc20Tokens,
     setIsLoggedIn,
     setIsUserIdle,
@@ -142,7 +139,6 @@ import { fetchUserRecentChanges } from './functions/fetchUserRecentChanges';
 import { getTransactionData } from './functions/getTransactionData';
 import AppOverlay from '../components/Global/AppOverlay/AppOverlay';
 import { getLiquidityFee } from './functions/getLiquidityFee';
-import trimString from '../utils/functions/trimString';
 import { useToken } from './hooks/useToken';
 import { useSidebar } from './hooks/useSidebar';
 import useDebounce from './hooks/useDebounce';
@@ -190,7 +186,6 @@ import { useSnackbar } from '../components/Global/SnackbarComponent/useSnackbar'
 import { RangeStateContext } from '../contexts/RangeStateContext';
 import { CandleContext } from '../contexts/CandleContext';
 
-const cachedFetchAddress = memoizeFetchAddress();
 const cachedFetchNativeTokenBalance = memoizeFetchNativeTokenBalance();
 const cachedFetchErc20TokenBalances = memoizeFetchErc20TokenBalances();
 const cachedFetchTokenPrice = memoizeTokenPrice();
@@ -792,56 +787,6 @@ export default function App() {
             );
         }
     }, [lastReceiptHash]);
-
-    const ensName = userData.ensNameCurrent || '';
-
-    // check for ENS name account changes
-    useEffect(() => {
-        (async () => {
-            if (isUserLoggedIn && account && provider) {
-                IS_LOCAL_ENV && console.debug('checking for ens name');
-                try {
-                    const ensName = await cachedFetchAddress(
-                        provider,
-                        account,
-                        chainData.chainId,
-                    );
-                    if (ensName) {
-                        // setEnsName(ensName);
-                        dispatch(setEnsNameCurrent(ensName));
-                        if (ensName.length > 15) {
-                            dispatch(
-                                setEnsOrAddressTruncated(
-                                    trimString(ensName, 10, 3, '…'),
-                                ),
-                            );
-                        } else {
-                            dispatch(setEnsOrAddressTruncated(ensName));
-                        }
-                    } else {
-                        dispatch(setEnsNameCurrent(undefined));
-                        // setEnsName('');
-
-                        dispatch(
-                            setEnsOrAddressTruncated(
-                                trimString(account, 5, 3, '…'),
-                            ),
-                        );
-                    }
-                } catch (error) {
-                    dispatch(setEnsNameCurrent(undefined));
-                    // setEnsName('');
-                    dispatch(
-                        setEnsOrAddressTruncated(
-                            trimString(account, 5, 3, '…'),
-                        ),
-                    );
-                }
-            } else if (!isUserLoggedIn || !account) {
-                dispatch(setEnsOrAddressTruncated(undefined));
-            }
-        })();
-    }, [isUserLoggedIn, account, chainData.chainId]);
 
     // const everySecondBlock = useMemo(() => Math.floor(lastBlockNumber / 2), [lastBlockNumber]);
     const everyEigthBlock = useMemo(
@@ -2829,7 +2774,6 @@ export default function App() {
     const headerProps = {
         isUserLoggedIn: isUserLoggedIn,
         clickLogout: clickLogout,
-        ensName: ensName,
         shouldDisplayAccountTab: shouldDisplayAccountTab,
         chainId: chainData.chainId,
         isChainSupported: isChainSupported,
@@ -3310,7 +3254,6 @@ export default function App() {
         cachedFetchErc20TokenBalances,
         cachedFetchNativeTokenBalance,
         cachedFetchTokenPrice,
-        ensName,
         lastBlockNumber,
         connectedAccount: account ? account : '',
         chainId: chainData.chainId,
@@ -3362,7 +3305,6 @@ export default function App() {
         },
         currentPool: currentPoolInfo,
         isFullScreen: true,
-        username: ensName,
         appPage: true,
         topPools: topPools,
     };

--- a/src/App/components/PageHeader/Account/Account.tsx
+++ b/src/App/components/PageHeader/Account/Account.tsx
@@ -12,8 +12,8 @@ import { DefaultTooltip } from '../../../../components/Global/StyledTooltip/Styl
 import { ChainSpec } from '@crocswap-libs/sdk';
 import WalletDropdown from './WalletDropdown/WalletDropdown';
 import useKeyPress from '../../../hooks/useKeyPress';
-import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import { AppStateContext } from '../../../../contexts/AppStateContext';
+import trimString from '../../../../utils/functions/trimString';
 
 interface AccountPropsIF {
     isUserLoggedIn: boolean | undefined;
@@ -54,10 +54,6 @@ export default function Account(props: AccountPropsIF) {
     } = useContext(AppStateContext);
     const { connector, isConnected } = useAccount();
 
-    const ensOrAddressTruncated = useAppSelector(
-        (state) => state.userData.ensOrAddressTruncated,
-    );
-
     const isUserLoggedIn = isConnected;
 
     const [_, copy] = useCopyToClipboard();
@@ -66,6 +62,10 @@ export default function Account(props: AccountPropsIF) {
         copy(props.accountAddressFull);
         openSnackbar(`${props.accountAddressFull} copied`, 'info');
     }
+
+    const connectedEnsOrAddressTruncated = ensName
+        ? trimString(ensName, 10, 3, '…')
+        : trimString(props.accountAddressFull, 5, 3, '…');
 
     const [openNavbarMenu, setOpenNavbarMenu] = useState(false);
     const [showWalletDropdown, setShowWalletDropdown] = useState(false);
@@ -136,7 +136,7 @@ export default function Account(props: AccountPropsIF) {
             >
                 <MdAccountBalanceWallet color='var(--text1)' />
                 <p className={styles.wallet_name}>
-                    {ensOrAddressTruncated || '...'}
+                    {connectedEnsOrAddressTruncated || '...'}
                 </p>
             </button>
             {showWalletDropdown ? (

--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -24,7 +24,6 @@ import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 interface HeaderPropsIF {
     isUserLoggedIn: boolean | undefined;
     clickLogout: () => void;
-    ensName: string;
     shouldDisplayAccountTab: boolean | undefined;
     chainId: string;
     isChainSupported: boolean;

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -65,7 +65,6 @@ interface propsIF {
     cachedFetchErc20TokenBalances: Erc20TokenBalanceFn;
     cachedPositionUpdateQuery: PositionUpdateFn;
     cachedFetchTokenPrice: TokenPriceFn;
-    ensName: string;
     lastBlockNumber: number;
     connectedAccount: string;
     chainId: string;


### PR DESCRIPTION
### Describe your changes 

The fetching of the connected user's ENS name from App.tsx and saving in RTK was redundant with the availability of the user's ENS name from Wagmi's useEnsName() hook.



### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
