### PR TITLE
refactor `useTokenSearch.ts` to use tiebreaker sort alphanumeric

### DIFF
--- a/src/App/hooks/useTokenSearch.ts
+++ b/src/App/hooks/useTokenSearch.ts
@@ -145,6 +145,7 @@ export const useTokenSearch = (
             .sort((a: TokenIF, b: TokenIF) => {
                 // fn to numerically prioritize a token (high = important)
                 const getPriority = (tkn: TokenIF): number => {
+                    const tknAddress: string = tkn.address.toLowerCase();
                     // declare an output variable
                     let priority: number;
                     // canonical token addresses to assign probability
@@ -154,26 +155,24 @@ export const useTokenSearch = (
                             chainId.toLowerCase() as keyof typeof USDC
                         ].toLowerCase(),
                     };
-                    // logic router to assign numerical priority to output
-                    // unlisted tokens get priority 0
-                    switch (tkn.address.toLowerCase()) {
-                        // native token
-                        case addresses.nativeToken:
-                            priority = 1000;
-                            break;
-                        // USDCoin (uses address for current chain)
-                        case addresses.USDC:
-                            priority = 900;
-                            break;
-                        // all non-privileged tokens
-                        default:
-                            priority = 0;
+                    if (tknAddress === ZERO_ADDRESS) {
+                        priority = 100;
+                    } else if (tknAddress === addresses.USDC) {
+                        priority = 90;
+                    } else if (tkn.listedBy) {
+                        priority = tkn.listedBy.length;
+                    } else {
+                        priority = 0;
                     }
                     // return numerical priority of the token
                     return priority;
                 };
+                // token priority values (numeric)
+                const priorityTknA: number = getPriority(a);
+                const priorityTknB: number = getPriority(b);
+                const priority123ABC: number = b.symbol < a.symbol ? 1 : -1;
                 // sort tokens by relative priority level
-                return getPriority(b) - getPriority(a);
+                return priorityTknB - priorityTknA || priority123ABC;
             });
         setOutputTokens(sortedTokens);
         // run hook every time the validated input from the user changes

--- a/src/App/hooks/useTokenSearch.ts
+++ b/src/App/hooks/useTokenSearch.ts
@@ -170,7 +170,7 @@ export const useTokenSearch = (
                 // token priority values (numeric)
                 const priorityTknA: number = getPriority(a);
                 const priorityTknB: number = getPriority(b);
-                const priority123ABC: number = b.symbol < a.symbol ? 1 : -1;
+                const priority123ABC: number = b.name < a.name ? 1 : -1;
                 // sort tokens by relative priority level
                 return priorityTknB - priorityTknA || priority123ABC;
             });


### PR DESCRIPTION
### Describe your changes 
Add a tertiary sort to `useTokenSearch.ts` for alphanumeric sorting (eg: 1 => 2 => A => B)

### Link the related issue
_none_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Open Token Select modal; confirm tokens appear in anticipated sequence.
2. Enter search input; confirm tokens appear in anticipated sequence.
* First sort: Ambient vs other lists
* Second sort: number of lists a token appears on
* Third sort: alphanumeric
* Final sort: original sequence

**Environmental conditions which may result in expected but differential behavior.**
_none_

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
Logic is self-contained on line 173 of `useTokenSearch.ts`, feel free to tweak
![image](https://github.com/CrocSwap/ambient-ts-app/assets/71150790/36267d6c-a8fc-4d8c-a4ea-f219d4d706a7)