### PR TITLE
fix pool price change percentage display

### DIFF
--- a/src/App/functions/getPoolStats.ts
+++ b/src/App/functions/getPoolStats.ts
@@ -220,8 +220,8 @@ const get24hChange = async (
 
     if (ydayPrice && nowPrice && ydayPrice > 0 && nowPrice > 0) {
         return denomInBase
-            ? nowPrice / ydayPrice - 1.0
-            : ydayPrice / nowPrice - 1.0;
+            ? ydayPrice / nowPrice - 1.0
+            : nowPrice / ydayPrice - 1.0;
     } else {
         return 0.0;
     }

--- a/src/App/hooks/usePoolPricing.ts
+++ b/src/App/hooks/usePoolPricing.ts
@@ -179,8 +179,10 @@ export function usePoolPricing(props: PoolPricingPropsIF) {
                         setIsPoolPriceChangePositive(true);
                         return;
                     }
-
-                    if (priceChangeResult > -0.01 && priceChangeResult < 0.01) {
+                    if (
+                        priceChangeResult > -0.0001 &&
+                        priceChangeResult < 0.0001
+                    ) {
                         setPoolPriceChangePercent('No Change');
                         setIsPoolPriceChangePositive(true);
                     } else {
@@ -188,15 +190,17 @@ export function usePoolPricing(props: PoolPricingPropsIF) {
                             ? setIsPoolPriceChangePositive(true)
                             : setIsPoolPriceChangePositive(false);
 
+                        const priceChangePercent = priceChangeResult * 100;
+
                         const priceChangeString =
-                            priceChangeResult > 0
+                            priceChangePercent > 0
                                 ? '+' +
-                                  priceChangeResult.toLocaleString(undefined, {
+                                  priceChangePercent.toLocaleString(undefined, {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) +
                                   '%'
-                                : priceChangeResult.toLocaleString(undefined, {
+                                : priceChangePercent.toLocaleString(undefined, {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) + '%';

--- a/src/components/Global/PoolCard/PoolCard.tsx
+++ b/src/components/Global/PoolCard/PoolCard.tsx
@@ -213,7 +213,10 @@ export default function PoolCard(props: propsIF) {
                         return;
                     }
 
-                    if (priceChangeResult > -0.01 && priceChangeResult < 0.01) {
+                    if (
+                        priceChangeResult > -0.0001 &&
+                        priceChangeResult < 0.0001
+                    ) {
                         setPoolPriceChangePercent('No Change');
                         setIsPoolPriceChangePositive(true);
                     } else {
@@ -221,15 +224,17 @@ export default function PoolCard(props: propsIF) {
                             ? setIsPoolPriceChangePositive(true)
                             : setIsPoolPriceChangePositive(false);
 
+                        const priceChangePercent = priceChangeResult * 100;
+
                         const priceChangeString =
-                            priceChangeResult > 0
+                            priceChangePercent > 0
                                 ? '+' +
-                                  priceChangeResult.toLocaleString(undefined, {
+                                  priceChangePercent.toLocaleString(undefined, {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) +
                                   '%'
-                                : priceChangeResult.toLocaleString(undefined, {
+                                : priceChangePercent.toLocaleString(undefined, {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) + '%';


### PR DESCRIPTION
### Describe your changes 

This should fix the issues where pool price changes were appearing as 'No Change' when the change was greater than the absolute value of .01% and the issue where the changes were appearing differently on the homepage pool cards and the trade route.

### Link the related issue
Closes #2521

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
Functionalities tested:

1. Positive changes appear in green, negative in red

2. moving the pool price results in an expected change in the pool price change % on home and trade
3. moving the price back to within .01% of yesterday's price results in the appearance of 'No Change'

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)