### PR TITLE
remove character limit on sidebar search input

### DIFF
--- a/src/App/components/Sidebar/Sidebar.tsx
+++ b/src/App/components/Sidebar/Sidebar.tsx
@@ -315,7 +315,6 @@ function Sidebar(props: propsIF) {
                 id='search_input'
                 ref={searchInputRef}
                 placeholder='Search...'
-                maxLength={40}
                 className={styles.search__box}
                 onChange={(e) => handleSearchInput(e)}
                 spellCheck='false'


### PR DESCRIPTION
### Describe your changes 
The sidebar search input has an arbitrary character limit which prevents a user from entering a full 42-digit contract address. I removed the character limit.

### Link the related issue
Closes #2023

### Checklist before requesting a review
- [x] I have performed a self-review of my code.
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
