### PR TITLE
update display of pool card on homepage

### DIFF
--- a/src/components/Global/PoolCard/PoolCard.module.css
+++ b/src/components/Global/PoolCard/PoolCard.module.css
@@ -118,7 +118,7 @@
     font-weight: 200;
     font-size: 12px;
     line-height: 22px;
-
+    margin-top: 2px;
     letter-spacing: -0.02em;
 
     /* other/positive */

--- a/src/components/Global/PoolCard/PoolCard.module.css
+++ b/src/components/Global/PoolCard/PoolCard.module.css
@@ -118,7 +118,6 @@
     font-weight: 200;
     font-size: 12px;
     line-height: 22px;
-    margin-top: 2px;
     letter-spacing: -0.02em;
 
     /* other/positive */
@@ -129,7 +128,6 @@
     font-weight: 200;
     font-size: 12px;
     line-height: 22px;
-    margin-top: 2px;
     letter-spacing: -0.02em;
 
     /* other/positive */

--- a/src/components/Global/PoolCard/PoolCard.module.css
+++ b/src/components/Global/PoolCard/PoolCard.module.css
@@ -71,6 +71,7 @@
     font-weight: 300;
     font-size: 12px;
     color: var(--text1);
+    margin-left: 2px;
 }
 
 .row_title {
@@ -128,7 +129,7 @@
     font-weight: 200;
     font-size: 12px;
     line-height: 22px;
-
+    margin-top: 2px;
     letter-spacing: -0.02em;
 
     /* other/positive */

--- a/src/components/Global/PoolCard/PoolCard.tsx
+++ b/src/components/Global/PoolCard/PoolCard.tsx
@@ -345,13 +345,13 @@ export default function PoolCard(props: propsIF) {
                     <div className={styles.column}>
                         <div className={styles.row}></div>
                         <div className={styles.row}>
-                            <div className={styles.row_title}>APR</div>
+                            <div className={styles.row_title}>24h APR</div>
                             <div className={styles.apr}>
                                 {poolApy === undefined ? '…' : `${poolApy}%`}
                             </div>
                         </div>
                         <div className={styles.row}>
-                            <div className={styles.row_title}>Vol.</div>
+                            <div className={styles.row_title}>Volume</div>
                             <div className={styles.vol}>
                                 {poolVolume === undefined
                                     ? '…'


### PR DESCRIPTION
### Describe your changes 

update pool cards on homepage to reflect that APR is a 24h stat and clarify 'Vol.' refers to volume and not volatility.

new: 
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/c1ff6923-27f9-4807-a999-7fe491202ae4)

old: 
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/01171e2e-d330-4c4d-960e-bc3860cf13a9)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [x] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
