### PR TITLE
fix missing ipfs token logos

### DIFF
--- a/src/components/Chat/FullChat/FullChat.tsx
+++ b/src/components/Chat/FullChat/FullChat.tsx
@@ -21,6 +21,7 @@ import { useMediaQuery } from '@material-ui/core';
 import { defaultTokens } from '../../../utils/data/defaultTokens';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
+import uriToHttp from '../../../utils/functions/uriToHttp';
 
 interface FullChatPropsIF {
     messageList: JSX.Element;
@@ -399,8 +400,11 @@ export default function FullChat(props: FullChatPropsIF) {
                 )}
 
                 <div className={styles.token_logos}>
-                    <img src={pool?.base.logoURI} alt='base token' />
-                    <img src={pool?.quote.logoURI} alt='quote token' />
+                    <img src={uriToHttp(pool?.base.logoURI)} alt='base token' />
+                    <img
+                        src={uriToHttp(pool?.quote.logoURI)}
+                        alt='quote token'
+                    />
                 </div>
                 <span>{pool?.name}</span>
                 {poolIsCurrentPool && (

--- a/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
+++ b/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
@@ -2,12 +2,13 @@ import styles from './ExchangeCard.module.css';
 import { testTokenMap } from '../../../../../utils/data/testTokenMap';
 import { TokenIF } from '../../../../../utils/interfaces/exports';
 import { useContext, useEffect, useState } from 'react';
-import { ZERO_ADDRESS } from '../../../../../constants';
+import { ETH_ICON_URL, ZERO_ADDRESS } from '../../../../../constants';
 import { DefaultTooltip } from '../../../StyledTooltip/StyledTooltip';
 import { TokenContext } from '../../../../../contexts/TokenContext';
 import { CrocEnvContext } from '../../../../../contexts/CrocEnvContext';
 import { TokenPriceFn } from '../../../../../App/functions/fetchTokenPrice';
 import uriToHttp from '../../../../../utils/functions/uriToHttp';
+import TokenIcon from '../../../TokenIcon/TokenIcon';
 
 interface propsIF {
     token?: TokenIF;
@@ -87,16 +88,16 @@ export default function ExchangeCard(props: propsIF) {
             leaveDelay={200}
         >
             <div className={styles.token_icon}>
-                <img
+                <TokenIcon
                     src={uriToHttp(
                         tokenFromMap?.logoURI
                             ? tokenFromMap?.logoURI
                             : token?.logoURI
                             ? token?.logoURI
-                            : 'https://icons.iconarchive.com/icons/cjdowner/cryptocurrency-flat/1024/Ethereum-ETH-icon.png',
+                            : ETH_ICON_URL,
                     )}
                     alt=''
-                    width='30px'
+                    size='2xl'
                 />
                 <p className={styles.token_key}>
                     {tokenFromMap?.symbol

--- a/src/components/Global/Tabs/TokenQty/TokenQty.tsx
+++ b/src/components/Global/Tabs/TokenQty/TokenQty.tsx
@@ -1,4 +1,3 @@
-// import { TokenIF } from '../../../../utils/interfaces/TokenIF';
 import styles from './TokenQty.module.css';
 
 interface propsIF {
@@ -19,8 +18,6 @@ export default function TokenQty(props: propsIF) {
             {quantitiesAvailable
                 ? `${baseTokenCharacter}${baseQty || '0.00'}`
                 : '…'}
-            {/* {baseTokenCharacter} <p>{baseQty}</p> */}
-            {/* <img src={baseToken ? baseToken.logoURI : undefined} alt='' /> */}
         </section>
     );
 
@@ -29,9 +26,6 @@ export default function TokenQty(props: propsIF) {
             {quantitiesAvailable
                 ? `${quoteTokenCharacter}${quoteQty || '0.00'}`
                 : '…'}
-
-            {/* {quoteTokenCharacter}<p>{quoteQty}</p> */}
-            {/* <img src={quoteToken ? quoteToken.logoURI : undefined} alt='' /> */}
         </section>
     );
 
@@ -41,14 +35,12 @@ export default function TokenQty(props: propsIF) {
                 <div>
                     {baseTokenCharacter}
                     <p>{baseQty}</p>
-                    {/* <img src={baseToken ? baseToken.logoURI : undefined} alt='' /> */}
                 </div>
             ) : null}
             {quoteQty ? (
                 <div>
                     {quoteTokenCharacter}
                     <p>{quoteQty}</p>
-                    {/* <img src={quoteToken ? quoteToken.logoURI : undefined} alt='' /> */}
                 </div>
             ) : null}
         </section>

--- a/src/components/Global/TokenSelectContainer/SoloTokenImport.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenImport.tsx
@@ -5,6 +5,7 @@ import Button from '../../Global/Button/Button';
 import DividerDark from '../DividerDark/DividerDark';
 import { lookupChain } from '@crocswap-libs/sdk/dist/context';
 import TokenIcon from '../TokenIcon/TokenIcon';
+import uriToHttp from '../../../utils/functions/uriToHttp';
 interface propsIF {
     customToken: TokenIF | null | 'querying';
     chooseToken: (tkn: TokenIF, isCustom: boolean) => void;
@@ -41,7 +42,7 @@ export default function SoloTokenImport(props: propsIF) {
             <div className={styles.token_display}>
                 <div>
                     <TokenIcon
-                        src={customToken.logoURI}
+                        src={uriToHttp(customToken.logoURI)}
                         alt={customToken.name}
                         size='2xl'
                     />

--- a/src/components/Global/TransactionDetails/TransactionDetailsPriceInfo/TransactionDetailsPriceInfo.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsPriceInfo/TransactionDetailsPriceInfo.tsx
@@ -9,6 +9,7 @@ import { useLocation } from 'react-router-dom';
 import { DefaultTooltip } from '../../StyledTooltip/StyledTooltip';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import TokenIcon from '../../TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 type ItemIF = {
     slug: string;
@@ -58,12 +59,12 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
         <div className={styles.token_pair_details}>
             <div className={styles.token_pair_images}>
                 <TokenIcon
-                    src={baseTokenLogo}
+                    src={uriToHttp(baseTokenLogo)}
                     alt={baseTokenSymbol}
                     size='2xl'
                 />
                 <TokenIcon
-                    src={quoteTokenLogo}
+                    src={uriToHttp(quoteTokenLogo)}
                     alt={quoteTokenSymbol}
                     size='2xl'
                 />
@@ -127,10 +128,18 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
     );
 
     const buySellBaseToken = (
-        <TokenIcon src={baseTokenLogo} alt={baseTokenSymbol} size='xs' />
+        <TokenIcon
+            src={uriToHttp(baseTokenLogo)}
+            alt={baseTokenSymbol}
+            size='xs'
+        />
     );
     const buySellQuoteToken = (
-        <TokenIcon src={quoteTokenLogo} alt={quoteTokenSymbol} size='xs' />
+        <TokenIcon
+            src={uriToHttp(quoteTokenLogo)}
+            alt={quoteTokenSymbol}
+            size='xs'
+        />
     );
 
     const isBuyTransactionDetails = (

--- a/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
+++ b/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
@@ -26,6 +26,7 @@ import { PoolContext } from '../../../contexts/PoolContext';
 import { ChainDataContext } from '../../../contexts/ChainDataContext';
 import { getDisplayableEffectivePriceString } from '../../../App/functions/swap/getDisplayableEffectivePriceString';
 import TokenIcon from '../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../utils/functions/uriToHttp';
 
 interface propsIF {
     initiateSwapMethod: () => void;
@@ -178,7 +179,7 @@ export default function ConfirmSwapModal(props: propsIF) {
 
             <div className={styles.logo_display}>
                 <TokenIcon
-                    src={buyTokenData.logoURI}
+                    src={uriToHttp(buyTokenData.logoURI)}
                     alt={buyTokenData.symbol}
                     size='2xl'
                 />
@@ -219,7 +220,7 @@ export default function ConfirmSwapModal(props: propsIF) {
             <h2>{localeSellString}</h2>
             <div className={styles.logo_display}>
                 <TokenIcon
-                    src={sellTokenData.logoURI}
+                    src={uriToHttp(sellTokenData.logoURI)}
                     alt={sellTokenData.symbol}
                     size='2xl'
                 />
@@ -299,7 +300,7 @@ export default function ConfirmSwapModal(props: propsIF) {
             tokenBSymbol={buyTokenData.symbol}
             tokenBAddress={buyTokenData.address}
             tokenBDecimals={buyTokenData.decimals}
-            tokenBImage={buyTokenData.logoURI}
+            tokenBImage={uriToHttp(buyTokenData.logoURI)}
             chainId={buyTokenData.chainId}
         />
     );

--- a/src/components/Swap/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.tsx
@@ -29,6 +29,7 @@ import { TokenContext } from '../../../contexts/TokenContext';
 import { TradeTableContext } from '../../../contexts/TradeTableContext';
 import { FiRefreshCw } from 'react-icons/fi';
 import TokenIcon from '../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../utils/functions/uriToHttp';
 
 interface propsIF {
     disableReverseTokens: boolean;
@@ -528,7 +529,7 @@ function CurrencySelector(props: propsIF) {
                     id='swap_token_selector'
                 >
                     <TokenIcon
-                        src={thisToken.logoURI}
+                        src={uriToHttp(thisToken.logoURI)}
                         alt={thisToken.name}
                         size='2xl'
                     />

--- a/src/components/Swap/SwapButton/BypassConfirmSwapButton.tsx
+++ b/src/components/Swap/SwapButton/BypassConfirmSwapButton.tsx
@@ -19,6 +19,7 @@ import styles from './BypassConfirmSwapButton.module.css';
 import { TokenPairIF } from '../../../utils/interfaces/TokenPairIF';
 import { useAppSelector } from '../../../utils/hooks/reduxToolkit';
 import { TokenIF } from '../../../utils/interfaces/exports';
+import uriToHttp from '../../../utils/functions/uriToHttp';
 
 interface propsIF {
     initiateSwapMethod: () => void;
@@ -103,7 +104,7 @@ export default function BypassConfirmSwapButton(props: propsIF) {
             tokenBSymbol={buyTokenData.symbol}
             tokenBAddress={buyTokenData.address}
             tokenBDecimals={buyTokenData.decimals}
-            tokenBImage={buyTokenData.logoURI}
+            tokenBImage={uriToHttp(buyTokenData.logoURI)}
             chainId={buyTokenData.chainId}
             noAnimation
         />

--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -11,6 +11,7 @@ import ConfirmationModalControl from '../../../Global/ConfirmationModalControl/C
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
 import { PoolContext } from '../../../../contexts/PoolContext';
 import TokenIcon from '../../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     initiateLimitOrderMethod: () => void;
@@ -103,7 +104,7 @@ export default function ConfirmLimitModal(props: propsIF) {
 
             <div className={styles.logo_display}>
                 <TokenIcon
-                    src={buyTokenData.logoURI}
+                    src={uriToHttp(buyTokenData.logoURI)}
                     alt={buyTokenData.symbol}
                     size='3xl'
                 />
@@ -117,7 +118,7 @@ export default function ConfirmLimitModal(props: propsIF) {
 
             <div className={styles.logo_display}>
                 <TokenIcon
-                    src={sellTokenData.logoURI}
+                    src={uriToHttp(sellTokenData.logoURI)}
                     alt={sellTokenData.symbol}
                     size='3xl'
                 />
@@ -241,7 +242,7 @@ export default function ConfirmLimitModal(props: propsIF) {
             tokenBSymbol={buyTokenData.symbol}
             tokenBAddress={buyTokenData.address}
             tokenBDecimals={buyTokenData.decimals}
-            tokenBImage={buyTokenData.logoURI}
+            tokenBImage={uriToHttp(buyTokenData.logoURI)}
             chainId={buyTokenData.chainId}
             limit
         />

--- a/src/components/Trade/Limit/LimitButton/BypassLimitButton.tsx
+++ b/src/components/Trade/Limit/LimitButton/BypassLimitButton.tsx
@@ -13,6 +13,7 @@ import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import { useState, Dispatch, SetStateAction, memo } from 'react';
 import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri';
 import TransactionFailed from '../../../Global/TransactionFailed/TransactionFailed';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 // import { CrocImpact } from '@crocswap-libs/sdk';
 
 interface propsIF {
@@ -104,7 +105,7 @@ function BypassLimitButton(props: propsIF) {
             tokenBSymbol={buyTokenData.symbol}
             tokenBAddress={buyTokenData.address}
             tokenBDecimals={buyTokenData.decimals}
-            tokenBImage={buyTokenData.logoURI}
+            tokenBImage={uriToHttp(buyTokenData.logoURI)}
             chainId={buyTokenData.chainId}
             noAnimation
         />

--- a/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
+++ b/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
@@ -31,6 +31,7 @@ import { ChainDataContext } from '../../../../contexts/ChainDataContext';
 import { TradeTableContext } from '../../../../contexts/TradeTableContext';
 import { TokenContext } from '../../../../contexts/TokenContext';
 import TokenIcon from '../../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 // interface for component props
 interface propsIF {
@@ -119,7 +120,7 @@ function LimitCurrencySelector(props: propsIF) {
             id='limit_token_selector'
         >
             <TokenIcon
-                src={thisToken.logoURI}
+                src={uriToHttp(thisToken.logoURI)}
                 alt={thisToken.name + 'token logo'}
                 size='2xl'
             />

--- a/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
+++ b/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
@@ -17,6 +17,7 @@ import getUnicodeCharacter from '../../../../utils/functions/getUnicodeCharacter
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import TokenIcon from '../../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     sendTransaction: () => void;
@@ -121,12 +122,12 @@ function ConfirmRangeModal(props: propsIF) {
                 <div className={styles.token_display}>
                     <div className={styles.tokens}>
                         <TokenIcon
-                            src={tokenA.logoURI}
+                            src={uriToHttp(tokenA.logoURI)}
                             alt={tokenA.name}
                             size='2xl'
                         />
                         <TokenIcon
-                            src={tokenB.logoURI}
+                            src={uriToHttp(tokenB.logoURI)}
                             alt={tokenB.name}
                             size='2xl'
                         />
@@ -146,7 +147,7 @@ function ConfirmRangeModal(props: propsIF) {
                     <div className={styles.detail_line}>
                         <div>
                             <TokenIcon
-                                src={tokenA.logoURI}
+                                src={uriToHttp(tokenA.logoURI)}
                                 alt={tokenA.name}
                                 size='m'
                             />
@@ -161,7 +162,7 @@ function ConfirmRangeModal(props: propsIF) {
                     <div className={styles.detail_line}>
                         <div>
                             <TokenIcon
-                                src={tokenB.logoURI}
+                                src={uriToHttp(tokenB.logoURI)}
                                 alt={tokenB.name}
                                 size='m'
                             />

--- a/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
+++ b/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
@@ -102,7 +102,7 @@ function ConfirmRangeModal(props: propsIF) {
             tokenBSymbol={tokenB.symbol}
             tokenBAddress={tokenB.address}
             tokenBDecimals={tokenB.decimals}
-            tokenBImage={tokenB.logoURI}
+            tokenBImage={uriToHttp(tokenB.logoURI)}
             chainId={tokenB.chainId}
             range
         />

--- a/src/components/Trade/Range/RangeButton/BypassConfirmRangeButton.tsx
+++ b/src/components/Trade/Range/RangeButton/BypassConfirmRangeButton.tsx
@@ -15,6 +15,7 @@ import TransactionException from '../../../Global/TransactionException/Transacti
 import TransactionSubmitted from '../../../Global/TransactionSubmitted/TransactionSubmitted';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import TransactionFailed from '../../../Global/TransactionFailed/TransactionFailed';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     newRangeTransactionHash: string;
@@ -99,7 +100,7 @@ export default function BypassConfirmRangeButton(props: propsIF) {
             tokenBSymbol={tokenA.symbol}
             tokenBAddress={tokenA.address}
             tokenBDecimals={tokenA.decimals}
-            tokenBImage={tokenA.logoURI}
+            tokenBImage={uriToHttp(tokenB.logoURI)}
             chainId={tokenA.chainId}
             noAnimation
         />

--- a/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
+++ b/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
@@ -26,6 +26,7 @@ import { ChainDataContext } from '../../../../contexts/ChainDataContext';
 import { TradeTableContext } from '../../../../contexts/TradeTableContext';
 import { TokenContext } from '../../../../contexts/TokenContext';
 import TokenIcon from '../../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     fieldId: string;
@@ -378,7 +379,7 @@ function RangeCurrencySelector(props: propsIF) {
                     aria-label={`Open range ${fieldId} token modal.`}
                 >
                     <TokenIcon
-                        src={thisToken.logoURI}
+                        src={uriToHttp(thisToken.logoURI)}
                         alt={thisToken.name + 'token logo'}
                         size='2xl'
                     />

--- a/src/components/Trade/Reposition/BypassConfirmRepositionButton/BypassConfirmRepositionButton.tsx
+++ b/src/components/Trade/Reposition/BypassConfirmRepositionButton/BypassConfirmRepositionButton.tsx
@@ -19,6 +19,7 @@ import {
 import styles from './BypassConfirmRepositionButton.module.css';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import { TokenIF } from '../../../../utils/interfaces/exports';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     txErrorCode: string;
@@ -62,7 +63,7 @@ function BypassConfirmRepositionButton(props: propsIF) {
             tokenBSymbol={buyTokenData.symbol}
             tokenBAddress={buyTokenData.address}
             tokenBDecimals={buyTokenData.decimals}
-            tokenBImage={buyTokenData.logoURI}
+            tokenBImage={uriToHttp(buyTokenData.logoURI)}
             chainId={buyTokenData.chainId}
             noAnimation
             reposition

--- a/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
+++ b/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
@@ -12,6 +12,7 @@ import ConfirmationModalControl from '../../../Global/ConfirmationModalControl/C
 import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContext';
 import { useAppSelector } from '../../../../utils/hooks/reduxToolkit';
 import TokenIcon from '../../../Global/TokenIcon/TokenIcon';
+import uriToHttp from '../../../../utils/functions/uriToHttp';
 
 interface propsIF {
     position: PositionIF;
@@ -171,12 +172,12 @@ export default function ConfirmRepositionModal(props: propsIF) {
                 <div className={styles.token_display}>
                     <div className={styles.tokens}>
                         <TokenIcon
-                            src={tokenA.logoURI}
+                            src={uriToHttp(tokenA.logoURI)}
                             alt={tokenA.name}
                             size='2xl'
                         />
                         <TokenIcon
-                            src={tokenB.logoURI}
+                            src={uriToHttp(tokenB.logoURI)}
                             alt={tokenB.name}
                             size='2xl'
                         />

--- a/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
+++ b/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
@@ -80,7 +80,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
             tokenBSymbol={tokenB.symbol}
             tokenBAddress={tokenB.address}
             tokenBDecimals={tokenB.decimals}
-            tokenBImage={tokenB.logoURI}
+            tokenBImage={uriToHttp(tokenB.logoURI)}
             chainId={tokenB.chainId}
             reposition
         />

--- a/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
+++ b/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
@@ -113,7 +113,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
                 <div className={styles.detail_line}>
                     <div>
                         <TokenIcon
-                            src={baseToken.logoURI}
+                            src={uriToHttp(baseToken.logoURI)}
                             alt={baseToken.name}
                             size='m'
                         />
@@ -125,7 +125,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
                 <div className={styles.detail_line}>
                     <div>
                         <TokenIcon
-                            src={baseToken.logoURI}
+                            src={uriToHttp(baseToken.logoURI)}
                             alt={baseToken.name}
                             size='m'
                         />
@@ -138,7 +138,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
                 <div className={styles.detail_line}>
                     <div>
                         <TokenIcon
-                            src={quoteToken.logoURI}
+                            src={uriToHttp(quoteToken.logoURI)}
                             alt={quoteToken.name}
                             size='m'
                         />
@@ -149,7 +149,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
                 <div className={styles.detail_line}>
                     <div>
                         <TokenIcon
-                            src={quoteToken.logoURI}
+                            src={uriToHttp(quoteToken.logoURI)}
                             alt={quoteToken.name}
                             size='m'
                         />

--- a/src/pages/InitPool/InitPool.module.css
+++ b/src/pages/InitPool/InitPool.module.css
@@ -102,7 +102,6 @@
 
     justify-content: center;
     padding: 16px 0;
-    /* align-items: center; */
 }
 
 .pool_price_container span {

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -29,9 +29,9 @@ import { AppStateContext } from '../../contexts/AppStateContext';
 import { TradeTokenContext } from '../../contexts/TradeTokenContext';
 import { useAccount } from 'wagmi';
 import { useLinkGen, linkGenMethodsIF } from '../../utils/hooks/useLinkGen';
-import NoTokenIcon from '../../components/Global/NoTokenIcon/NoTokenIcon';
 import { exponentialNumRegEx } from '../../utils/regex/exports';
 import uriToHttp from '../../utils/functions/uriToHttp';
+import TokenIcon from '../../components/Global/TokenIcon/TokenIcon';
 
 // react functional component
 export default function InitPool() {
@@ -421,19 +421,11 @@ export default function InitPool() {
     const tokenADisplay = (
         <div className={styles.pool_display}>
             <div>
-                {tokenA &&
-                    (tokenA.logoURI ? (
-                        <img
-                            src={uriToHttp(tokenA.logoURI)}
-                            alt={tokenA.symbol}
-                            width='30px'
-                        />
-                    ) : (
-                        <NoTokenIcon
-                            tokenInitial={tokenA.symbol.charAt(0)}
-                            width='30px'
-                        />
-                    ))}
+                <TokenIcon
+                    src={uriToHttp(tokenA.logoURI)}
+                    alt={tokenA.symbol}
+                    size='2xl'
+                />
                 {tokenA && <h3>{tokenA.symbol}</h3>}
             </div>
             {tokenA && <p>{tokenA.name}</p>}
@@ -443,19 +435,11 @@ export default function InitPool() {
     const tokenBDisplay = (
         <div className={styles.pool_display}>
             <div>
-                {tokenB &&
-                    (tokenB.logoURI ? (
-                        <img
-                            src={uriToHttp(tokenB.logoURI)}
-                            alt={tokenB.symbol}
-                            width='30px'
-                        />
-                    ) : (
-                        <NoTokenIcon
-                            tokenInitial={tokenB.symbol.charAt(0)}
-                            width='30px'
-                        />
-                    ))}
+                <TokenIcon
+                    src={uriToHttp(tokenB.logoURI)}
+                    alt={tokenB.symbol}
+                    size='2xl'
+                />
                 {tokenB && <h3>{tokenB.symbol}</h3>}
             </div>
             {tokenB && <p>{tokenB.name}</p>}

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -31,6 +31,7 @@ import { useAccount } from 'wagmi';
 import { useLinkGen, linkGenMethodsIF } from '../../utils/hooks/useLinkGen';
 import NoTokenIcon from '../../components/Global/NoTokenIcon/NoTokenIcon';
 import { exponentialNumRegEx } from '../../utils/regex/exports';
+import uriToHttp from '../../utils/functions/uriToHttp';
 
 // react functional component
 export default function InitPool() {
@@ -423,7 +424,7 @@ export default function InitPool() {
                 {tokenA &&
                     (tokenA.logoURI ? (
                         <img
-                            src={tokenA.logoURI}
+                            src={uriToHttp(tokenA.logoURI)}
                             alt={tokenA.symbol}
                             width='30px'
                         />
@@ -445,7 +446,7 @@ export default function InitPool() {
                 {tokenB &&
                     (tokenB.logoURI ? (
                         <img
-                            src={tokenB.logoURI}
+                            src={uriToHttp(tokenB.logoURI)}
                             alt={tokenB.symbol}
                             width='30px'
                         />

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -420,28 +420,24 @@ export default function InitPool() {
 
     const tokenADisplay = (
         <div className={styles.pool_display}>
-            <div>
-                <TokenIcon
-                    src={uriToHttp(tokenA.logoURI)}
-                    alt={tokenA.symbol}
-                    size='2xl'
-                />
-                {tokenA && <h3>{tokenA.symbol}</h3>}
-            </div>
+            <TokenIcon
+                src={uriToHttp(tokenA.logoURI)}
+                alt={tokenA.symbol}
+                size='2xl'
+            />
+            {tokenA && <h3>{tokenA.symbol}</h3>}
             {tokenA && <p>{tokenA.name}</p>}
         </div>
     );
 
     const tokenBDisplay = (
         <div className={styles.pool_display}>
-            <div>
-                <TokenIcon
-                    src={uriToHttp(tokenB.logoURI)}
-                    alt={tokenB.symbol}
-                    size='2xl'
-                />
-                {tokenB && <h3>{tokenB.symbol}</h3>}
-            </div>
+            <TokenIcon
+                src={uriToHttp(tokenB.logoURI)}
+                alt={tokenB.symbol}
+                size='2xl'
+            />
+            {tokenB && <h3>{tokenB.symbol}</h3>}
             {tokenB && <p>{tokenB.name}</p>}
         </div>
     );

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -420,24 +420,28 @@ export default function InitPool() {
 
     const tokenADisplay = (
         <div className={styles.pool_display}>
-            <TokenIcon
-                src={uriToHttp(tokenA.logoURI)}
-                alt={tokenA.symbol}
-                size='2xl'
-            />
-            {tokenA && <h3>{tokenA.symbol}</h3>}
+            <div>
+                <TokenIcon
+                    src={uriToHttp(tokenA.logoURI)}
+                    alt={tokenA.symbol}
+                    size='2xl'
+                />
+                {tokenA && <h3>{tokenA.symbol}</h3>}
+            </div>
             {tokenA && <p>{tokenA.name}</p>}
         </div>
     );
 
     const tokenBDisplay = (
         <div className={styles.pool_display}>
-            <TokenIcon
-                src={uriToHttp(tokenB.logoURI)}
-                alt={tokenB.symbol}
-                size='2xl'
-            />
-            {tokenB && <h3>{tokenB.symbol}</h3>}
+            <div>
+                <TokenIcon
+                    src={uriToHttp(tokenB.logoURI)}
+                    alt={tokenB.symbol}
+                    size='2xl'
+                />
+                {tokenB && <h3>{tokenB.symbol}</h3>}
+            </div>
             {tokenB && <p>{tokenB.name}</p>}
         </div>
     );

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -53,6 +53,7 @@ import { getPriceImpactString } from '../../App/functions/swap/getPriceImpactStr
 import { useTradeData } from '../../App/hooks/useTradeData';
 import TokenIcon from '../../components/Global/TokenIcon/TokenIcon';
 import { linkGenMethodsIF, useLinkGen } from '../../utils/hooks/useLinkGen';
+import uriToHttp from '../../utils/functions/uriToHttp';
 
 interface propsIF {
     isOnTradeRoute?: boolean;
@@ -600,12 +601,12 @@ function Swap(props: propsIF) {
                         >
                             Initialize Pool
                             <TokenIcon
-                                src={tokenA.logoURI}
+                                src={uriToHttp(tokenA.logoURI)}
                                 alt={tokenA.symbol}
                                 size='m'
                             />
                             <TokenIcon
-                                src={tokenB.logoURI}
+                                src={uriToHttp(tokenB.logoURI)}
                                 alt={tokenB.symbol}
                                 size='m'
                             />

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -31,6 +31,7 @@ import { TradeTokenContext } from '../../contexts/TradeTokenContext';
 import TokenIcon from '../../components/Global/TokenIcon/TokenIcon';
 import { CandleData } from '../../App/functions/fetchCandleSeries';
 import { linkGenMethodsIF, useLinkGen } from '../../utils/hooks/useLinkGen';
+import uriToHttp from '../../utils/functions/uriToHttp';
 
 // React functional component
 function Trade() {
@@ -263,12 +264,12 @@ function Trade() {
                         >
                             Initialize Pool
                             <TokenIcon
-                                src={baseTokenLogo}
+                                src={uriToHttp(baseTokenLogo)}
                                 alt={baseTokenSymbol}
                                 size='m'
                             />
                             <TokenIcon
-                                src={quoteTokenLogo}
+                                src={uriToHttp(quoteTokenLogo)}
                                 alt={quoteTokenSymbol}
                                 size='m'
                             />

--- a/src/utils/hooks/useProcessOrder.ts
+++ b/src/utils/hooks/useProcessOrder.ts
@@ -18,6 +18,7 @@ import moment from 'moment';
 import { getChainExplorer } from '../data/chains';
 import { getElapsedTime } from '../../App/functions/getElapsedTime';
 import { diffHashSig } from '../functions/diffHashSig';
+import uriToHttp from '../functions/uriToHttp';
 
 export const useProcessOrder = (
     limitOrder: LimitOrderIF,
@@ -36,8 +37,8 @@ export const useProcessOrder = (
     const baseTokenName = limitOrder.baseName;
     const quoteTokenName = limitOrder.quoteName;
 
-    const quoteTokenLogo = limitOrder.quoteTokenLogoURI;
-    const baseTokenLogo = limitOrder.baseTokenLogoURI;
+    const quoteTokenLogo = uriToHttp(limitOrder.quoteTokenLogoURI);
+    const baseTokenLogo = uriToHttp(limitOrder.baseTokenLogoURI);
 
     const isOwnerActiveAccount =
         limitOrder.user.toLowerCase() === account?.toLowerCase();


### PR DESCRIPTION
### Describe your changes 

fix remaining token logo references that were not using the httpToUri transformation for IPFS addresses:

Example: ETH-UNI:  https://develop--ambient-finance.netlify.app/trade/market/chain=0x5&tokenA=0xD87Ba7A50B2E7E660f678A895E4B72E7CB4CCd9C&tokenB=0x1f9840a85d5af5bf1d1762f925bdaddc4201f984

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/12db7bba-c915-46b2-998a-289ebbb7cf72)


### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)