### PR TITLE
bug fix: lopsided spinner animations

### DIFF
--- a/src/components/Swap/SwapButton/BypassConfirmSwapButton.tsx
+++ b/src/components/Swap/SwapButton/BypassConfirmSwapButton.tsx
@@ -153,8 +153,8 @@ export default function BypassConfirmSwapButton(props: propsIF) {
                     onClick={() => setShowExtraInfo(!showExtraInfo)}
                 >
                     <div style={{ color: buttonColor }}>
-                        {animationDisplay}
-                        {buttonText}
+                        <div style={{ width: '35px' }}>{animationDisplay}</div>
+                        <div>{buttonText}</div>
                     </div>
                     {showExtraInfo ? (
                         <RiArrowUpSLine size={20} />

--- a/src/components/Trade/Limit/LimitButton/BypassLimitButton.tsx
+++ b/src/components/Trade/Limit/LimitButton/BypassLimitButton.tsx
@@ -158,8 +158,8 @@ function BypassLimitButton(props: propsIF) {
                     onClick={() => setShowExtraInfo(!showExtraInfo)}
                 >
                     <div style={{ color: buttonColor }}>
-                        {animationDisplay}
-                        {buttonText}
+                        <div style={{ width: '35px' }}>{animationDisplay}</div>
+                        <div>{buttonText}</div>
                     </div>
                     {showExtraInfo ? (
                         <RiArrowUpSLine size={20} />

--- a/src/components/Trade/Range/RangeButton/BypassConfirmRangeButton.tsx
+++ b/src/components/Trade/Range/RangeButton/BypassConfirmRangeButton.tsx
@@ -154,8 +154,8 @@ export default function BypassConfirmRangeButton(props: propsIF) {
                     onClick={() => setShowExtraInfo(!showExtraInfo)}
                 >
                     <div style={{ color: buttonColor }}>
-                        {animationDisplay}
-                        {buttonText}
+                        <div style={{ width: '35px' }}>{animationDisplay}</div>
+                        <div>{buttonText}</div>
                     </div>
                     {showExtraInfo ? (
                         <RiArrowUpSLine size={20} />


### PR DESCRIPTION

### Describe your changes 

The circular animations displayed to the user after choosing to bypass confirmations and subsequently submitting a limit order or range order appear lopsided. 

### Link the related issue

Closes #2302

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [x] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
