### PR TITLE
reduce minimum eth balance for deposits

### DIFF
--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
@@ -64,7 +64,7 @@ export default function Deposit(props: propsIF) {
 
     const isTokenEth = selectedToken.address === ZERO_ADDRESS;
 
-    const amountToReduceEth = BigNumber.from(1).mul('100000000000000000'); // .1 ETH
+    const amountToReduceEth = BigNumber.from(25).mul('1000000000000000'); // .025 ETH
 
     const tokenWalletBalanceAdjustedNonDisplayString =
         isTokenEth && !!tokenWalletBalance
@@ -121,7 +121,16 @@ export default function Deposit(props: propsIF) {
         [tokenAllowance, depositQtyNonDisplay],
     );
 
-    const isWalletBalanceSufficient = useMemo(
+    const isWalletBalanceSufficientToCoverGas = useMemo(
+        () =>
+            tokenWalletBalance
+                ? BigNumber.from(tokenWalletBalance).gt(amountToReduceEth)
+                : false,
+
+        [tokenWalletBalance, amountToReduceEth],
+    );
+
+    const isWalletBalanceSufficientToCoverDeposit = useMemo(
         () =>
             tokenWalletBalanceAdjustedNonDisplayString && !!depositQtyNonDisplay
                 ? BigNumber.from(
@@ -157,11 +166,17 @@ export default function Deposit(props: propsIF) {
             setIsButtonDisabled(true);
             setIsCurrencyFieldDisabled(true);
             setButtonMessage(`${selectedToken.symbol} Approval Pending`);
-        } else if (!isWalletBalanceSufficient) {
+        } else if (!isWalletBalanceSufficientToCoverGas) {
             setIsButtonDisabled(true);
             setIsCurrencyFieldDisabled(false);
             setButtonMessage(
-                `${selectedToken.symbol} Wallet Balance Insufficient`,
+                `${selectedToken.symbol} Wallet Balance Insufficient To Cover Gas`,
+            );
+        } else if (!isWalletBalanceSufficientToCoverDeposit) {
+            setIsButtonDisabled(true);
+            setIsCurrencyFieldDisabled(false);
+            setButtonMessage(
+                `${selectedToken.symbol} Wallet Balance Insufficient to Cover Deposit`,
             );
         } else if (!isTokenAllowanceSufficient) {
             setIsButtonDisabled(false);
@@ -176,7 +191,7 @@ export default function Deposit(props: propsIF) {
         isApprovalPending,
         isDepositPending,
         isTokenAllowanceSufficient,
-        isWalletBalanceSufficient,
+        isWalletBalanceSufficientToCoverDeposit,
         isDepositQtyValid,
         selectedToken.symbol,
     ]);
@@ -384,7 +399,7 @@ export default function Deposit(props: propsIF) {
                 >
                     <div className={styles.available_text}>Available:</div>
                     {tokenWalletBalanceTruncated || '0.0'}
-                    {isWalletBalanceSufficient ? (
+                    {isWalletBalanceSufficientToCoverDeposit ? (
                         <button
                             className={`${styles.max_button} ${styles.max_button_enable}`}
                             onClick={handleBalanceClick}

--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
@@ -192,6 +192,7 @@ export default function Deposit(props: propsIF) {
         isDepositPending,
         isTokenAllowanceSufficient,
         isWalletBalanceSufficientToCoverDeposit,
+        isWalletBalanceSufficientToCoverGas,
         isDepositQtyValid,
         selectedToken.symbol,
     ]);


### PR DESCRIPTION
### Describe your changes 

The minimum ETH balance requirement had been set to 0.1 ETH to avoid situations where a user could not cover the cost of gas in addition to the deposit quantity.

This value has been reduced to 0.025 ETH and extra logic has been added to specifically alert the user when their ETH balance is not sufficient to cover gas.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/a7b5920d-db77-4df8-95da-4d23684d5bd1)
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/9356e4b8-4873-4f5a-ad24-181d163fe30d)


### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
