### PR TITLE
Add figma hover states

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -140,9 +140,11 @@ export default function RangesMenu(props: propsIF) {
                 lowTick: position.bidTick.toString(),
                 highTick: position.askTick.toString(),
             })}
-            onClick={() => setSimpleRangeWidth(10)}
+            onClick={() => {
+                setSimpleRangeWidth(10);
+                setCurrentRangeInReposition(position.positionId);
+            }}
             state={{ position: position }}
-            onClick={() => setCurrentRangeInReposition(position.positionId)}
         >
             Reposition
         </Link>

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -66,7 +66,8 @@ export default function RangesMenu(props: propsIF) {
     const {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
-    const { setSimpleRangeWidth } = useContext(RangeContext);
+    const { setSimpleRangeWidth, setCurrentRangeInReposition } =
+        useContext(RangeContext);
     const { sidebar } = useContext(SidebarContext);
     const { handlePulseAnimation } = useContext(TradeTableContext);
 
@@ -137,6 +138,7 @@ export default function RangesMenu(props: propsIF) {
                 highTick: position.askTick.toString(),
             })}
             state={{ position: position }}
+            onClick={() => setCurrentRangeInReposition(position.positionId)}
         >
             Reposition
         </Link>

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -172,7 +172,7 @@ export default function RangesMenu(props: propsIF) {
 
     const addButton = (
         <Link
-            style={{ opacity: '1' }}
+            style={{ opacity: '1', zIndex: '3' }}
             className={styles.option_button}
             to={linkGenPool.getFullURL({
                 chain: chainId,
@@ -181,7 +181,8 @@ export default function RangesMenu(props: propsIF) {
                 lowTick: position.bidTick.toString(),
                 highTick: position.askTick.toString(),
             })}
-            onClick={() => {
+            onClick={(event) => {
+                event.stopPropagation();
                 handleCopyClick();
                 setCurrentRangeInAdd(position.positionId);
             }}

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -143,6 +143,7 @@ export default function RangesMenu(props: propsIF) {
             onClick={() => {
                 setSimpleRangeWidth(10);
                 setCurrentRangeInReposition(position.positionId);
+                setCurrentRangeInAdd('');
             }}
             state={{ position: position }}
         >

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -66,8 +66,11 @@ export default function RangesMenu(props: propsIF) {
     const {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
-    const { setSimpleRangeWidth, setCurrentRangeInReposition } =
-        useContext(RangeContext);
+    const {
+        setSimpleRangeWidth,
+        setCurrentRangeInReposition,
+        setCurrentRangeInAdd,
+    } = useContext(RangeContext);
     const { sidebar } = useContext(SidebarContext);
     const { handlePulseAnimation } = useContext(TradeTableContext);
 
@@ -178,7 +181,10 @@ export default function RangesMenu(props: propsIF) {
                 lowTick: position.bidTick.toString(),
                 highTick: position.askTick.toString(),
             })}
-            onClick={handleCopyClick}
+            onClick={() => {
+                handleCopyClick();
+                setCurrentRangeInAdd(position.positionId);
+            }}
         >
             Add
         </Link>

--- a/src/components/Portfolio/ExchangeBalance/Withdraw/WithdrawButton/WithdrawButton.module.css
+++ b/src/components/Portfolio/ExchangeBalance/Withdraw/WithdrawButton/WithdrawButton.module.css
@@ -1,3 +1,4 @@
 .button_container_disabled button {
     color: var(--text3);
 }
+

--- a/src/components/Trade/Range/RangeButton/RangeButton.tsx
+++ b/src/components/Trade/Range/RangeButton/RangeButton.tsx
@@ -23,21 +23,30 @@ function RangeButton(props: propsIF) {
 
     const { bypassConfirmRange } = useContext(UserPreferenceContext);
 
+    let title;
+
+    switch (true) {
+        case areBothAckd:
+            if (rangeAllowed) {
+                if (bypassConfirmRange.isEnabled) {
+                    title = isAdd
+                        ? `Add ${isAmbient ? 'Ambient' : ''} Liquidity`
+                        : `Submit ${isAmbient ? 'Ambient' : ''} Liquidity`;
+                } else {
+                    title = 'Confirm';
+                }
+            } else {
+                title = rangeButtonErrorMessage;
+            }
+            break;
+
+        default:
+            title = 'Acknowledge';
+    }
+
     return (
         <Button
-            title={
-                areBothAckd
-                    ? rangeAllowed
-                        ? bypassConfirmRange.isEnabled
-                            ? isAdd
-                                ? `Add ${isAmbient ? 'Ambient' : ''} Liquidity`
-                                : `Submit ${
-                                      isAmbient ? 'Ambient' : ''
-                                  } Liquidity`
-                            : 'Confirm'
-                        : rangeButtonErrorMessage
-                    : 'Acknowledge'
-            }
+            title={title}
             action={onClickFn}
             disabled={!rangeAllowed && areBothAckd}
             flat={true}

--- a/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
+++ b/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
@@ -28,7 +28,8 @@ interface propsIF {
 function RepositionHeader(props: propsIF) {
     const { setRangeWidthPercentage, positionHash, resetTxHash } = props;
 
-    const { setSimpleRangeWidth } = useContext(RangeContext);
+    const { setSimpleRangeWidth, setCurrentRangeInReposition } =
+        useContext(RangeContext);
     const { bypassConfirmRepo, repoSlippage } = useContext(
         UserPreferenceContext,
     );
@@ -76,6 +77,7 @@ function RepositionHeader(props: propsIF) {
                     setSimpleRangeWidth(10);
                     navigate(exitPath, { replace: true });
                     resetTxHash();
+                    setCurrentRangeInReposition('');
                 }}
             />
         </ContentHeader>

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -21,6 +21,8 @@ import { TradeTableContext } from '../../../../contexts/TradeTableContext';
 import usePagination from '../../../Global/Pagination/usePagination';
 import { RowsPerPageDropdown } from '../../../Global/Pagination/RowsPerPageDropdown';
 import Spinner from '../../../Global/Spinner/Spinner';
+import { useLocation } from 'react-router-dom';
+import { RangeContext } from '../../../../contexts/RangeContext';
 
 const NUM_RANGES_WHEN_COLLAPSED = 10; // Number of ranges we show when the table is collapsed (i.e. half page)
 // NOTE: this is done to improve rendering speed for this page.
@@ -45,7 +47,7 @@ function Ranges(props: propsIF) {
     const {
         sidebar: { isOpen: isSidebarOpen },
     } = useContext(SidebarContext);
-
+    const { setCurrentRangeInReposition } = useContext(RangeContext);
     // only show all data when on trade tabs page
     const showAllData = !isAccountView && showAllDataSelection;
     const expandTradeTable = !isAccountView && expandTradeTableSelection;
@@ -61,6 +63,11 @@ function Ranges(props: propsIF) {
 
     const [rangeData, setRangeData] = useState<PositionIF[]>([]);
     const [isLoading, setIsLoading] = useState(true);
+    const path = useLocation().pathname;
+
+    if (!path.includes('reposition')) {
+        setCurrentRangeInReposition('');
+    }
 
     useEffect(() => {
         if (isAccountView) setRangeData(activeAccountPositionData || []);

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -45,7 +45,8 @@ function RangesRow(props: propsIF) {
         setCurrentPositionActive,
     } = useContext(TradeTableContext);
 
-    const { currentRangeInReposition } = useContext(RangeContext);
+    const { currentRangeInReposition, currentRangeInAdd } =
+        useContext(RangeContext);
 
     // only show all data when on trade tabs page
     const showAllData = !isAccountView && showAllDataSelection;
@@ -188,7 +189,8 @@ function RangesRow(props: propsIF) {
 
     const activePositionStyle =
         position.firstMintTx === currentPositionActive ||
-        position.positionId === currentRangeInReposition
+        position.positionId === currentRangeInReposition ||
+        position.positionId === currentRangeInAdd
             ? styles.active_position_style
             : '';
 

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -14,6 +14,7 @@ import useCopyToClipboard from '../../../../../utils/hooks/useCopyToClipboard';
 import rangeRowConstants from '../rangeRowConstants';
 import { AppStateContext } from '../../../../../contexts/AppStateContext';
 import { TradeTableContext } from '../../../../../contexts/TradeTableContext';
+import { RangeContext } from '../../../../../contexts/RangeContext';
 
 interface propsIF {
     showPair: boolean;
@@ -43,6 +44,8 @@ function RangesRow(props: propsIF) {
         currentPositionActive,
         setCurrentPositionActive,
     } = useContext(TradeTableContext);
+
+    const { currentRangeInReposition } = useContext(RangeContext);
 
     // only show all data when on trade tabs page
     const showAllData = !isAccountView && showAllDataSelection;
@@ -184,7 +187,8 @@ function RangesRow(props: propsIF) {
             : 'username_base_color';
 
     const activePositionStyle =
-        position.firstMintTx === currentPositionActive
+        position.firstMintTx === currentPositionActive ||
+        position.positionId === currentRangeInReposition
             ? styles.active_position_style
             : '';
 

--- a/src/contexts/RangeContext.tsx
+++ b/src/contexts/RangeContext.tsx
@@ -16,6 +16,8 @@ interface RangeContextIF {
     setRescaleRangeBoundariesWithSlider: Dispatch<SetStateAction<boolean>>;
     chartTriggeredBy: string;
     setChartTriggeredBy: Dispatch<SetStateAction<string>>;
+    currentRangeInReposition: string;
+    setCurrentRangeInReposition: Dispatch<SetStateAction<string>>;
 }
 
 export const RangeContext = createContext<RangeContextIF>({} as RangeContextIF);
@@ -24,6 +26,9 @@ export const RangeContextProvider = (props: { children: React.ReactNode }) => {
     const [maxRangePrice, setMaxRangePrice] = useState<number>(0);
     const [minRangePrice, setMinRangePrice] = useState<number>(0);
     const [simpleRangeWidth, setSimpleRangeWidth] = useState<number>(10);
+
+    const [currentRangeInReposition, setCurrentRangeInReposition] =
+        useState<string>('');
 
     const [
         rescaleRangeBoundariesWithSlider,
@@ -42,6 +47,8 @@ export const RangeContextProvider = (props: { children: React.ReactNode }) => {
         setRescaleRangeBoundariesWithSlider,
         chartTriggeredBy,
         setChartTriggeredBy,
+        currentRangeInReposition,
+        setCurrentRangeInReposition,
     };
 
     return (

--- a/src/contexts/RangeContext.tsx
+++ b/src/contexts/RangeContext.tsx
@@ -18,6 +18,8 @@ interface RangeContextIF {
     setChartTriggeredBy: Dispatch<SetStateAction<string>>;
     currentRangeInReposition: string;
     setCurrentRangeInReposition: Dispatch<SetStateAction<string>>;
+    currentRangeInAdd: string;
+    setCurrentRangeInAdd: Dispatch<SetStateAction<string>>;
 }
 
 export const RangeContext = createContext<RangeContextIF>({} as RangeContextIF);
@@ -29,6 +31,7 @@ export const RangeContextProvider = (props: { children: React.ReactNode }) => {
 
     const [currentRangeInReposition, setCurrentRangeInReposition] =
         useState<string>('');
+    const [currentRangeInAdd, setCurrentRangeInAdd] = useState<string>('');
 
     const [
         rescaleRangeBoundariesWithSlider,
@@ -49,6 +52,8 @@ export const RangeContextProvider = (props: { children: React.ReactNode }) => {
         setChartTriggeredBy,
         currentRangeInReposition,
         setCurrentRangeInReposition,
+        currentRangeInAdd,
+        setCurrentRangeInAdd,
     };
 
     return (

--- a/src/css/GlobalCssClassnames.css
+++ b/src/css/GlobalCssClassnames.css
@@ -159,6 +159,9 @@ aside.emoji-picker-react {
     outline: 1px solid transparent !important;
 }
 
+.MuiPaginationItem-root:hover{
+    color: var(--text1) !important;
+} 
 .Mui-selected.MuiPaginationItem-root {
     color: var(--text1) !important;
     background: transparent !important;

--- a/src/pages/Trade/Range/Range.tsx
+++ b/src/pages/Trade/Range/Range.tsx
@@ -96,6 +96,7 @@ function Range() {
         setChartTriggeredBy,
         chartTriggeredBy,
         setRescaleRangeBoundariesWithSlider,
+        setCurrentRangeInAdd,
     } = useContext(RangeContext);
     const { tokens } = useContext(TokenContext);
     const {
@@ -325,6 +326,12 @@ function Range() {
             defaultHighTick,
         ],
     );
+
+    useEffect(() => {
+        if (!isAdd) {
+            setCurrentRangeInAdd('');
+        }
+    }, [isAdd]);
 
     const [minPriceDifferencePercentage, setMinPriceDifferencePercentage] =
         useState(defaultMinPriceDifferencePercentage);

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -82,6 +82,7 @@ function Reposition() {
         setSimpleRangeWidth,
         setMaxRangePrice: setMaxPrice,
         setMinRangePrice: setMinPrice,
+        setCurrentRangeInReposition,
     } = useContext(RangeContext);
 
     const [newRepositionTransactionHash, setNewRepositionTransactionHash] =
@@ -124,6 +125,9 @@ function Reposition() {
 
     // position data from the locationHook object
     const { position } = locationHook.state as { position: PositionIF };
+    if (position) {
+        setCurrentRangeInReposition(position.positionId);
+    }
 
     const [concLiq, setConcLiq] = useState<string>('');
 

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -125,9 +125,13 @@ function Reposition() {
 
     // position data from the locationHook object
     const { position } = locationHook.state as { position: PositionIF };
-    if (position) {
-        setCurrentRangeInReposition(position.positionId);
-    }
+
+    useEffect(() => {
+        setCurrentRangeInReposition('');
+        if (position) {
+            setCurrentRangeInReposition(position.positionId);
+        }
+    }, [position]);
 
     const [concLiq, setConcLiq] = useState<string>('');
 


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
When a user is repositioning or adding to a transaction, it is easy for them to lose track of which transaction they clicked on. This PR adds an active hover state to the position that is being repositioned.
<img width="1673" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/db0f9bec-abe7-48a6-bf0f-aef024d82ba0">

