### PR TITLE
Fix height of headers in range table

### DIFF
--- a/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.module.css
@@ -40,10 +40,16 @@
 
 .header {
     position: sticky;
-    height: 50px;
     top: 0; /* Don't forget this, required for the stickiness */
     box-shadow: 0 2px 2px -1px rgba(0, 0, 0, 0.4);
 }
+
+@media (max-width: 1900px) {
+    .header {
+        height: 50px;
+    }
+}
+
 
 .table_content {
     flex-grow: 1; /* Allow the content to grow and occupy remaining space */

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangeHeader.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangeHeader.tsx
@@ -2,6 +2,7 @@ import { Dispatch, memo, SetStateAction, useMemo } from 'react';
 import { BsSortDown, BsSortUpAlt } from 'react-icons/bs';
 import { IS_LOCAL_ENV } from '../../../../../constants';
 import styles from '../Ranges.module.css';
+import { useMediaQuery } from '@material-ui/core';
 interface RangeHeaderPropsIF {
     header: {
         name: string | JSX.Element;
@@ -65,6 +66,10 @@ function RangeHeader(props: RangeHeaderPropsIF) {
     const activeSortStyle =
         sortBy === slug.toLocaleLowerCase() && sortable ? 'active_sort' : '';
 
+    const fixedHeight = useMediaQuery('(max-width: 1900px)')
+        ? { height: 24 }
+        : {};
+
     return (
         <>
             {show && (
@@ -77,7 +82,7 @@ function RangeHeader(props: RangeHeaderPropsIF) {
                     ${alignCenter && styles.align_center}
                     `}
                 >
-                    <p style={{ height: 24 }}>
+                    <p style={fixedHeight}>
                         {name} {arrow}
                     </p>
                 </li>


### PR DESCRIPTION
### Describe your changes 

- Fixes the height of header columns
- Fixes the height of the ID/Wallet combined column since its sort icon appears vertically below pushing the text above

<img width="1535" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/45405267/575b3db8-081d-454e-934f-96f05e906997">

### Link the related issue

_Closes #2218

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
