### PR TITLE
increase pool limit/range records requested from 50 to 200

### DIFF
--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -252,7 +252,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                 omitEmpty: 'true',
                                 omitKnockout: 'true',
                                 addValue: 'true',
-                                n: '50',
+                                n: '200',
                             }),
                     )
                         .then((response) => response.json())
@@ -427,7 +427,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                                 quote: sortedTokens[1].toLowerCase(),
                                 poolIdx: props.chainData.poolIndex.toString(),
                                 chainId: props.chainData.chainId,
-                                n: '50',
+                                n: '200',
                             }),
                     )
                         .then((response) => response?.json())


### PR DESCRIPTION
### Describe your changes 

Increase the number of pool limit and range records requested when a user loads a pool from 50 to 200.

### Link the related issue
Closes #2635

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1. ETH-USDC pool ranges tables should now display close to 200 records by default

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)