### PR TITLE
fix local storage retrieval for chart settings

### DIFF
--- a/src/App/hooks/useChartSettings.ts
+++ b/src/App/hooks/useChartSettings.ts
@@ -56,7 +56,7 @@ export const useChartSettings = (): chartSettingsMethodsIF => {
         overlayFor: 'market' | 'limit' | 'range',
     ): OverlayType | undefined => {
         const chartSettings: chartSettingsIF | null = JSON.parse(
-            getLocalStorageItem(LS_KEY_CHART_SETTINGS) ?? '',
+            getLocalStorageItem(LS_KEY_CHART_SETTINGS) ?? '{}',
         );
         // declare an output variable to be assigned in switch router
         let output: string | undefined;
@@ -80,7 +80,7 @@ export const useChartSettings = (): chartSettingsMethodsIF => {
         timeFor: 'global' | 'market' | 'limit' | 'range',
     ): TimeInSecondsType | undefined => {
         const chartSettings: chartSettingsIF | null = JSON.parse(
-            getLocalStorageItem(LS_KEY_CHART_SETTINGS) ?? '',
+            getLocalStorageItem(LS_KEY_CHART_SETTINGS) ?? '{}',
         );
         let time: number | undefined;
         switch (timeFor) {

--- a/src/pages/Trade/TradeCharts/TradeCharts.tsx
+++ b/src/pages/Trade/TradeCharts/TradeCharts.tsx
@@ -122,7 +122,9 @@ function TradeCharts(props: propsIF) {
         isVolumeSubchartEnabled: boolean;
         isTvlSubchartEnabled: boolean;
         isFeeRateSubchartEnabled: boolean;
-    } | null = JSON.parse(getLocalStorageItem(LS_KEY_SUBCHART_SETTINGS) ?? '');
+    } | null = JSON.parse(
+        getLocalStorageItem(LS_KEY_SUBCHART_SETTINGS) ?? '{}',
+    );
 
     const [showTvl, setShowTvl] = useState(
         subchartState?.isTvlSubchartEnabled ?? false,


### PR DESCRIPTION
### Describe your changes 

The functionality to initialize chart settings (e.g. subchart display, candle duration, liquidity display preference) had broken.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
