### PR TITLE
bug fix: range table not cleared when token pair changes

### DIFF
--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -227,7 +227,7 @@ function Ranges(props: propsIF) {
         setRangeData([]);
         dispatch(
             setPositionsByPool({
-                dataReceived: true,
+                dataReceived: false,
                 positions: [],
             }),
         );


### PR DESCRIPTION
### Describe your changes 

The set of data used to create the sorted Ranges table was not getting cleared when the user switches token pairs.

A future enhancement should clean up the logic that memoizes, filters and sorts the ranges data.

### Link the related issue

Closes #2180

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
