### PR TITLE
force US number formatting

### DIFF
--- a/src/App/functions/getFormattedNumber.ts
+++ b/src/App/functions/getFormattedNumber.ts
@@ -36,7 +36,7 @@ export function getFormattedNumber({
         valueString = '∞';
     } else if (isUSD) {
         // only display two decimal points for USD values
-        valueString = value.toLocaleString(undefined, {
+        valueString = value.toLocaleString('en-US', {
             minimumFractionDigits: 2,
             maximumFractionDigits: 2,
         });
@@ -45,7 +45,7 @@ export function getFormattedNumber({
         if (value < 0.0001) {
             valueString = value.toExponential(2);
         } else if (value < 2) {
-            valueString = value.toLocaleString(undefined, {
+            valueString = value.toLocaleString('en-US', {
                 minimumFractionDigits: 2,
                 maximumFractionDigits: 6,
             });
@@ -53,7 +53,7 @@ export function getFormattedNumber({
             // prevent scientific notation for inputs
             valueString = Number(value?.toPrecision(3)).toString();
         } else {
-            valueString = value.toLocaleString(undefined, {
+            valueString = value.toLocaleString('en-US', {
                 minimumFractionDigits: minFracDigits,
                 maximumFractionDigits: maxFracDigits,
             });
@@ -71,7 +71,7 @@ export function getFormattedNumber({
         // use abbreviations (k, M, B, T) for big numbers
         valueString = formatAbbrev(value, isTvl);
     } else {
-        valueString = value.toLocaleString(undefined, {
+        valueString = value.toLocaleString('en-US', {
             minimumFractionDigits: minFracDigits,
             maximumFractionDigits: maxFracDigits,
         });

--- a/src/App/functions/swap/getPriceImpactString.ts
+++ b/src/App/functions/swap/getPriceImpactString.ts
@@ -3,7 +3,7 @@ export const getPriceImpactString = (priceImpactNum: number | undefined) => {
         return '…';
     } else {
         const fractionDigits = priceImpactNum >= 100 ? 0 : 2;
-        return priceImpactNum.toLocaleString(undefined, {
+        return priceImpactNum.toLocaleString('en-US', {
             minimumFractionDigits: fractionDigits,
             maximumFractionDigits: fractionDigits,
         });

--- a/src/App/hooks/usePoolPricing.ts
+++ b/src/App/hooks/usePoolPricing.ts
@@ -195,12 +195,12 @@ export function usePoolPricing(props: PoolPricingPropsIF) {
                         const priceChangeString =
                             priceChangePercent > 0
                                 ? '+' +
-                                  priceChangePercent.toLocaleString(undefined, {
+                                  priceChangePercent.toLocaleString('en-US', {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) +
                                   '%'
-                                : priceChangePercent.toLocaleString(undefined, {
+                                : priceChangePercent.toLocaleString('en-US', {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) + '%';

--- a/src/components/Global/PoolCard/PoolCard.tsx
+++ b/src/components/Global/PoolCard/PoolCard.tsx
@@ -178,7 +178,7 @@ export default function PoolCard(props: propsIF) {
                     setPoolVolume(volumeString);
                 }
                 if (apyResult) {
-                    const apyString = apyResult.toLocaleString(undefined, {
+                    const apyString = apyResult.toLocaleString('en-US', {
                         minimumFractionDigits: 2,
                         maximumFractionDigits: 2,
                     });
@@ -216,12 +216,12 @@ export default function PoolCard(props: propsIF) {
                         const priceChangeString =
                             priceChangePercent > 0
                                 ? '+' +
-                                  priceChangePercent.toLocaleString(undefined, {
+                                  priceChangePercent.toLocaleString('en-US', {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) +
                                   '%'
-                                : priceChangePercent.toLocaleString(undefined, {
+                                : priceChangePercent.toLocaleString('en-US', {
                                       minimumFractionDigits: 2,
                                       maximumFractionDigits: 2,
                                   }) + '%';

--- a/src/components/Global/Tabs/Apy/Apy.tsx
+++ b/src/components/Global/Tabs/Apy/Apy.tsx
@@ -13,11 +13,11 @@ export default function Apy(props: ApyProps) {
 
     const amountString = amount
         ? amount >= 1000
-            ? amount.toLocaleString(undefined, {
+            ? amount.toLocaleString('en-US', {
                   minimumFractionDigits: 0,
                   maximumFractionDigits: 0,
               }) + '%+'
-            : amount.toLocaleString(undefined, {
+            : amount.toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               }) + '%'

--- a/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
+++ b/src/components/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
@@ -94,11 +94,11 @@ export default function RangeDetailsSimplify(
 
     const aprAmountString = updatedPositionApy
         ? updatedPositionApy >= 1000
-            ? updatedPositionApy.toLocaleString(undefined, {
+            ? updatedPositionApy.toLocaleString('en-US', {
                   minimumFractionDigits: 0,
                   maximumFractionDigits: 0,
               }) + '%+'
-            : updatedPositionApy.toLocaleString(undefined, {
+            : updatedPositionApy.toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               }) + '%'

--- a/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
+++ b/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
@@ -86,14 +86,14 @@ export default function ConfirmSwapModal(props: propsIF) {
 
     const localeSellString =
         parseFloat(sellQtyString) > 999
-            ? parseFloat(sellQtyString).toLocaleString(undefined, {
+            ? parseFloat(sellQtyString).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
             : sellQtyString;
     const localeBuyString =
         parseFloat(buyQtyString) > 999
-            ? parseFloat(buyQtyString).toLocaleString(undefined, {
+            ? parseFloat(buyQtyString).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
@@ -157,7 +157,7 @@ export default function ConfirmSwapModal(props: propsIF) {
     }, [currentBuyTokenPrice, baselineBuyTokenPrice]);
 
     const buyTokenPriceChangeString = buyTokenPriceChangePercentage
-        ? buyTokenPriceChangePercentage.toLocaleString(undefined, {
+        ? buyTokenPriceChangePercentage.toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })

--- a/src/components/Swap/CurrencySelector/CurrencySelector.tsx
+++ b/src/components/Swap/CurrencySelector/CurrencySelector.tsx
@@ -129,13 +129,13 @@ function CurrencySelector(props: propsIF) {
 
     const walletBalanceLocaleString = props.sellToken
         ? tokenABalance
-            ? parseFloat(tokenABalance).toLocaleString(undefined, {
+            ? parseFloat(tokenABalance).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
             : '...'
         : tokenBBalance
-        ? parseFloat(tokenBBalance || '...').toLocaleString(undefined, {
+        ? parseFloat(tokenBBalance || '...').toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })
@@ -159,7 +159,7 @@ function CurrencySelector(props: propsIF) {
         ? tokenADexBalance
             ? (
                   parseFloat(tokenADexBalance) + parseFloat(tokenABalance)
-              ).toLocaleString(undefined, {
+              ).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
@@ -167,7 +167,7 @@ function CurrencySelector(props: propsIF) {
         : tokenBDexBalance
         ? (
               parseFloat(tokenBDexBalance) + parseFloat(tokenBBalance)
-          ).toLocaleString(undefined, {
+          ).toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })

--- a/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
+++ b/src/components/Trade/Limit/LimitCurrencySelector/LimitCurrencySelector.tsx
@@ -142,7 +142,7 @@ function LimitCurrencySelector(props: propsIF) {
             : '';
 
     const walletBalanceLocaleString = tokenABalance
-        ? parseFloat(tokenABalance).toLocaleString(undefined, {
+        ? parseFloat(tokenABalance).toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })
@@ -164,7 +164,7 @@ function LimitCurrencySelector(props: propsIF) {
     const walletAndSurplusBalanceLocaleString = tokenADexBalance
         ? (
               parseFloat(tokenADexBalance) + parseFloat(tokenABalance)
-          ).toLocaleString(undefined, {
+          ).toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })

--- a/src/components/Trade/Range/AdvancedModeComponents/AdvancedPriceInfo/AdvancedPriceInfo.tsx
+++ b/src/components/Trade/Range/AdvancedModeComponents/AdvancedPriceInfo/AdvancedPriceInfo.tsx
@@ -36,7 +36,7 @@ function AdvancedPriceInfo(props: propsIF) {
     );
 
     const aprPercentageString = aprPercentage
-        ? `${aprPercentage.toLocaleString(undefined, {
+        ? `${aprPercentage.toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })}%`

--- a/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
+++ b/src/components/Trade/Range/RangeCurrencySelector/RangeCurrencySelector.tsx
@@ -125,7 +125,7 @@ function RangeCurrencySelector(props: propsIF) {
         ? tokenADexBalance
             ? (
                   parseFloat(tokenADexBalance) + parseFloat(tokenABalance)
-              ).toLocaleString(undefined, {
+              ).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
@@ -133,7 +133,7 @@ function RangeCurrencySelector(props: propsIF) {
         : tokenBDexBalance
         ? (
               parseFloat(tokenBDexBalance) + parseFloat(tokenBBalance)
-          ).toLocaleString(undefined, {
+          ).toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })
@@ -159,13 +159,13 @@ function RangeCurrencySelector(props: propsIF) {
 
     const walletBalanceLocaleString = isTokenASelector
         ? tokenABalance
-            ? parseFloat(tokenABalance).toLocaleString(undefined, {
+            ? parseFloat(tokenABalance).toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               })
             : '...'
         : tokenBBalance
-        ? parseFloat(tokenBBalance).toLocaleString(undefined, {
+        ? parseFloat(tokenBBalance).toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })

--- a/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
+++ b/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
@@ -66,7 +66,7 @@ function RangePriceInfo(props: propsIF) {
     const dispatch = useAppDispatch();
 
     const aprPercentageString = aprPercentage
-        ? `${aprPercentage.toLocaleString(undefined, {
+        ? `${aprPercentage.toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })}%`

--- a/src/components/Trade/Reposition/RepositionPriceInfo/RepositionPriceInfo.tsx
+++ b/src/components/Trade/Reposition/RepositionPriceInfo/RepositionPriceInfo.tsx
@@ -127,7 +127,7 @@ export default function RepositionPriceInfo(props: IRepositionPriceInfoProps) {
     }
 
     const aprPercentageString = aprPercentage
-        ? ` ${aprPercentage.toLocaleString(undefined, {
+        ? ` ${aprPercentage.toLocaleString('en-US', {
               minimumFractionDigits: 2,
               maximumFractionDigits: 2,
           })}%`

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -134,7 +134,7 @@ export default function InitPool() {
                     ? defaultPriceNum.toExponential(2)
                     : defaultPriceNum < 2
                     ? defaultPriceNum.toPrecision(3)
-                    : defaultPriceNum.toLocaleString(undefined, {
+                    : defaultPriceNum.toLocaleString('en-US', {
                           minimumFractionDigits: 2,
                           maximumFractionDigits: 2,
                       });
@@ -349,7 +349,7 @@ export default function InitPool() {
                         ? invertedPriceNum.toExponential(2)
                         : invertedPriceNum < 2
                         ? invertedPriceNum.toPrecision(3)
-                        : invertedPriceNum.toLocaleString(undefined, {
+                        : invertedPriceNum.toLocaleString('en-US', {
                               minimumFractionDigits: 2,
                               maximumFractionDigits: 2,
                           });
@@ -377,7 +377,7 @@ export default function InitPool() {
                         ? initialPriceInBaseDenom.toExponential(2)
                         : initialPriceInBaseDenom < 2
                         ? initialPriceInBaseDenom.toPrecision(3)
-                        : initialPriceInBaseDenom.toLocaleString(undefined, {
+                        : initialPriceInBaseDenom.toLocaleString('en-US', {
                               minimumFractionDigits: 2,
                               maximumFractionDigits: 2,
                           });

--- a/src/pages/Swap/Swap.tsx
+++ b/src/pages/Swap/Swap.tsx
@@ -564,7 +564,7 @@ function Swap(props: propsIF) {
 
     const liquidityProviderFeeString = (
         tradeData.liquidityFee * 100
-    ).toLocaleString(undefined, {
+    ).toLocaleString('en-US', {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
     });

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -680,7 +680,7 @@ export default function Limit() {
 
     const liquidityProviderFeeString = (
         tradeData.liquidityFee * 100
-    ).toLocaleString(undefined, {
+    ).toLocaleString('en-US', {
         minimumFractionDigits: 2,
         maximumFractionDigits: 2,
     });

--- a/src/utils/hooks/useProcessRange.ts
+++ b/src/utils/hooks/useProcessRange.ts
@@ -56,11 +56,11 @@ export const useProcessRange = (
     const apy = position.apy ?? undefined;
     const apyString = apy
         ? apy >= 1000
-            ? apy.toLocaleString(undefined, {
+            ? apy.toLocaleString('en-US', {
                   minimumFractionDigits: 0,
                   maximumFractionDigits: 0,
               }) + '%+'
-            : apy.toLocaleString(undefined, {
+            : apy.toLocaleString('en-US', {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
               }) + '%'


### PR DESCRIPTION
### Describe your changes 

This change forces all number to get locally formatted into strings using US number formatting conventions (i.e. periods as decimal separators). 

### Link the related issue
Closes #2623

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)