### PR TITLE
wait until user completes typing range boundary prices to update chart

### DIFF
--- a/src/components/Trade/Range/AdvancedModeComponents/MinMaxPrice/MinMaxPrice.tsx
+++ b/src/components/Trade/Range/AdvancedModeComponents/MinMaxPrice/MinMaxPrice.tsx
@@ -156,12 +156,13 @@ function MinMaxPrice(props: MinMaxPriceIF) {
                     fieldId='min'
                     title='Min Price'
                     percentageDifference={minPricePercentage}
-                    handleChangeEvent={
+                    handleChangeEvent={() => undefined}
+                    onBlur={(event) => {
                         !isDenomBase
-                            ? handleMaxPriceChangeEvent
-                            : handleMinPriceChangeEvent
-                    }
-                    onBlur={lowBoundOnBlur}
+                            ? handleMaxPriceChangeEvent(event)
+                            : handleMinPriceChangeEvent(event);
+                        lowBoundOnBlur();
+                    }}
                     increaseTick={
                         !isDenomBase ? increaseLowTick : decreaseHighTick
                     }
@@ -173,12 +174,13 @@ function MinMaxPrice(props: MinMaxPriceIF) {
                     fieldId='max'
                     title='Max Price'
                     percentageDifference={maxPricePercentage}
-                    handleChangeEvent={
+                    handleChangeEvent={() => undefined}
+                    onBlur={(event) => {
                         !isDenomBase
-                            ? handleMinPriceChangeEvent
-                            : handleMaxPriceChangeEvent
-                    }
-                    onBlur={highBoundOnBlur}
+                            ? handleMinPriceChangeEvent(event)
+                            : handleMaxPriceChangeEvent(event);
+                        highBoundOnBlur();
+                    }}
                     increaseTick={
                         !isDenomBase ? increaseHighTick : decreaseLowTick
                     }

--- a/src/components/Trade/Range/AdvancedModeComponents/PriceInput/PriceInput.tsx
+++ b/src/components/Trade/Range/AdvancedModeComponents/PriceInput/PriceInput.tsx
@@ -1,6 +1,6 @@
 import styles from './PriceInput.module.css';
 import { FaMinus, FaPlus } from 'react-icons/fa';
-import { ChangeEvent, memo, useContext } from 'react';
+import { ChangeEvent, FocusEventHandler, memo, useContext } from 'react';
 import { TradeTableContext } from '../../../../../contexts/TradeTableContext';
 
 interface priceInputProps {
@@ -10,7 +10,7 @@ interface priceInputProps {
     percentageDifference: number;
     handleChangeEvent: (evt: ChangeEvent<HTMLInputElement>) => void;
     // onFocus: () => void;
-    onBlur: () => void;
+    onBlur: FocusEventHandler<HTMLInputElement>;
     increaseTick: () => void;
     decreaseTick: () => void;
 }
@@ -34,7 +34,7 @@ function PriceInput(props: priceInputProps) {
             className={styles.price_quantity}
             type='text'
             onChange={(event) => handleChangeEvent(event)}
-            onBlur={() => onBlur()}
+            onBlur={onBlur}
             inputMode='decimal'
             autoComplete='off'
             autoCorrect='off'


### PR DESCRIPTION
### Describe your changes 

fix bug where chart updates as user is typing range boundaries in advanced mode.

### Link the related issue

Closes #2260

### Checklist before requesting a review
- [ ] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
