### PR TITLE
update APR truncation to display "1,000%+" apr

### DIFF
--- a/src/components/Global/Tabs/Apy/Apy.tsx
+++ b/src/components/Global/Tabs/Apy/Apy.tsx
@@ -12,10 +12,15 @@ export default function Apy(props: ApyProps) {
     const { amount, fs, lh, center, showTitle } = props;
 
     const amountString = amount
-        ? amount.toLocaleString(undefined, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-          }) + '%'
+        ? amount >= 1000
+            ? amount.toLocaleString(undefined, {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+              }) + '%+'
+            : amount.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+              }) + '%'
         : undefined;
 
     // const aprColor = styles.apr_green;

--- a/src/utils/hooks/useProcessRange.ts
+++ b/src/utils/hooks/useProcessRange.ts
@@ -55,10 +55,15 @@ export const useProcessRange = (
 
     const apy = position.apy ?? undefined;
     const apyString = apy
-        ? apy.toLocaleString(undefined, {
-              minimumFractionDigits: 2,
-              maximumFractionDigits: 2,
-          }) + '%'
+        ? apy >= 1000
+            ? apy.toLocaleString(undefined, {
+                  minimumFractionDigits: 0,
+                  maximumFractionDigits: 0,
+              }) + '%+'
+            : apy.toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+              }) + '%'
         : undefined;
 
     const apyClassname = apy > 0 ? 'apy_positive' : 'apy_negative';


### PR DESCRIPTION
### Describe your changes 

Range positions with an APR calculated to exceed 1,000% have the APR display overflowing the container.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/988236a2-6807-41d0-8ea1-3191515e6ec8)

### Link the related issue

this PR updates the display to not show the decimal value:

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/142c9745-16cc-40f2-abc9-4baeac8fb7d4)


### Checklist before requesting a review
- [ ] Is this a PR meant for test purposes? If so, please open/change to a draft PR to indicate work in progress/test. 
- [ ] I have performed a self-review of my code.
- [ ] Did you request feedback from another team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?
