### PR TITLE
fix portfolio page footer from sticking to bottom

### DIFF
--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -529,6 +529,8 @@ function Orders(props: propsIF) {
         ? 'calc(100vh - 19.5rem)'
         : expandStyle;
 
+    const portfolioPageFooter = props.isOnPortfolioPage ? '1rem 0' : '';
+
     return (
         <section
             className={`${styles.main_list_container} ${
@@ -546,7 +548,7 @@ function Orders(props: propsIF) {
                 )}
             </div>
 
-            <div>{footerDisplay}</div>
+            <div style={{ margin: portfolioPageFooter }}>{footerDisplay}</div>
         </section>
     );
 }

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -619,6 +619,8 @@ function Ranges(props: propsIF) {
         />
     );
 
+    const portfolioPageFooter = props.isOnPortfolioPage ? '1rem 0' : '';
+
     return (
         <section
             className={`${styles.main_list_container} ${
@@ -636,7 +638,7 @@ function Ranges(props: propsIF) {
                 )}
             </div>
 
-            <div>{footerDisplay}</div>
+            <div style={{ margin: portfolioPageFooter }}>{footerDisplay}</div>
         </section>
     );
 }

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -562,6 +562,7 @@ function Transactions(props: propsIF) {
     const portfolioPageStyle = props.isOnPortfolioPage
         ? 'calc(100vh - 19.5rem)'
         : expandStyle;
+    const portfolioPageFooter = props.isOnPortfolioPage ? '1rem 0' : '';
 
     return (
         <section
@@ -580,7 +581,7 @@ function Transactions(props: propsIF) {
                 )}
             </div>
 
-            <div>{footerDisplay}</div>
+            <div style={{ margin: portfolioPageFooter }}>{footerDisplay}</div>
         </section>
     );
 }


### PR DESCRIPTION
### Describe your changes 
There is a problem with the footer sticking all the way to the bottom of the trade. This PR should fix it.
Before:
<img width="1060" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/b4c48e7c-470a-4a7b-843d-f4b0cf8ce0b9">
After:
<img width="1054" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/2972c3bf-4c36-4266-8e83-26cb9e13d594">

_Describe the purpose + content of these changes_
### Link the related issue

Closes #2216

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
