### PR TITLE
show full addresses in tx details

### DIFF
--- a/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
@@ -9,6 +9,7 @@ import moment from 'moment';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import { useContext } from 'react';
 import { CrocEnvContext } from '../../../../contexts/CrocEnvContext';
+import { useMediaQuery } from '@material-ui/core';
 
 interface ItemRowPropsIF {
     title: string;
@@ -30,6 +31,7 @@ export default function TransactionDetailsSimplify(
     );
 
     const {
+        ensName,
         userNameToDisplay,
         txHashTruncated,
         txHash,
@@ -57,6 +59,8 @@ export default function TransactionDetailsSimplify(
     } = useProcessTransaction(tx, userAddress);
 
     const { chainData } = useContext(CrocEnvContext);
+
+    const showFullAddresses = useMediaQuery('(min-width: 768px)');
 
     const isAmbient = tx.positionType === 'ambient';
 
@@ -97,7 +101,7 @@ export default function TransactionDetailsSimplify(
             onClick={handleOpenExplorer}
             style={{ cursor: 'pointer' }}
         >
-            <p>{txHashTruncated}</p>
+            <p>{showFullAddresses ? txHash : txHashTruncated}</p>
             <RiExternalLinkLine />
         </div>
     );
@@ -108,7 +112,13 @@ export default function TransactionDetailsSimplify(
             onClick={handleOpenWallet}
             style={{ cursor: 'pointer' }}
         >
-            <p>{userNameToDisplay}</p>
+            <p>
+                {showFullAddresses
+                    ? ensName
+                        ? ensName
+                        : ownerId
+                    : userNameToDisplay}
+            </p>
             <RiExternalLinkLine />
         </div>
     );
@@ -119,7 +129,7 @@ export default function TransactionDetailsSimplify(
             className={styles.link_row}
             style={{ cursor: 'pointer' }}
         >
-            <p>{baseTokenAddressTruncated}</p>
+            <p>{showFullAddresses ? tx.base : baseTokenAddressTruncated}</p>
             <RiExternalLinkLine />
         </div>
     );
@@ -129,7 +139,7 @@ export default function TransactionDetailsSimplify(
             className={styles.link_row}
             style={{ cursor: 'pointer' }}
         >
-            <p>{quoteTokenAddressTruncated}</p>
+            <p>{showFullAddresses ? tx.quote : quoteTokenAddressTruncated}</p>
             <RiExternalLinkLine />
         </div>
     );

--- a/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
@@ -101,7 +101,9 @@ export default function TransactionDetailsSimplify(
             onClick={handleOpenExplorer}
             style={{ cursor: 'pointer' }}
         >
-            <p>{showFullAddresses ? txHash : txHashTruncated}</p>
+            <p style={{ fontFamily: 'monospace' }}>
+                {showFullAddresses ? txHash : txHashTruncated}
+            </p>
             <RiExternalLinkLine />
         </div>
     );
@@ -112,7 +114,7 @@ export default function TransactionDetailsSimplify(
             onClick={handleOpenWallet}
             style={{ cursor: 'pointer' }}
         >
-            <p>
+            <p style={!ensName ? { fontFamily: 'monospace' } : undefined}>
                 {showFullAddresses
                     ? ensName
                         ? ensName
@@ -129,7 +131,9 @@ export default function TransactionDetailsSimplify(
             className={styles.link_row}
             style={{ cursor: 'pointer' }}
         >
-            <p>{showFullAddresses ? tx.base : baseTokenAddressTruncated}</p>
+            <p style={{ fontFamily: 'monospace' }}>
+                {showFullAddresses ? tx.base : baseTokenAddressTruncated}
+            </p>
             <RiExternalLinkLine />
         </div>
     );
@@ -139,7 +143,9 @@ export default function TransactionDetailsSimplify(
             className={styles.link_row}
             style={{ cursor: 'pointer' }}
         >
-            <p>{showFullAddresses ? tx.quote : quoteTokenAddressTruncated}</p>
+            <p style={{ fontFamily: 'monospace' }}>
+                {showFullAddresses ? tx.quote : quoteTokenAddressTruncated}
+            </p>
             <RiExternalLinkLine />
         </div>
     );

--- a/src/utils/hooks/useProcessTransaction.ts
+++ b/src/utils/hooks/useProcessTransaction.ts
@@ -45,9 +45,9 @@ export const useProcessTransaction = (
     const quoteTokenSymbol = tx.quoteSymbol;
 
     const baseTokenAddress = tx.base;
-    const baseTokenAddressTruncated = trimString(baseTokenAddress, 6, 0, '…');
+    const baseTokenAddressTruncated = trimString(baseTokenAddress, 6, 4, '…');
     const quoteTokenAddress = tx.quote;
-    const quoteTokenAddressTruncated = trimString(quoteTokenAddress, 6, 0, '…');
+    const quoteTokenAddressTruncated = trimString(quoteTokenAddress, 6, 4, '…');
 
     const quoteTokenLogo = tx.quoteTokenLogoURI;
     const baseTokenLogo = tx.baseTokenLogoURI;


### PR DESCRIPTION
### Describe your changes 
add logic to display full account and token addresses when space is sufficient in transaction details:

before update:
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/963de10a-5e8f-43e6-9d75-145c321c5775)

after update:
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/8a83d2ab-850d-4626-ae39-0f1b0f717548)

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)