### PR TITLE
Allow panning in chart

### DIFF
--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -1016,9 +1016,11 @@ export default function Chart(props: propsIF) {
                     const deltaX = linearX(dx);
                     if (lastCandleTime && firstCandleTime) {
                         if (
-                            event.sourceEvent.shiftKey ||
-                            event.sourceEvent.altKey ||
-                            event.sourceEvent.deltaX !== 0
+                            (event.sourceEvent.shiftKey ||
+                                event.sourceEvent.altKey ||
+                                event.sourceEvent.deltaX !== 0) &&
+                            !event.sourceEvent.ctrlKey &&
+                            !event.sourceEvent.metaKey
                         ) {
                             getNewCandleData(
                                 firstTime + deltaX,

--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -1017,7 +1017,8 @@ export default function Chart(props: propsIF) {
                     if (lastCandleTime && firstCandleTime) {
                         if (
                             event.sourceEvent.shiftKey ||
-                            event.sourceEvent.altKey
+                            event.sourceEvent.altKey ||
+                            event.sourceEvent.deltaX !== 0
                         ) {
                             getNewCandleData(
                                 firstTime + deltaX,

--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -989,10 +989,10 @@ export default function Chart(props: propsIF) {
                     event: any,
                     unparsedCandleData: Array<CandleData>,
                 ) => {
-                    let dx = event.sourceEvent.deltaY / 3;
-
-                    dx =
-                        Math.abs(dx) === 0 ? -event.sourceEvent.deltaX / 3 : dx;
+                    const dx =
+                        Math.abs(event.sourceEvent.deltaX) != 0
+                            ? event.sourceEvent.deltaX / 3
+                            : event.sourceEvent.deltaY / 3;
 
                     const domainX = scaleData?.xScale.domain();
                     const linearX = d3


### PR DESCRIPTION
### Describe your changes 
This one was a tricky one despite the simplicity of the change. Since the chart container is static, scrolling doesn't work naturally, which is why every action needs to be customized. This is trickier when taking into account that both trackpad and mouse (scrollwheel) behaviour needs to be taken into account, with no way to distinguish between the two when analyzing the mouseEvents. 

Since scrollwheel cannot scroll horizontally, I kept the option + vertical scroll = horizontal scroll functionality that currently exists, and then added functionality for horizontal scroll via the trackpad. By using that physical limitation to distinguish between the two sources of scrolling, I was able to implement a version of horizontal scrolling via the trackpad. 

Unfortunately, due to the non-linear nature of a human finger on a trackpad, as well as the computational behaviour of wheelEvents being fired (for a mouse, its 1 wheelEvent with a large delta, but for a trackpad, its a large number of events with a very small delta), this means that any slight horizontal movement will also be picked up by the chart and cause it to shift horizontally, even if the user intention was to scroll vertically, and vice versa. 

A potential next step would be to implement a debounce on the scrolling and have it store a number of events before analyzing and determine whether the user was attempting to scroll horizontally or vertically.

### Link the related issue
_Closes #2608_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
