### PR TITLE
move memoization of token price query to higher component in portfolio

### DIFF
--- a/src/components/Global/Account/AccountTabs/Exchange/Exchange.tsx
+++ b/src/components/Global/Account/AccountTabs/Exchange/Exchange.tsx
@@ -5,16 +5,23 @@ import { TokenIF } from '../../../../../utils/interfaces/exports';
 import { tokenMethodsIF } from '../../../../../App/hooks/useTokens';
 import Spinner from '../../../Spinner/Spinner';
 import { useAppSelector } from '../../../../../utils/hooks/reduxToolkit';
+import { TokenPriceFn } from '../../../../../App/functions/fetchTokenPrice';
 
 interface propsIF {
     resolvedAddressTokens: (TokenIF | undefined)[];
     resolvedAddress: string;
     connectedAccountActive: boolean;
     tokens: tokenMethodsIF;
+    cachedFetchTokenPrice: TokenPriceFn;
 }
 
 export default function Exchange(props: propsIF) {
-    const { connectedAccountActive, resolvedAddressTokens, tokens } = props;
+    const {
+        connectedAccountActive,
+        resolvedAddressTokens,
+        tokens,
+        cachedFetchTokenPrice,
+    } = props;
 
     const { nativeToken, erc20Tokens } = useAppSelector(
         (state) => state.userData.tokens,
@@ -26,14 +33,24 @@ export default function Exchange(props: propsIF) {
     const ItemContent = connectedAccountActive ? (
         connectedUserTokens && connectedUserTokens.length > 0 ? (
             connectedUserTokens.map((item, idx) => (
-                <ExchangeCard key={idx} token={item} tokens={tokens} />
+                <ExchangeCard
+                    key={idx}
+                    token={item}
+                    tokens={tokens}
+                    cachedFetchTokenPrice={cachedFetchTokenPrice}
+                />
             ))
         ) : (
             <Spinner size={100} bg='var(--dark1)' centered />
         )
     ) : resolvedAddressTokens && resolvedAddressTokens[0] ? (
         resolvedAddressTokens.map((item, idx) => (
-            <ExchangeCard key={idx} token={item} tokens={tokens} />
+            <ExchangeCard
+                key={idx}
+                token={item}
+                tokens={tokens}
+                cachedFetchTokenPrice={cachedFetchTokenPrice}
+            />
         ))
     ) : (
         <Spinner size={100} bg='var(--dark1)' centered />

--- a/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
+++ b/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
@@ -5,22 +5,21 @@ import { useContext, useEffect, useState } from 'react';
 import { ZERO_ADDRESS } from '../../../../../constants';
 import { DefaultTooltip } from '../../../StyledTooltip/StyledTooltip';
 import { tokenMethodsIF } from '../../../../../App/hooks/useTokens';
-import { memoizeTokenPrice } from '../../../../../App/functions/fetchTokenPrice';
 import { CrocEnvContext } from '../../../../../contexts/CrocEnvContext';
+import { TokenPriceFn } from '../../../../../App/functions/fetchTokenPrice';
 
 interface propsIF {
     token?: TokenIF;
     tokens: tokenMethodsIF;
+    cachedFetchTokenPrice: TokenPriceFn;
 }
 
 export default function ExchangeCard(props: propsIF) {
-    const { token, tokens } = props;
+    const { token, tokens, cachedFetchTokenPrice } = props;
 
     const {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
-
-    const cachedFetchTokenPrice = memoizeTokenPrice();
 
     const tokenMapKey: string = token?.address + '_' + chainId;
 

--- a/src/components/Global/Account/AccountTabs/Wallet/Wallet.tsx
+++ b/src/components/Global/Account/AccountTabs/Wallet/Wallet.tsx
@@ -5,16 +5,23 @@ import { TokenIF } from '../../../../../utils/interfaces/exports';
 import { tokenMethodsIF } from '../../../../../App/hooks/useTokens';
 import { useAppSelector } from '../../../../../utils/hooks/reduxToolkit';
 import Spinner from '../../../Spinner/Spinner';
+import { TokenPriceFn } from '../../../../../App/functions/fetchTokenPrice';
 
 interface propsIF {
     resolvedAddressTokens: (TokenIF | undefined)[];
     resolvedAddress: string;
     connectedAccountActive: boolean;
     tokens: tokenMethodsIF;
+    cachedFetchTokenPrice: TokenPriceFn;
 }
 
 export default function Wallet(props: propsIF) {
-    const { connectedAccountActive, resolvedAddressTokens, tokens } = props;
+    const {
+        connectedAccountActive,
+        resolvedAddressTokens,
+        tokens,
+        cachedFetchTokenPrice,
+    } = props;
 
     const { nativeToken, erc20Tokens } = useAppSelector(
         (state) => state.userData.tokens,
@@ -45,6 +52,7 @@ export default function Wallet(props: propsIF) {
                             key={JSON.stringify(token)}
                             token={token}
                             tokens={tokens}
+                            cachedFetchTokenPrice={cachedFetchTokenPrice}
                         />
                     ))
                 ) : (

--- a/src/components/Global/Account/AccountTabs/Wallet/WalletCard.tsx
+++ b/src/components/Global/Account/AccountTabs/Wallet/WalletCard.tsx
@@ -6,20 +6,19 @@ import { ZERO_ADDRESS } from '../../../../../constants';
 import { DefaultTooltip } from '../../../StyledTooltip/StyledTooltip';
 import { CrocEnvContext } from '../../../../../contexts/CrocEnvContext';
 import { tokenMethodsIF } from '../../../../../App/hooks/useTokens';
-import { memoizeTokenPrice } from '../../../../../App/functions/fetchTokenPrice';
+import { TokenPriceFn } from '../../../../../App/functions/fetchTokenPrice';
 
 interface propsIF {
     token?: TokenIF;
     tokens: tokenMethodsIF;
+    cachedFetchTokenPrice: TokenPriceFn;
 }
 
 export default function WalletCard(props: propsIF) {
-    const { token, tokens } = props;
+    const { token, tokens, cachedFetchTokenPrice } = props;
     const {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
-
-    const cachedFetchTokenPrice = memoizeTokenPrice();
 
     const tokenAddress = token?.address?.toLowerCase() + '_' + chainId;
 

--- a/src/components/Portfolio/PortfolioTabs/PortfolioTabs.tsx
+++ b/src/components/Portfolio/PortfolioTabs/PortfolioTabs.tsx
@@ -41,6 +41,7 @@ import { GRAPHCACHE_URL, IS_LOCAL_ENV } from '../../../constants';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
 import { ChainDataContext } from '../../../contexts/ChainDataContext';
 import { tokenMethodsIF } from '../../../App/hooks/useTokens';
+import { memoizeTokenPrice } from '../../../App/functions/fetchTokenPrice';
 
 // interface for React functional component props
 interface propsIF {
@@ -51,6 +52,8 @@ interface propsIF {
     fullLayoutToggle: JSX.Element;
     tokens: tokenMethodsIF;
 }
+
+const cachedFetchTokenPrice = memoizeTokenPrice();
 
 // React functional component
 export default function PortfolioTabs(props: propsIF) {
@@ -272,6 +275,7 @@ export default function PortfolioTabs(props: propsIF) {
         connectedAccountActive: connectedAccountActive,
         resolvedAddress: resolvedAddress,
         tokens: tokens,
+        cachedFetchTokenPrice: cachedFetchTokenPrice,
     };
 
     // props for <Exchange/> React Element
@@ -281,6 +285,7 @@ export default function PortfolioTabs(props: propsIF) {
         resolvedAddress: resolvedAddress,
         openTokenModal: openTokenModal,
         tokens: tokens,
+        cachedFetchTokenPrice: cachedFetchTokenPrice,
     };
 
     // props for <Range/> React Element


### PR DESCRIPTION
### Describe your changes 

The query to retrieve the USD equivalent of a particular token balance was getting repeated for each token displayed in the portfolio's wallet and exchange balance section.  

This was fixed by moving the memoized function up to the PortfolioTabs component.

https://github.com/CrocSwap/ambient-ts-app/assets/570819/c9bf2539-256e-4650-ac95-bb6b237d81e6


### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
