### PR TITLE
fix momentary display of incorrect balances in Exchange Balance module

### DIFF
--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.module.css
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.module.css
@@ -56,7 +56,6 @@
 }
 
 .max_button {
-    cursor: pointer;
     font-size: var(--body-size);
     line-height: var(--body-lh);
     color: var(--text1);
@@ -74,12 +73,13 @@
     max-height: 20px;
     transition: all var(--animation-speed) ease-in-out;
     background: transparent;
-}
-
-.max_button_enable {
     border-radius: 4px;
 }
 
-.max_button:hover {
+.max_button_enabled {
+    cursor: pointer;
+}
+
+.max_button_enabled:hover {
     color: var(--accent1);
 }

--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
@@ -74,12 +74,10 @@ export default function Deposit(props: propsIF) {
                   .toString()
             : tokenWalletBalance;
 
-    const tokenWalletBalanceDisplay = useDebounce(
-        tokenWalletBalance
-            ? toDisplayQty(tokenWalletBalance, selectedTokenDecimals)
-            : undefined,
-        500,
-    );
+    const tokenWalletBalanceDisplay = tokenWalletBalance
+        ? toDisplayQty(tokenWalletBalance, selectedTokenDecimals)
+        : undefined;
+
     const adjustedTokenWalletBalanceDisplay = useDebounce(
         tokenWalletBalanceAdjustedNonDisplayString
             ? toDisplayQty(
@@ -403,14 +401,16 @@ export default function Deposit(props: propsIF) {
                 >
                     <div className={styles.available_text}>Available:</div>
                     {tokenWalletBalanceTruncated || '...'}
-                    {isWalletBalanceSufficientToCoverDeposit ? (
-                        <button
-                            className={`${styles.max_button} ${styles.max_button_enable}`}
-                            onClick={handleBalanceClick}
-                        >
-                            Max
-                        </button>
-                    ) : null}
+                    <button
+                        className={`${styles.max_button} ${
+                            isWalletBalanceSufficientToCoverDeposit &&
+                            styles.max_button_enabled
+                        }`}
+                        onClick={handleBalanceClick}
+                        disabled={!isWalletBalanceSufficientToCoverDeposit}
+                    >
+                        Max
+                    </button>
                 </div>
                 <div className={styles.gas_pump}>
                     <div className={styles.svg_container}>

--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
@@ -94,16 +94,19 @@ export default function Deposit(props: propsIF) {
         ? parseFloat(tokenWalletBalanceDisplay)
         : undefined;
 
-    const tokenWalletBalanceTruncated = tokenWalletBalanceDisplayNum
-        ? tokenWalletBalanceDisplayNum < 0.0001
-            ? 0.0
-            : tokenWalletBalanceDisplayNum < 2
-            ? tokenWalletBalanceDisplayNum.toPrecision(3)
-            : tokenWalletBalanceDisplayNum.toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-              })
-        : undefined;
+    const tokenWalletBalanceTruncated =
+        tokenWalletBalanceDisplayNum !== undefined
+            ? tokenWalletBalanceDisplayNum === 0
+                ? '0.00'
+                : tokenWalletBalanceDisplayNum < 0.0001
+                ? 0.0
+                : tokenWalletBalanceDisplayNum < 2
+                ? tokenWalletBalanceDisplayNum.toPrecision(3)
+                : tokenWalletBalanceDisplayNum.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                  })
+            : undefined;
 
     const [depositQtyNonDisplay, setDepositQtyNonDisplay] = useState<
         string | undefined
@@ -399,7 +402,7 @@ export default function Deposit(props: propsIF) {
                     className={`${styles.available_container} ${styles.info_text_non_clickable}`}
                 >
                     <div className={styles.available_text}>Available:</div>
-                    {tokenWalletBalanceTruncated || '0.0'}
+                    {tokenWalletBalanceTruncated || '...'}
                     {isWalletBalanceSufficientToCoverDeposit ? (
                         <button
                             className={`${styles.max_button} ${styles.max_button_enable}`}

--- a/src/components/Portfolio/ExchangeBalance/Deposit/DepositCurrencySelector/DepositCurrencySelector.module.css
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/DepositCurrencySelector/DepositCurrencySelector.module.css
@@ -67,7 +67,6 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    width: 30%;
     gap: 4px;
     cursor: pointer;
 }

--- a/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
+++ b/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
@@ -103,15 +103,18 @@ export default function ExchangeBalance(props: propsIF) {
     const selectedTokenDecimals = selectedToken.decimals;
 
     useEffect(() => {
+        setTokenWalletBalance('');
+        setTokenDexBalance('');
+    }, [selectedToken.address, userAddress]);
+
+    useEffect(() => {
         if (crocEnv && selectedToken.address && userAddress) {
-            setTokenWalletBalance('');
             crocEnv
                 .token(selectedToken.address)
                 .wallet(userAddress)
                 .then((bal: BigNumber) => setTokenWalletBalance(bal.toString()))
                 .catch(console.error);
 
-            setTokenDexBalance('');
             crocEnv
                 .token(selectedToken.address)
                 .balance(userAddress)

--- a/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
+++ b/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
@@ -110,24 +110,8 @@ export default function ExchangeBalance(props: propsIF) {
                 .wallet(userAddress)
                 .then((bal: BigNumber) => setTokenWalletBalance(bal.toString()))
                 .catch(console.error);
-            setTokenDexBalance('');
-            crocEnv
-                .token(selectedToken.address)
-                .balance(userAddress)
-                .then((bal: BigNumber) => {
-                    setTokenDexBalance(bal.toString());
-                })
-                .catch(console.error);
-        }
-    }, [crocEnv, selectedToken.address, userAddress]);
 
-    useEffect(() => {
-        if (crocEnv && selectedToken.address && userAddress) {
-            crocEnv
-                .token(selectedToken.address)
-                .wallet(userAddress)
-                .then((bal: BigNumber) => setTokenWalletBalance(bal.toString()))
-                .catch(console.error);
+            setTokenDexBalance('');
             crocEnv
                 .token(selectedToken.address)
                 .balance(userAddress)

--- a/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
+++ b/src/components/Portfolio/ExchangeBalance/ExchangeBalance.tsx
@@ -104,6 +104,25 @@ export default function ExchangeBalance(props: propsIF) {
 
     useEffect(() => {
         if (crocEnv && selectedToken.address && userAddress) {
+            setTokenWalletBalance('');
+            crocEnv
+                .token(selectedToken.address)
+                .wallet(userAddress)
+                .then((bal: BigNumber) => setTokenWalletBalance(bal.toString()))
+                .catch(console.error);
+            setTokenDexBalance('');
+            crocEnv
+                .token(selectedToken.address)
+                .balance(userAddress)
+                .then((bal: BigNumber) => {
+                    setTokenDexBalance(bal.toString());
+                })
+                .catch(console.error);
+        }
+    }, [crocEnv, selectedToken.address, userAddress]);
+
+    useEffect(() => {
+        if (crocEnv && selectedToken.address && userAddress) {
             crocEnv
                 .token(selectedToken.address)
                 .wallet(userAddress)

--- a/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.module.css
+++ b/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.module.css
@@ -61,7 +61,6 @@
 }
 
 .max_button {
-    cursor: pointer;
     font-size: var(--body-size);
     line-height: var(--body-lh);
     color: var(--text1);
@@ -79,12 +78,13 @@
     max-height: 20px;
     transition: all var(--animation-speed) ease-in-out;
     background: transparent;
-}
-
-.max_button_enable {
     border-radius: 4px;
 }
 
-.max_button:hover {
+.max_button_enabled {
+    cursor: pointer;
+}
+
+.max_button_enabled:hover {
     color: var(--accent1);
 }

--- a/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.tsx
@@ -364,14 +364,15 @@ export default function Transfer(props: propsIF) {
                 >
                     <div className={styles.available_text}>Available:</div>
                     {tokenDexBalanceTruncated || '...'}
-                    {tokenDexBalance !== '0' ? (
-                        <button
-                            className={`${styles.max_button} ${styles.max_button_enable}`}
-                            onClick={handleBalanceClick}
-                        >
-                            Max
-                        </button>
-                    ) : null}
+                    <button
+                        className={`${styles.max_button} ${
+                            tokenDexBalance !== '0' && styles.max_button_enabled
+                        }`}
+                        onClick={handleBalanceClick}
+                        disabled={tokenDexBalance === '0'}
+                    >
+                        Max
+                    </button>
                 </div>
                 <div className={styles.gas_pump}>
                     <div className={styles.svg_container}>

--- a/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Transfer/Transfer.tsx
@@ -75,18 +75,21 @@ export default function Transfer(props: propsIF) {
         ? parseFloat(tokenExchangeDepositsDisplay)
         : undefined;
 
-    const tokenDexBalanceTruncated = tokenExchangeDepositsDisplayNum
-        ? tokenExchangeDepositsDisplayNum < 0.0001
-            ? tokenExchangeDepositsDisplayNum.toExponential(2)
-            : tokenExchangeDepositsDisplayNum < 2
-            ? tokenExchangeDepositsDisplayNum.toPrecision(3)
-            : // : tokenDexBalanceNum >= 100000
-              // ? formatAmountOld(tokenDexBalanceNum)
-              tokenExchangeDepositsDisplayNum.toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-              })
-        : undefined;
+    const tokenDexBalanceTruncated =
+        tokenExchangeDepositsDisplayNum !== undefined
+            ? tokenExchangeDepositsDisplayNum === 0
+                ? '0.00'
+                : tokenExchangeDepositsDisplayNum < 0.0001
+                ? tokenExchangeDepositsDisplayNum.toExponential(2)
+                : tokenExchangeDepositsDisplayNum < 2
+                ? tokenExchangeDepositsDisplayNum.toPrecision(3)
+                : // : tokenDexBalanceNum >= 100000
+                  // ? formatAmountOld(tokenDexBalanceNum)
+                  tokenExchangeDepositsDisplayNum.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                  })
+            : undefined;
 
     const [transferQtyNonDisplay, setTransferQtyNonDisplay] = useState<
         string | undefined
@@ -360,7 +363,7 @@ export default function Transfer(props: propsIF) {
                     className={`${styles.available_container} ${styles.info_text_non_clickable}`}
                 >
                     <div className={styles.available_text}>Available:</div>
-                    {tokenDexBalanceTruncated || '0.0'}
+                    {tokenDexBalanceTruncated || '...'}
                     {tokenDexBalance !== '0' ? (
                         <button
                             className={`${styles.max_button} ${styles.max_button_enable}`}

--- a/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.module.css
+++ b/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.module.css
@@ -76,7 +76,6 @@
 }
 
 .max_button {
-    cursor: pointer;
     font-size: var(--body-size);
     line-height: var(--body-lh);
     color: var(--text1);
@@ -94,12 +93,13 @@
     max-height: 20px;
     transition: all var(--animation-speed) ease-in-out;
     background: transparent;
-}
-
-.max_button_enable {
     border-radius: 4px;
 }
 
-.max_button:hover {
+.max_button_enabled {
+    cursor: pointer;
+}
+
+.max_button_enabled:hover {
     color: var(--accent1);
 }

--- a/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.tsx
@@ -84,18 +84,21 @@ export default function Withdraw(props: propsIF) {
         ? parseFloat(tokenExchangeDepositsDisplay)
         : undefined;
 
-    const tokenDexBalanceTruncated = tokenExchangeDepositsDisplayNum
-        ? tokenExchangeDepositsDisplayNum < 0.0001
-            ? tokenExchangeDepositsDisplayNum.toExponential(2)
-            : tokenExchangeDepositsDisplayNum < 2
-            ? tokenExchangeDepositsDisplayNum.toPrecision(3)
-            : // : tokenDexBalanceNum >= 100000
-              // ? formatAmountOld(tokenDexBalanceNum)
-              tokenExchangeDepositsDisplayNum.toLocaleString(undefined, {
-                  minimumFractionDigits: 2,
-                  maximumFractionDigits: 2,
-              })
-        : undefined;
+    const tokenDexBalanceTruncated =
+        tokenExchangeDepositsDisplayNum !== undefined
+            ? tokenExchangeDepositsDisplayNum === 0
+                ? '0.00'
+                : tokenExchangeDepositsDisplayNum < 0.0001
+                ? tokenExchangeDepositsDisplayNum.toExponential(2)
+                : tokenExchangeDepositsDisplayNum < 2
+                ? tokenExchangeDepositsDisplayNum.toPrecision(3)
+                : // : tokenDexBalanceNum >= 100000
+                  // ? formatAmountOld(tokenDexBalanceNum)
+                  tokenExchangeDepositsDisplayNum.toLocaleString(undefined, {
+                      minimumFractionDigits: 2,
+                      maximumFractionDigits: 2,
+                  })
+            : undefined;
 
     const [withdrawQtyNonDisplay, setWithdrawQtyNonDisplay] = useState<
         string | undefined
@@ -396,7 +399,7 @@ export default function Withdraw(props: propsIF) {
                     className={`${styles.available_container} ${styles.info_text_non_clickable}`}
                 >
                     <div className={styles.available_text}>Available:</div>
-                    {tokenDexBalanceTruncated || '0.0'}
+                    {tokenDexBalanceTruncated || '...'}
                     {tokenDexBalance !== '0' ? (
                         <button
                             className={`${styles.max_button} ${styles.max_button_enable}`}

--- a/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Withdraw/Withdraw.tsx
@@ -400,14 +400,15 @@ export default function Withdraw(props: propsIF) {
                 >
                     <div className={styles.available_text}>Available:</div>
                     {tokenDexBalanceTruncated || '...'}
-                    {tokenDexBalance !== '0' ? (
-                        <button
-                            className={`${styles.max_button} ${styles.max_button_enable}`}
-                            onClick={handleBalanceClick}
-                        >
-                            Max
-                        </button>
-                    ) : null}
+                    <button
+                        className={`${styles.max_button} ${
+                            tokenDexBalance !== '0' && styles.max_button_enabled
+                        }`}
+                        onClick={handleBalanceClick}
+                        disabled={tokenDexBalance === '0'}
+                    >
+                        Max
+                    </button>
                 </div>
                 <div className={styles.gas_pump}>
                     <div className={styles.svg_container}>


### PR DESCRIPTION
### Describe your changes 
fix momentary display of incorrect token balances when user switches token selection in Exchange Balance module.

### Link the related issue
Closes #2523

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1. switch between tokens for which you have wallet/dex balances and tokens for which you do not

2. observe temporary display of '...' when initially loading the module and when switching tokens

3.  verify that incorrect numbers do not appear for wallet/dex balances

4. verify that '0.00' is displayed when a user's wallet or dex balance is zero (depending on which section is open - deposit/withdraw/transfer)

**Environmental conditions which may result in expected but differential behavior.**

1. This issue is most apparent when using a slow connection (e.g. using a VPN)

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)