### PR TITLE
fix limit order reversal when triggered from chart

### DIFF
--- a/src/components/Trade/Limit/LimitCurrencyConverter/LimitCurrencyConverter.tsx
+++ b/src/components/Trade/Limit/LimitCurrencyConverter/LimitCurrencyConverter.tsx
@@ -255,8 +255,8 @@ function LimitCurrencyConverter(props: propsIF) {
 
     useEffect(() => {
         if (tradeData.shouldLimitDirectionReverse) {
-            reverseTokens();
             setIsTokenAPrimaryLocal((state) => {
+                reverseTokens();
                 return !state;
             });
         }


### PR DESCRIPTION
### Describe your changes 

This change appears to have broken limit order reversal when triggered from the chart (dragging the limit line the side opposite of the current pool price): 

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/a1b68dd5-d42c-4be2-9df1-40b2ce839bf8)

### Link the related issue

Closes #2237

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
