### PR TITLE
Remove uninitialized pools from recent list

### DIFF
--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -38,7 +38,7 @@ const PageHeader = function () {
     const {
         wagmiModal: { open: openWagmiModal },
     } = useContext(AppStateContext);
-    const { setCrocEnv } = useContext(CrocEnvContext);
+    const { crocEnv, setCrocEnv } = useContext(CrocEnvContext);
     const { poolPriceDisplay } = useContext(PoolContext);
     const { recentPools } = useContext(SidebarContext);
     const { setShowAllData } = useContext(TradeTableContext);
@@ -168,10 +168,20 @@ const PageHeader = function () {
     const quoteAddressInRtk = tradeData.quoteToken.address;
 
     useEffect(() => {
-        if (baseAddressInRtk && quoteAddressInRtk) {
-            recentPools.addPool(tradeData.baseToken, tradeData.quoteToken);
+        if (baseAddressInRtk && quoteAddressInRtk && crocEnv) {
+            const promise = crocEnv
+                .pool(tradeData.baseToken.address, tradeData.quoteToken.address)
+                .isInit();
+            Promise.resolve(promise).then((poolExists: boolean) => {
+                console.log({ poolExists });
+                poolExists &&
+                    recentPools.addPool(
+                        tradeData.baseToken,
+                        tradeData.quoteToken,
+                    );
+            });
         }
-    }, [baseAddressInRtk, quoteAddressInRtk]);
+    }, [baseAddressInRtk, quoteAddressInRtk, crocEnv]);
 
     const poolPriceDisplayWithDenom = poolPriceDisplay
         ? isDenomBase

--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -174,10 +174,7 @@ const PageHeader = function () {
                 .isInit();
             Promise.resolve(promise).then((poolExists: boolean) => {
                 poolExists &&
-                    recentPools.addPool(
-                        tradeData.baseToken,
-                        tradeData.quoteToken,
-                    );
+                    recentPools.add(tradeData.baseToken, tradeData.quoteToken);
             });
         }
     }, [baseAddressInRtk, quoteAddressInRtk, crocEnv]);

--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -173,7 +173,6 @@ const PageHeader = function () {
                 .pool(tradeData.baseToken.address, tradeData.quoteToken.address)
                 .isInit();
             Promise.resolve(promise).then((poolExists: boolean) => {
-                console.log({ poolExists });
                 poolExists &&
                     recentPools.addPool(
                         tradeData.baseToken,

--- a/src/App/hooks/useRecentPools.ts
+++ b/src/App/hooks/useRecentPools.ts
@@ -13,6 +13,12 @@ export interface recentPoolsMethodsIF {
     resetPools: () => void;
 }
 
+// !important:  logic to prevent addition of non-existent pools has been relocated
+// !important:  ... from this file to the in-situ function call of `addPool` in the
+// !important:  ... PageHeader.tsx file to (A) prevent a flash in the sidebar when
+// !important:  ... updating and (B) to allow us to force a token pair into the recent
+// !important:  ... token list should the need ever arise
+
 // Hook for maintaining a list of pools the user has accessed during this session.
 // Pools are sorted in order from most recently to least recently used. Viewing any
 //  pool-related page will bump that pool to the front of the list.

--- a/src/App/hooks/useRecentPools.ts
+++ b/src/App/hooks/useRecentPools.ts
@@ -1,9 +1,6 @@
 import { sortBaseQuoteTokens } from '@crocswap-libs/sdk';
-import { useContext, useEffect, useMemo, useState } from 'react';
-import sortTokens from '../../utils/functions/sortTokens';
+import { useMemo, useState } from 'react';
 import { TokenIF } from '../../utils/interfaces/exports';
-import { tokenMethodsIF } from './useTokens';
-import { CrocEnvContext } from '../../contexts/CrocEnvContext';
 
 export interface SmallerPoolIF {
     baseToken: TokenIF;
@@ -19,48 +16,9 @@ export interface recentPoolsMethodsIF {
 // Hook for maintaining a list of pools the user has accessed during this session.
 // Pools are sorted in order from most recently to least recently used. Viewing any
 //  pool-related page will bump that pool to the front of the list.
-export const useRecentPools = (
-    chainId: string,
-    tokenA: TokenIF,
-    tokenB: TokenIF,
-    tokens: tokenMethodsIF,
-): recentPoolsMethodsIF => {
-    const { crocEnv } = useContext(CrocEnvContext);
-
+export const useRecentPools = (chainId: string): recentPoolsMethodsIF => {
     // array of pools the user has interacted with in the current session
     const [recentPools, setRecentPools] = useState<SmallerPoolIF[]>([]);
-
-    // subset of recent pools filtered for current chain and being initialized
-    const realPools = useMemo<SmallerPoolIF[]>(() => {
-        const existingPools: SmallerPoolIF[] = [];
-        if (crocEnv) {
-            recentPools.forEach((pool: SmallerPoolIF) => {
-                const promise = crocEnv
-                    .pool(pool.baseToken.address, pool.quoteToken.address)
-                    .isInit();
-                Promise.resolve(promise).then(
-                    (result: boolean) => result && existingPools.push(pool),
-                );
-            });
-        }
-        return existingPools;
-    }, [recentPools, crocEnv]);
-
-    // add pools to the recent pools list (in-session)
-    // runs every time to the current token pair changes
-    // later this will need more logic for a Pool ID value
-    useEffect(() => {
-        // sort current token pair as base and quote
-        const [baseToken, quoteToken]: TokenIF[] = sortTokens(tokenA, tokenB);
-        // add the pool to the list of recent pools
-        // fn has internal logic to handle duplicate values
-        if (
-            tokens.verifyToken(baseToken.address) &&
-            tokens.verifyToken(quoteToken.address)
-        ) {
-            addPool(baseToken, quoteToken);
-        }
-    }, [tokenA.address, tokenB.address]);
 
     // fn to add a token to the recentTokens array
     function addPool(tokenA: TokenIF, tokenB: TokenIF): void {
@@ -109,7 +67,7 @@ export const useRecentPools = (
         const currentChain: number = parseInt(chainId);
         // filter out pairs for which a pool does not yet exist
         // return a set number of pools on the current active chain
-        return realPools
+        return recentPools
             .filter(
                 (pool: SmallerPoolIF) =>
                     pool.baseToken.chainId === currentChain &&

--- a/src/App/hooks/useRecentPools.ts
+++ b/src/App/hooks/useRecentPools.ts
@@ -9,9 +9,9 @@ export interface SmallerPoolIF {
 }
 
 export interface recentPoolsMethodsIF {
-    addPool: (tokenA: TokenIF, tokenB: TokenIF) => void;
-    getPools: (count: number) => SmallerPoolIF[];
-    resetPools: () => void;
+    add: (tokenA: TokenIF, tokenB: TokenIF) => void;
+    get: (count: number) => SmallerPoolIF[];
+    reset: () => void;
 }
 
 // !important:  logic to prevent addition of non-existent pools has been relocated
@@ -88,9 +88,9 @@ export const useRecentPools = (chainId: string): recentPoolsMethodsIF => {
 
     return useMemo(
         () => ({
-            addPool,
-            getPools,
-            resetPools,
+            add: addPool,
+            get: getPools,
+            reset: resetPools,
         }),
         [recentPools],
     );

--- a/src/App/hooks/useRecentPools.ts
+++ b/src/App/hooks/useRecentPools.ts
@@ -44,7 +44,7 @@ export const useRecentPools = (chainId: string): recentPoolsMethodsIF => {
 
         const nextPool = { baseToken: baseToken, quoteToken: quoteToken };
 
-        function poolMatches(pool: SmallerPoolIF) {
+        function matchPools(pool: SmallerPoolIF): boolean {
             return (
                 pool.baseToken.address.toLowerCase() ===
                     baseTokenAddr.toLowerCase() &&
@@ -57,11 +57,11 @@ export const useRecentPools = (chainId: string): recentPoolsMethodsIF => {
         if (recentPools.length == 0) {
             // Initialize empty list
             setRecentPools([nextPool]);
-        } else if (poolMatches(recentPools[0])) {
+        } else if (matchPools(recentPools[0])) {
             // Do nothing because front matches
         } else {
             // Remove the pool (if previously present) and move to the front of the list
-            const removed = recentPools.filter((pool) => !poolMatches(pool));
+            const removed = recentPools.filter((pool) => !matchPools(pool));
             setRecentPools([nextPool, ...removed]);
         }
     }

--- a/src/App/hooks/useRecentPools.ts
+++ b/src/App/hooks/useRecentPools.ts
@@ -1,6 +1,7 @@
 import { sortBaseQuoteTokens } from '@crocswap-libs/sdk';
 import { useMemo, useState } from 'react';
 import { TokenIF } from '../../utils/interfaces/exports';
+import sortTokens from '../../utils/functions/sortTokens';
 
 export interface SmallerPoolIF {
     baseToken: TokenIF;
@@ -17,7 +18,7 @@ export interface recentPoolsMethodsIF {
 // !important:  ... from this file to the in-situ function call of `addPool` in the
 // !important:  ... PageHeader.tsx file to (A) prevent a flash in the sidebar when
 // !important:  ... updating and (B) to allow us to force a token pair into the recent
-// !important:  ... token list should the need ever arise
+// !important:  ... token list should the need ever
 
 // Hook for maintaining a list of pools the user has accessed during this session.
 // Pools are sorted in order from most recently to least recently used. Viewing any
@@ -39,10 +40,8 @@ export const useRecentPools = (chainId: string): recentPoolsMethodsIF => {
             tokenB.address,
         );
 
-        const [baseToken, quoteToken] =
-            baseTokenAddr === tokenA.address
-                ? [tokenA, tokenB]
-                : [tokenB, tokenA];
+        const [baseToken, quoteToken] = sortTokens(tokenA, tokenB);
+
         const nextPool = { baseToken: baseToken, quoteToken: quoteToken };
 
         function poolMatches(pool: SmallerPoolIF) {

--- a/src/components/Global/Sidebar/RecentPools/RecentPools.tsx
+++ b/src/components/Global/Sidebar/RecentPools/RecentPools.tsx
@@ -26,7 +26,7 @@ function RecentPools(props: propsIF) {
                 <div>TVL</div>
             </header>
             <div className={styles.content}>
-                {recentPools.getPools(5).map((pool: SmallerPoolIF) => (
+                {recentPools.get(5).map((pool: SmallerPoolIF) => (
                     <RecentPoolsCard
                         pool={pool}
                         key={'recent_pool_' + JSON.stringify(pool)}

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,5 +1,11 @@
 import { useMediaQuery } from '@material-ui/core';
-import React, { createContext, useEffect, useMemo, useContext } from 'react';
+import {
+    ReactNode,
+    createContext,
+    useEffect,
+    useMemo,
+    useContext,
+} from 'react';
 import { useLocation } from 'react-router-dom';
 import {
     recentPoolsMethodsIF,
@@ -12,7 +18,6 @@ import isJsonString from '../utils/functions/isJsonString';
 import { useAppSelector } from '../utils/hooks/reduxToolkit';
 import { AppStateContext } from './AppStateContext';
 import { CrocEnvContext } from './CrocEnvContext';
-import { TokenContext } from './TokenContext';
 
 interface SidebarStateIF {
     recentPools: recentPoolsMethodsIF;
@@ -23,16 +28,13 @@ export const SidebarContext = createContext<SidebarStateIF>(
     {} as SidebarStateIF,
 );
 
-export const SidebarContextProvider = (props: {
-    children: React.ReactNode;
-}) => {
+export const SidebarContextProvider = (props: { children: ReactNode }) => {
     const {
         snackbar: { open: openSnackbar },
     } = useContext(AppStateContext);
     const { chainData } = useContext(CrocEnvContext);
-    const { tokens } = useContext(TokenContext);
 
-    const { tradeData, receiptData } = useAppSelector((state) => state);
+    const { receiptData } = useAppSelector((state) => state);
     const lastReceipt =
         receiptData.sessionReceipts.length > 0 &&
         isJsonString(receiptData.sessionReceipts[0])
@@ -48,12 +50,7 @@ export const SidebarContextProvider = (props: {
 
     const sidebar = useSidebar(location.pathname);
     // hook to manage recent pool data in-session
-    const recentPools: recentPoolsMethodsIF = useRecentPools(
-        chainData.chainId,
-        tradeData.tokenA,
-        tradeData.tokenB,
-        tokens,
-    );
+    const recentPools: recentPoolsMethodsIF = useRecentPools(chainData.chainId);
 
     const sidebarState = {
         sidebar,


### PR DESCRIPTION
### Describe your changes 
* Gatekeep functionality in `PageHeader.tsx` to prevent addition of non-existent pools to the **Recent Pools** sidebar list
* Remove redundant action to add a pool to the **Recent Pools** sidebar list (existed both in `useRecentPools.ts` and `PageHeader.tsx`)
* General improvements to code in `useRecentPools.ts` file

I did consult with @miyuki-eto prior to documenting the issue to confirm that adding non-existent pools to the **Recent Pools** list is a bug and not a feature.

### Link the related issue
Closes #2583

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Go to the deployed production [Ambient Finance](https://ambient.finance/) site
2. Navigate between token pairs, note that every token pair is added to the **Recent Pools** sidebar list regardless of whether a pool exists for that pair
3. Go to the deploy preview for this pull request
4. Navigate between token pairs; only pairs with an initialized pool should appear in the **Recent Pools** list

**Environmental conditions which may result in expected but differential behavior.**
None found or anticipated

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
None; code is ready for merge