### PR TITLE
implement user/pool endpoints for position & limit retrieval

### DIFF
--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -424,6 +424,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                                 updatedLimitOrderStates,
                                         }),
                                     );
+                                    console.log('setting to false');
 
                                     dispatch(
                                         setDataLoadingStatus({
@@ -432,6 +433,20 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                         }),
                                     );
                                 });
+                            } else {
+                                console.log('setting to false');
+                                dispatch(
+                                    setLimitOrdersByPool({
+                                        dataReceived: false,
+                                        limitOrders: [],
+                                    }),
+                                );
+                                dispatch(
+                                    setDataLoadingStatus({
+                                        datasetName: 'poolOrderData',
+                                        loadingStatus: false,
+                                    }),
+                                );
                             }
                         })
                         .catch(console.error);
@@ -482,7 +497,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                             dispatch(
                                                 setDataLoadingStatus({
                                                     datasetName:
-                                                        'poolRangeData',
+                                                        'connectedUserPoolRangeData',
                                                     loadingStatus: false,
                                                 }),
                                             );
@@ -497,7 +512,8 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                     );
                                     dispatch(
                                         setDataLoadingStatus({
-                                            datasetName: 'poolRangeData',
+                                            datasetName:
+                                                'connectedUserPoolRangeData',
                                             loadingStatus: false,
                                         }),
                                     );
@@ -553,7 +569,8 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
 
                                         dispatch(
                                             setDataLoadingStatus({
-                                                datasetName: 'poolOrderData',
+                                                datasetName:
+                                                    'connectedUserPoolOrderData',
                                                 loadingStatus: false,
                                             }),
                                         );
@@ -567,7 +584,8 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                     );
                                     dispatch(
                                         setDataLoadingStatus({
-                                            datasetName: 'poolOrderData',
+                                            datasetName:
+                                                'connectedUserPoolOrderData',
                                             loadingStatus: false,
                                         }),
                                     );

--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -393,6 +393,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                 quote: sortedTokens[1].toLowerCase(),
                                 poolIdx: props.chainData.poolIndex.toString(),
                                 chainId: props.chainData.chainId,
+                                n: '50',
                             }),
                     )
                         .then((response) => response?.json())
@@ -424,8 +425,6 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                                 updatedLimitOrderStates,
                                         }),
                                     );
-                                    console.log('setting to false');
-
                                     dispatch(
                                         setDataLoadingStatus({
                                             datasetName: 'poolOrderData',
@@ -434,7 +433,6 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                     );
                                 });
                             } else {
-                                console.log('setting to false');
                                 dispatch(
                                     setLimitOrdersByPool({
                                         dataReceived: false,

--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -17,6 +17,8 @@ import {
     setLiquidity,
     setLiquidityPending,
     setPositionsByPool,
+    setUserLimitOrdersByPool,
+    setUserPositionsByPool,
 } from '../../utils/state/graphDataSlice';
 import {
     setAdvancedHighTick,
@@ -39,6 +41,7 @@ interface PoolParamsHookIF {
     crocEnv?: CrocEnv;
     pathname: string;
     chainData: ChainSpec;
+    userAddress: `0x${string}` | undefined;
     searchableTokens: TokenIF[];
     receiptCount: number;
     lastBlockNumber: number;
@@ -390,9 +393,6 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                 quote: sortedTokens[1].toLowerCase(),
                                 poolIdx: props.chainData.poolIndex.toString(),
                                 chainId: props.chainData.chainId,
-                                ensResolution: 'true',
-                                omitEmpty: 'true',
-                                n: '50',
                             }),
                     )
                         .then((response) => response?.json())
@@ -435,10 +435,151 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                             }
                         })
                         .catch(console.error);
+                    if (props.userAddress) {
+                        // retrieve user_pool_positions
+                        const userPoolPositionsCacheEndpoint =
+                            GRAPHCACHE_SMALL_URL + '/user_pool_positions?';
+                        fetch(
+                            userPoolPositionsCacheEndpoint +
+                                new URLSearchParams({
+                                    user: props.userAddress,
+                                    base: sortedTokens[0].toLowerCase(),
+                                    quote: sortedTokens[1].toLowerCase(),
+                                    poolIdx:
+                                        props.chainData.poolIndex.toString(),
+                                    chainId: props.chainData.chainId,
+                                }),
+                        )
+                            .then((response) => response.json())
+                            .then((json) => {
+                                const userPoolPositions = json.data;
+                                const crocEnv = props.crocEnv;
+                                if (userPoolPositions && crocEnv) {
+                                    Promise.all(
+                                        userPoolPositions.map(
+                                            (position: PositionServerIF) => {
+                                                return getPositionData(
+                                                    position,
+                                                    props.searchableTokens,
+                                                    crocEnv,
+                                                    props.chainData.chainId,
+                                                    props.lastBlockNumber,
+                                                    props.cachedFetchTokenPrice,
+                                                    props.cachedQuerySpotPrice,
+                                                    props.cachedTokenDetails,
+                                                    props.cachedEnsResolve,
+                                                );
+                                            },
+                                        ),
+                                    )
+                                        .then((updatedPositions) => {
+                                            dispatch(
+                                                setUserPositionsByPool({
+                                                    dataReceived: true,
+                                                    positions: updatedPositions,
+                                                }),
+                                            );
+                                            dispatch(
+                                                setDataLoadingStatus({
+                                                    datasetName:
+                                                        'poolRangeData',
+                                                    loadingStatus: false,
+                                                }),
+                                            );
+                                        })
+                                        .catch(console.error);
+                                } else {
+                                    dispatch(
+                                        setUserPositionsByPool({
+                                            dataReceived: false,
+                                            positions: [],
+                                        }),
+                                    );
+                                    dispatch(
+                                        setDataLoadingStatus({
+                                            datasetName: 'poolRangeData',
+                                            loadingStatus: false,
+                                        }),
+                                    );
+                                }
+                            })
+                            .catch(console.error);
+
+                        // retrieve user_pool_limit_orders
+                        const userPoolLimitOrdersCacheEndpoint =
+                            GRAPHCACHE_SMALL_URL + '/user_pool_limit_orders?';
+                        fetch(
+                            userPoolLimitOrdersCacheEndpoint +
+                                new URLSearchParams({
+                                    user: props.userAddress,
+                                    base: sortedTokens[0].toLowerCase(),
+                                    quote: sortedTokens[1].toLowerCase(),
+                                    poolIdx:
+                                        props.chainData.poolIndex.toString(),
+                                    chainId: props.chainData.chainId,
+                                }),
+                        )
+                            .then((response) => response?.json())
+                            .then((json) => {
+                                const userPoolLimitOrderStates = json?.data;
+                                const crocEnv = props.crocEnv;
+                                if (userPoolLimitOrderStates && crocEnv) {
+                                    Promise.all(
+                                        userPoolLimitOrderStates.map(
+                                            (
+                                                limitOrder: LimitOrderServerIF,
+                                            ) => {
+                                                return getLimitOrderData(
+                                                    limitOrder,
+                                                    props.searchableTokens,
+                                                    crocEnv,
+                                                    props.chainData.chainId,
+                                                    props.lastBlockNumber,
+                                                    props.cachedFetchTokenPrice,
+                                                    props.cachedQuerySpotPrice,
+                                                    props.cachedTokenDetails,
+                                                    props.cachedEnsResolve,
+                                                );
+                                            },
+                                        ),
+                                    ).then((updatedLimitOrderStates) => {
+                                        dispatch(
+                                            setUserLimitOrdersByPool({
+                                                dataReceived: true,
+                                                limitOrders:
+                                                    updatedLimitOrderStates,
+                                            }),
+                                        );
+
+                                        dispatch(
+                                            setDataLoadingStatus({
+                                                datasetName: 'poolOrderData',
+                                                loadingStatus: false,
+                                            }),
+                                        );
+                                    });
+                                } else {
+                                    dispatch(
+                                        setUserLimitOrdersByPool({
+                                            dataReceived: false,
+                                            limitOrders: [],
+                                        }),
+                                    );
+                                    dispatch(
+                                        setDataLoadingStatus({
+                                            datasetName: 'poolOrderData',
+                                            loadingStatus: false,
+                                        }),
+                                    );
+                                }
+                            })
+                            .catch(console.error);
+                    }
                 }
             }
         }
     }, [
+        props.userAddress,
         props.receiptCount,
         rtkMatchesParams,
         tradeData.tokenA.address,

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -66,7 +66,7 @@ function Orders(props: propsIF) {
         if (isAccountView) setLimitOrderData(activeAccountLimitOrderData || []);
         else if (!showAllData)
             setLimitOrderData(
-                graphData?.limitOrdersByUser?.limitOrders.filter(
+                graphData?.userLimitOrdersByPool?.limitOrders.filter(
                     (order) =>
                         order.base.toLowerCase() ===
                             baseTokenAddress.toLowerCase() &&
@@ -81,7 +81,7 @@ function Orders(props: propsIF) {
     }, [
         showAllData,
         activeAccountLimitOrderData,
-        graphData?.limitOrdersByUser,
+        graphData?.userLimitOrdersByPool,
         graphData?.limitOrdersByPool,
     ]);
 

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -80,9 +80,10 @@ function Orders(props: propsIF) {
         }
     }, [
         showAllData,
+        isAccountView,
         activeAccountLimitOrderData,
-        graphData?.userLimitOrdersByPool,
         graphData?.limitOrdersByPool,
+        graphData?.userLimitOrdersByPool,
     ]);
 
     useEffect(() => {
@@ -102,6 +103,7 @@ function Orders(props: propsIF) {
         else setIsLoading(graphData?.dataLoadingStatus.isPoolOrderDataLoading);
     }, [
         showAllData,
+        isAccountView,
         connectedAccountActive,
         graphData?.dataLoadingStatus.isConnectedUserOrderDataLoading,
         graphData?.dataLoadingStatus.isConnectedUserPoolOrderDataLoading,

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -96,13 +96,15 @@ function Orders(props: propsIF) {
             );
         else if (!showAllData)
             setIsLoading(
-                graphData?.dataLoadingStatus.isConnectedUserOrderDataLoading,
+                graphData?.dataLoadingStatus
+                    .isConnectedUserPoolOrderDataLoading,
             );
         else setIsLoading(graphData?.dataLoadingStatus.isPoolOrderDataLoading);
     }, [
         showAllData,
         connectedAccountActive,
         graphData?.dataLoadingStatus.isConnectedUserOrderDataLoading,
+        graphData?.dataLoadingStatus.isConnectedUserPoolOrderDataLoading,
         graphData?.dataLoadingStatus.isLookupUserOrderDataLoading,
         graphData?.dataLoadingStatus.isPoolOrderDataLoading,
     ]);

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -80,6 +80,7 @@ function Ranges(props: propsIF) {
         }
     }, [
         showAllData,
+        isAccountView,
         activeAccountPositionData,
         graphData?.positionsByUser,
         graphData?.userPositionsByPool,
@@ -102,6 +103,7 @@ function Ranges(props: propsIF) {
         else setIsLoading(graphData?.dataLoadingStatus.isPoolRangeDataLoading);
     }, [
         showAllData,
+        isAccountView,
         connectedAccountActive,
         graphData?.dataLoadingStatus.isConnectedUserRangeDataLoading,
         graphData?.dataLoadingStatus.isConnectedUserPoolRangeDataLoading,

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -96,13 +96,15 @@ function Ranges(props: propsIF) {
             );
         else if (!showAllData)
             setIsLoading(
-                graphData?.dataLoadingStatus.isConnectedUserRangeDataLoading,
+                graphData?.dataLoadingStatus
+                    .isConnectedUserPoolRangeDataLoading,
             );
         else setIsLoading(graphData?.dataLoadingStatus.isPoolRangeDataLoading);
     }, [
         showAllData,
         connectedAccountActive,
         graphData?.dataLoadingStatus.isConnectedUserRangeDataLoading,
+        graphData?.dataLoadingStatus.isConnectedUserPoolRangeDataLoading,
         graphData?.dataLoadingStatus.isLookupUserRangeDataLoading,
         graphData?.dataLoadingStatus.isPoolRangeDataLoading,
     ]);

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -66,7 +66,7 @@ function Ranges(props: propsIF) {
         if (isAccountView) setRangeData(activeAccountPositionData || []);
         else if (!showAllData)
             setRangeData(
-                graphData?.positionsByUser?.positions.filter(
+                graphData?.userPositionsByPool?.positions.filter(
                     (position) =>
                         position.base.toLowerCase() ===
                             baseTokenAddress.toLowerCase() &&
@@ -82,7 +82,7 @@ function Ranges(props: propsIF) {
         showAllData,
         activeAccountPositionData,
         graphData?.positionsByUser,
-        graphData?.positionsByPool,
+        graphData?.userPositionsByPool,
     ]);
 
     useEffect(() => {

--- a/src/contexts/TradeTokenContext.tsx
+++ b/src/contexts/TradeTokenContext.tsx
@@ -85,6 +85,7 @@ export const TradeTokenContextProvider = (props: {
         crocEnv,
         pathname: location.pathname,
         chainData,
+        userAddress,
         searchableTokens: tokens.tokenUniv,
         receiptCount: receiptData.sessionReceipts.length,
         lastBlockNumber,

--- a/src/utils/state/graphDataSlice.ts
+++ b/src/utils/state/graphDataSlice.ts
@@ -32,7 +32,9 @@ export interface PoolRequestParams {
 export interface DataLoadingStatus {
     isConnectedUserTxDataLoading: boolean;
     isConnectedUserOrderDataLoading: boolean;
+    isConnectedUserPoolOrderDataLoading: boolean;
     isConnectedUserRangeDataLoading: boolean;
+    isConnectedUserPoolRangeDataLoading: boolean;
     isLookupUserTxDataLoading: boolean;
     isLookupUserOrderDataLoading: boolean;
     isLookupUserRangeDataLoading: boolean;
@@ -119,7 +121,9 @@ const initialState: graphData = {
     dataLoadingStatus: {
         isConnectedUserTxDataLoading: true,
         isConnectedUserOrderDataLoading: true,
+        isConnectedUserPoolOrderDataLoading: true,
         isConnectedUserRangeDataLoading: true,
+        isConnectedUserPoolRangeDataLoading: true,
         isLookupUserTxDataLoading: true,
         isLookupUserOrderDataLoading: true,
         isLookupUserRangeDataLoading: true,
@@ -546,8 +550,16 @@ export const graphDataSlice = createSlice({
                     state.dataLoadingStatus.isConnectedUserOrderDataLoading =
                         action.payload.loadingStatus;
                     break;
+                case 'connectedUserPoolOrderData':
+                    state.dataLoadingStatus.isConnectedUserPoolOrderDataLoading =
+                        action.payload.loadingStatus;
+                    break;
                 case 'connectedUserRangeData':
                     state.dataLoadingStatus.isConnectedUserRangeDataLoading =
+                        action.payload.loadingStatus;
+                    break;
+                case 'connectedUserPoolRangeData':
+                    state.dataLoadingStatus.isConnectedUserPoolRangeDataLoading =
                         action.payload.loadingStatus;
                     break;
                 case 'lookupUserTxData':

--- a/src/utils/state/graphDataSlice.ts
+++ b/src/utils/state/graphDataSlice.ts
@@ -8,6 +8,7 @@ export interface graphData {
     lastBlock: number;
     lastBlockPoll?: NodeJS.Timer;
     positionsByUser: PositionsByUser;
+    userPositionsByPool: PositionsByPool;
     positionsByPool: PositionsByPool;
     leaderboardByPool: PositionsByPool;
     changesByUser: ChangesByUser;
@@ -16,6 +17,7 @@ export interface graphData {
     liquidityData?: LiquidityDataIF;
     liquidityRequest?: PoolRequestParams;
     limitOrdersByUser: LimitOrdersByUser;
+    userLimitOrdersByPool: LimitOrdersByPool;
     limitOrdersByPool: LimitOrdersByPool;
     dataLoadingStatus: DataLoadingStatus;
 }
@@ -103,11 +105,13 @@ export interface ChangesByPool {
 const initialState: graphData = {
     lastBlock: 0,
     positionsByUser: { dataReceived: false, positions: [] },
+    userPositionsByPool: { dataReceived: false, positions: [] },
     positionsByPool: { dataReceived: false, positions: [] },
     leaderboardByPool: { dataReceived: false, positions: [] },
     changesByUser: { dataReceived: false, changes: [] },
     changesByPool: { dataReceived: false, changes: [] },
     limitOrdersByUser: { dataReceived: false, limitOrders: [] },
+    userLimitOrdersByPool: { dataReceived: false, limitOrders: [] },
     limitOrdersByPool: { dataReceived: false, limitOrders: [] },
     candlesForAllPools: { pools: [] },
     liquidityData: undefined,
@@ -181,6 +185,12 @@ export const graphDataSlice = createSlice({
         setPositionsByPool: (state, action: PayloadAction<PositionsByPool>) => {
             state.positionsByPool = action.payload;
         },
+        setUserPositionsByPool: (
+            state,
+            action: PayloadAction<PositionsByPool>,
+        ) => {
+            state.userPositionsByPool = action.payload;
+        },
         setLeaderboardByPool: (
             state,
             action: PayloadAction<PositionsByPool>,
@@ -192,6 +202,12 @@ export const graphDataSlice = createSlice({
             action: PayloadAction<LimitOrdersByUser>,
         ) => {
             state.limitOrdersByUser = action.payload;
+        },
+        setUserLimitOrdersByPool: (
+            state,
+            action: PayloadAction<LimitOrdersByPool>,
+        ) => {
+            state.userLimitOrdersByPool = action.payload;
         },
         setLimitOrdersByPool: (
             state,
@@ -595,6 +611,7 @@ export const {
     setLastBlockPoll,
     setPositionsByUser,
     addPositionsByUser,
+    setUserPositionsByPool,
     setPositionsByPool,
     setLeaderboardByPool,
     updateLeaderboard,
@@ -604,6 +621,7 @@ export const {
     setCandles,
     addCandles,
     setLimitOrdersByUser,
+    setUserLimitOrdersByPool,
     setLimitOrdersByPool,
     setChangesByUser,
     addChangesByUser,


### PR DESCRIPTION
### Describe your changes 

This change implements the user_pool_limit_orders and user_pool_positions server endpoints for retrieving data specific to a user and the pool in view on the /trade route.

### Link the related issue
Closes #2525
Closes #2526

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)