### PR TITLE
fix page title for ens with special characters

### DIFF
--- a/src/App/components/PageHeader/PageHeader.tsx
+++ b/src/App/components/PageHeader/PageHeader.tsx
@@ -204,11 +204,12 @@ const PageHeader = function () {
             document.title = 'My Account ~ Ambient';
         } else if (isPathValidAddress) {
             const pathNoPrefix = pathNoLeadingSlash.replace(/account\//, '');
+            const pathNoPrefixDecoded = decodeURIComponent(pathNoPrefix);
             const ensNameOrAddressTruncated = isAddressEns
-                ? pathNoPrefix.length > 15
-                    ? trimString(pathNoPrefix, 10, 3, '…')
-                    : pathNoPrefix
-                : trimString(pathNoPrefix, 6, 0, '…');
+                ? pathNoPrefixDecoded.length > 15
+                    ? trimString(pathNoPrefixDecoded, 10, 3, '…')
+                    : pathNoPrefixDecoded
+                : trimString(pathNoPrefixDecoded, 6, 0, '…');
             document.title = `${ensNameOrAddressTruncated} ~ Ambient`;
         } else if (
             location.pathname.includes('swap') ||


### PR DESCRIPTION
### Describe your changes 

ens supports unicode. if a user goes to `ambient.finance/김정은.eth`, since ze page title issa read from ze url path, it will display `%EA%B9%80...eth ~ Ambient`. dis commit fixes it so it shows `김정은.eth ~ Ambient`

### Link the related issue

none

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1. jussa smol change. go try to peek into a random ens with emojis or special characters in it n u will see ze correct title shown

**Environmental conditions which may result in expected but differential behavior.**

1. dunno

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)