### PR TITLE
fix tooltip appearing in search bug

### DIFF
--- a/src/App/components/Sidebar/Sidebar.tsx
+++ b/src/App/components/Sidebar/Sidebar.tsx
@@ -353,7 +353,7 @@ export default function Sidebar(props: propsIF) {
         <button
             onClick={() => {
                 setIsDefaultOverridden(true);
-                if (sidebar.status === 'closed') {
+                if (!sidebar.isOpen) {
                     sidebar.open();
                 }
                 setOpenAllDefault(true);
@@ -361,7 +361,7 @@ export default function Sidebar(props: propsIF) {
             className={styles.open_all_button}
         >
             <BsChevronBarDown size={18} color='var(--text2)' />{' '}
-            {!sidebar.isOpen || !openAllDefault ? 'Expand All' : 'Collapse All'}
+            {openAllDefault ? 'Collapse All' : 'Expand All'}
         </button>
     );
 
@@ -404,20 +404,11 @@ export default function Sidebar(props: propsIF) {
                     </div>
                 </DefaultTooltip>
             ) : (
-                <DefaultTooltip
-                    interactive
-                    title={openAllButton}
-                    placement={sidebar.isOpen ? 'bottom' : 'right'}
-                    arrow
-                    enterDelay={100}
-                    leaveDelay={200}
-                >
-                    <BiSearch
-                        size={18}
-                        color='#CDC1FF'
-                        onClick={() => sidebar.open(true)}
-                    />
-                </DefaultTooltip>
+                <BiSearch
+                    size={18}
+                    color='#CDC1FF'
+                    onClick={() => sidebar.open(true)}
+                />
             )}
         </div>
     );


### PR DESCRIPTION
### Describe your changes 
When the sidebar goes from collapse to open after the user clicks the expand button, the "Expand All" tool tip remains open and covers the search box for about 10 seconds:
This PR should fix that.
_Describe the purpose + content of these changes_
### Link the related issue
https://github.com/CrocSwap/ambient-ts-app/issues/2111

_Closes #2111 _

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
