### PR TITLE
fix threshold for display of "No Change" for pool price

### DIFF
--- a/src/App/hooks/usePoolPricing.ts
+++ b/src/App/hooks/usePoolPricing.ts
@@ -179,9 +179,11 @@ export function usePoolPricing(props: PoolPricingPropsIF) {
                         setIsPoolPriceChangePositive(true);
                         return;
                     }
-
-                    if (priceChangeResult > -0.01 && priceChangeResult < 0.01) {
-                        setPoolPriceChangePercent('No Change');
+                    if (
+                        priceChangeResult > -0.0001 &&
+                        priceChangeResult < 0.0001
+                    ) {
+                        setPoolPriceChangePercent('No Change'); // display 'No Change' if price has moved less than .01%
                         setIsPoolPriceChangePositive(true);
                     } else {
                         priceChangeResult > 0


### PR DESCRIPTION
### Describe your changes 

The pool price 24 hour change was displaying as 'No Change' when the price had changed less than 1%, rather than .01%:

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/ad0d3530-1861-4814-92bf-3a33f2890c21)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
