### PR TITLE
hotfix: limit removal bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "0.1.2",
     "private": true,
     "dependencies": {
-        "@crocswap-libs/sdk": "^0.2.73",
+        "@crocswap-libs/sdk": "^0.2.75",
         "@d3fc/d3fc-extent": "^4.0.2",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",

--- a/src/components/OrderRemoval/RemoveOrderButton/RemoveOrderButton.tsx
+++ b/src/components/OrderRemoval/RemoveOrderButton/RemoveOrderButton.tsx
@@ -7,13 +7,13 @@ interface IRemoveOrderButtonProps {
 }
 
 export default function RemoveOrderButton(props: IRemoveOrderButtonProps) {
-    const { removeFn, title } = props;
+    const { removeFn, title, disabled } = props;
 
     return (
         <div className={styles.button_container}>
             <Button
-                title={title}
-                disabled={props.disabled}
+                title={disabled ? '...' : title}
+                disabled={disabled}
                 action={removeFn}
                 flat={true}
             />

--- a/yarn.lock
+++ b/yarn.lock
@@ -1131,10 +1131,10 @@
     stream-browserify "^3.0.0"
     util "^0.12.4"
 
-"@crocswap-libs/sdk@^0.2.73":
-  version "0.2.73"
-  resolved "https://registry.yarnpkg.com/@crocswap-libs/sdk/-/sdk-0.2.73.tgz#3386b0c49cbb4ac6efcd7e00b155bb8184894fde"
-  integrity sha512-mNmVneGvCJH8rSfaD/3uhoLt7DJe33wJ1Ii7ICzjJBJhMalFGmOTCoLdesYRuhnaeAvJzVp1yoTD1ZIkOGncEg==
+"@crocswap-libs/sdk@^0.2.75":
+  version "0.2.75"
+  resolved "https://registry.yarnpkg.com/@crocswap-libs/sdk/-/sdk-0.2.75.tgz#6f8fa532c2e7f83038d4e43edc60a298ee3a945f"
+  integrity sha512-nNFuRgSKrD4cEZ5dCD+SpCj/Szw0baNke1v4p8gzCOzeA0Ibd5owzf2MHlsc7u/n0JhZ+dv6HH1JDz97H0PN0w==
   dependencies:
     ethers "^5.5.3"
 


### PR DESCRIPTION
### Describe your changes 

Limit order removals were sometimes not working due to an incorrect or out of date liquidity value being returned from the server. A new SDK function has been added and implemented in the front end to pull the latest liquidity value from on chain when the limit removal modal is opened.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
