### PR TITLE
Fix reposition button spill by increasing screen size at which range menu buttons collapse

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -226,7 +226,7 @@ export default function RangesMenu(props: propsIF) {
     const view1 = useMediaQuery('(min-width: 720px)');
     const view2 = sidebar.isOpen
         ? useMediaQuery('(min-width: 1750px)')
-        : useMediaQuery('(min-width: 1500px)');
+        : useMediaQuery('(min-width: 1550px)');
     const view3 = useMediaQuery('(min-width: 2300px)');
 
     const showRepositionButton =


### PR DESCRIPTION
### Describe your changes 

- Increased screen size limit till where the range menu is collapsed to showing just one button

https://github.com/CrocSwap/ambient-ts-app/assets/45405267/d8bf1c1f-9e38-405b-be3a-d7bc58b5f473


### Link the related issue

_Closes #2214 

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
