### PR TITLE
Revert `useOnClickOutside`'s handler from using mouseup to mousedown

### DIFF
--- a/src/utils/hooks/useOnClickOutside.ts
+++ b/src/utils/hooks/useOnClickOutside.ts
@@ -16,11 +16,11 @@ const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
             handler(event); // Call the handler only if the click is outside of the element passed.
         };
 
-        document.addEventListener('mouseup', listener);
+        document.addEventListener('mousedown', listener);
         document.addEventListener('touchstart', listener);
 
         return () => {
-            document.removeEventListener('mouseup', listener);
+            document.removeEventListener('mousedown', listener);
             document.removeEventListener('touchstart', listener);
         };
     }, [ref, handler]); // Reload only if ref or handler changes


### PR DESCRIPTION
### Describe your changes 
- Initially the bug was noticed while using the mouse to select input in the exchange balance modal in the header and then clicking outside.
- This would cause the modal to close
- This behaviour seemed to happen for any modals/dropdowns using the `useOnClickOutside` hook

NOTE: Any modals/dropdowns will now close as soon as you click outside i.e. you won't be able to "hold your mouse" outside the given div and then let go to close the modal

### Link the related issue
_Closes #2628 

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

- Open any header element i.e. exhcangebalance modal
- Drag the mouse from the modal to outside the modal
- Verify that this does not close the given modal
- Clicking outside the modal however should still close the given modal

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)