### PR TITLE
bug fix: some transaction rows cut off when candle selected

### DIFF
--- a/src/components/Trade/TradeTabs/TradeTabs2.module.css
+++ b/src/components/Trade/TradeTabs/TradeTabs2.module.css
@@ -46,6 +46,8 @@
     border-radius: 4px;
     overflow: hidden;
     height: 100%;
+    display: flex;
+    flex-direction: column;
 }
 
 .flex_column {

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -554,6 +554,11 @@ function Transactions(props: propsIF) {
             className={`${styles.main_list_container} ${
                 expandTradeTable && styles.main_list_expanded
             }`}
+            style={
+                isCandleSelected && !showViewMoreButton
+                    ? { height: '80%' }
+                    : undefined
+            }
         >
             <div>{headerColumnsDisplay}</div>
 

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -555,7 +555,7 @@ function Transactions(props: propsIF) {
                 expandTradeTable && styles.main_list_expanded
             }`}
             style={
-                isCandleSelected && !showViewMoreButton
+                isCandleSelected && !expandTradeTable && !showViewMoreButton
                     ? { height: '80%' }
                     : undefined
             }

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -554,11 +554,6 @@ function Transactions(props: propsIF) {
             className={`${styles.main_list_container} ${
                 expandTradeTable && styles.main_list_expanded
             }`}
-            style={
-                isCandleSelected && !expandTradeTable && !showViewMoreButton
-                    ? { height: '80%' }
-                    : undefined
-            }
         >
             <div>{headerColumnsDisplay}</div>
 


### PR DESCRIPTION
### Describe your changes 
fixes issue where some transaction rows are cut off when a candle is selected. 

This seems to happen only when 6-9 transactions are intended to be displayed.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/eb4be03a-0841-4584-b89c-1d90f5548551)


### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1. clicking various candles display expected number of rows

2.

**Environmental conditions which may result in expected but differential behavior.**

1. different candles will have different number of transactions to display, some requiring a 'View More' button

2. 

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)