### PR TITLE
add temporary offset to tx details graph start boundary

### DIFF
--- a/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.css
+++ b/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.css
@@ -6,7 +6,7 @@
 }
 
 .transaction_details_graph_placeholder {
-    background: url(../../../../assets/images/home/shot4Low.jpg) no-repeat;
+    background: none no-repeat;
     background-position: center 90%;
     -webkit-background-size: cover;
     -moz-background-size: cover;

--- a/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsGraph/TransactionDetailsGraph.tsx
@@ -160,9 +160,11 @@ export default function TransactionDetailsGraph(
                             ? calcNumberCandlesNeeded
                             : maxNumCandlesNeeded;
 
-                    const startBoundary = Math.floor(
-                        new Date().getTime() / 1000,
-                    );
+                    const offsetInSeconds = 120;
+
+                    const startBoundary =
+                        Math.floor(new Date().getTime() / 1000) -
+                        offsetInSeconds;
 
                     try {
                         const graphData = await fetchGraphData(


### PR DESCRIPTION
### Describe your changes 

this is intended to be a stopgap solution to an issue being experienced by Miyuki.

The startBoundary, as calculated by Miyuki's computer, is somehow a minute or so in the future, resulting in a rejected request for tx details candles. 

This PR adds an offset by 2 minutes.


### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
