### PR TITLE
Fix browser OOM crash related to switching tokens

### DIFF
--- a/src/components/Global/Pagination/RowsPerPageDropdown.tsx
+++ b/src/components/Global/Pagination/RowsPerPageDropdown.tsx
@@ -23,11 +23,19 @@ export const RowsPerPageDropdown = ({
     setCurrentPage: Dispatch<SetStateAction<number>>;
 }) => {
     const generateOptions = (count: number) => {
+        if (count < 1) {
+            return [5, 10, 25, 50, 100];
+        }
+
         const maxOptions = 10;
         const increment = Math.ceil(count / maxOptions / 5) * 5;
         const options = [];
 
-        for (let i = increment; i <= count; i += increment) {
+        for (
+            let i = increment;
+            i <= count && options.length < maxOptions;
+            i += increment
+        ) {
             options.push(i);
         }
 


### PR DESCRIPTION
The pagination logic had a bug where if empty rows were processed processed by the `RowsPerPageDropdown` it would result in the browser crashing. This was caused by an infinite loop in the options array generator. This patches the infinite loop and returns sensible defaults when there are 0 items in the row set.