### PR TITLE
fix pagination issue

### DIFF
--- a/src/App/components/PageHeader/Account/Account.tsx
+++ b/src/App/components/PageHeader/Account/Account.tsx
@@ -13,6 +13,7 @@ import useKeyPress from '../../../hooks/useKeyPress';
 import { AppStateContext } from '../../../../contexts/AppStateContext';
 import trimString from '../../../../utils/functions/trimString';
 import { CrocEnvContext } from '../../../../contexts/CrocEnvContext';
+import { ExchangeBalanceModal } from '../ExchangeBalanceModal/ExchangeBalanceModal';
 
 interface propsIF {
     nativeBalance: string | undefined;
@@ -158,6 +159,7 @@ export default function Account(props: propsIF) {
     return (
         <div className={styles.account_container}>
             {isUserLoggedIn && walletDisplay}
+            {isConnected && <ExchangeBalanceModal />}
             <NavItem
                 icon={<FiMoreHorizontal size={20} color='#CDC1FF' />}
                 open={openNavbarMenu}

--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -33,7 +33,6 @@ import {
     resetUserAddresses,
 } from '../../../utils/state/userDataSlice';
 import { TradeTableContext } from '../../../contexts/TradeTableContext';
-import { ExchangeBalanceModal } from './ExchangeBalanceModal/ExchangeBalanceModal';
 
 const PageHeader = function () {
     const {
@@ -419,7 +418,6 @@ const PageHeader = function () {
                             <NetworkSelector switchNetwork={switchNetwork} />
                             {!isConnected && connectWagmiButton}
                             <Account {...accountProps} />
-                            {isConnected && <ExchangeBalanceModal />}
                             <NotificationCenter />
                         </div>
                     </div>

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -440,7 +440,7 @@ function Orders(props: propsIF) {
     }, [mobileView]);
 
     useEffect(() => {
-        if (!expandTradeTable) {
+        if (_DATA.currentData.length && !expandTradeTable) {
             setCurrentPage(1);
             const mockEvent = {} as React.ChangeEvent<unknown>;
             handleChange(mockEvent, 1);

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -442,6 +442,8 @@ function Orders(props: propsIF) {
     useEffect(() => {
         if (!expandTradeTable) {
             setCurrentPage(1);
+            const mockEvent = {} as React.ChangeEvent<unknown>;
+            handleChange(mockEvent, 1);
         }
     }, [expandTradeTable]);
 

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -439,6 +439,12 @@ function Orders(props: propsIF) {
         }
     }, [mobileView]);
 
+    useEffect(() => {
+        if (!expandTradeTable) {
+            setCurrentPage(1);
+        }
+    }, [expandTradeTable]);
+
     const mobileViewHeight = mobileView ? '70vh' : '260px';
 
     const expandStyle = expandTradeTable

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -374,6 +374,12 @@ function Ranges(props: propsIF) {
         }
     }, [mobileView]);
 
+    useEffect(() => {
+        if (!expandTradeTable) {
+            setCurrentPage(1);
+        }
+    }, [expandTradeTable]);
+
     const mobileViewHeight = mobileView ? '70vh' : '260px';
 
     const expandStyle = expandTradeTable

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -375,7 +375,7 @@ function Ranges(props: propsIF) {
     }, [mobileView]);
 
     useEffect(() => {
-        if (!expandTradeTable) {
+        if (_DATA.currentData.length && !expandTradeTable) {
             setCurrentPage(1);
             const mockEvent = {} as React.ChangeEvent<unknown>;
             handleChange(mockEvent, 1);

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -377,6 +377,8 @@ function Ranges(props: propsIF) {
     useEffect(() => {
         if (!expandTradeTable) {
             setCurrentPage(1);
+            const mockEvent = {} as React.ChangeEvent<unknown>;
+            handleChange(mockEvent, 1);
         }
     }, [expandTradeTable]);
 

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -426,6 +426,8 @@ function Transactions(props: propsIF) {
     useEffect(() => {
         if (!expandTradeTable) {
             setCurrentPage(1);
+            const mockEvent = {} as React.ChangeEvent<unknown>;
+            handleChange(mockEvent, 1);
         }
     }, [expandTradeTable]);
 

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -424,7 +424,7 @@ function Transactions(props: propsIF) {
     }, [mobileView]);
 
     useEffect(() => {
-        if (!expandTradeTable) {
+        if (_DATA.currentData.length && !expandTradeTable) {
             setCurrentPage(1);
             const mockEvent = {} as React.ChangeEvent<unknown>;
             handleChange(mockEvent, 1);

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -423,6 +423,12 @@ function Transactions(props: propsIF) {
         }
     }, [mobileView]);
 
+    useEffect(() => {
+        if (!expandTradeTable) {
+            setCurrentPage(1);
+        }
+    }, [expandTradeTable]);
+
     const mobileViewHeight = mobileView ? '70vh' : '260px';
 
     const expandStyle = expandTradeTable


### PR DESCRIPTION
### Describe your changes 
There is a current issue in Pagination. it seems that when you move to a new page, then collapse the table, the user is then stuck on that page. This PR adds a useEffect that makes sure when the page isn't expanded, the current page is set to 0.
_Describe the purpose + content of these changes_
### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
