### PR TITLE
default all modules to curve liquidity mode

### DIFF
--- a/src/pages/Trade/TradeCharts/TradeCharts.tsx
+++ b/src/pages/Trade/TradeCharts/TradeCharts.tsx
@@ -123,13 +123,10 @@ function TradeCharts(props: propsIF) {
             showFeeRate,
             showTvl,
             showVolume,
-            liqMode: isMarketOrLimitModule
-                ? chartSettings.marketOverlay.overlay
-                : chartSettings.rangeOverlay.overlay,
+            liqMode: chartSettings.rangeOverlay.overlay,
         };
     }, [
         isMarketOrLimitModule,
-        chartSettings.marketOverlay,
         chartSettings.rangeOverlay,
         showTvl,
         showVolume,
@@ -252,13 +249,7 @@ function TradeCharts(props: propsIF) {
                 }}
                 id='trade_charts_curve_depth'
             >
-                <CurveDepth
-                    overlayMethods={
-                        isMarketOrLimitModule
-                            ? chartSettings.marketOverlay
-                            : chartSettings.rangeOverlay
-                    }
-                />
+                <CurveDepth overlayMethods={chartSettings.rangeOverlay} />
             </div>
         </div>
     );


### PR DESCRIPTION
### Describe your changes 

We were defaulting to different liquidity modes for different modules, i.e. depth for swap/limit and curve for pool. 

We are now going to default to curve for all modules. However, the user's preference for displaying depth or no liquidity chart should still be saved in local storage.

For simplicity, this PR just reads/sets the preference for range (chartSettings.rangeOverlay) for all three.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
