### PR TITLE
Chart will now jump closed if it is left in a too small state

### DIFF
--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -394,7 +394,7 @@ function Trade() {
                         size={{ width: '100%', height: chartHeights.current }}
                         minHeight={4}
                         onResizeStart={() => {
-                            setTradeTableState(undefined);
+                            // may be useful later
                         }}
                         onResizeStop={(e, direction, ref, d) => {
                             // the resizable bar is 4px in height
@@ -412,10 +412,17 @@ function Trade() {
                                 chartHeights.current + d.height <
                                 TRADE_CHART_MIN_HEIGHT
                             ) {
-                                setChartHeight(4);
-                                setTradeTableState('Expanded');
+                                if(tradeTableState == 'Expanded'){
+                                    setChartHeight(chartHeights.default);
+                                    setTradeTableState(undefined);
+                                }
+                                else{
+                                    setChartHeight(4);
+                                    setTradeTableState('Expanded');
+                                }
                             } else {
                                 setChartHeight(chartHeights.current + d.height);
+                                setTradeTableState(undefined);
                             }
                         }}
                         handleClasses={

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -45,7 +45,7 @@ import { linkGenMethodsIF, useLinkGen } from '../../utils/hooks/useLinkGen';
 import uriToHttp from '../../utils/functions/uriToHttp';
 import { TradeChartsHeader } from './TradeCharts/TradeChartsHeader/TradeChartsHeader';
 
-const TRADE_CHART_MIN_HEIGHT = 348;
+const TRADE_CHART_MIN_HEIGHT = 195;
 
 // React functional component
 function Trade() {

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -45,7 +45,7 @@ import { linkGenMethodsIF, useLinkGen } from '../../utils/hooks/useLinkGen';
 import uriToHttp from '../../utils/functions/uriToHttp';
 import { TradeChartsHeader } from './TradeCharts/TradeChartsHeader/TradeChartsHeader';
 
-const TRADE_CHART_MIN_HEIGHT = 195;
+const TRADE_CHART_MIN_HEIGHT = 175;
 
 // React functional component
 function Trade() {
@@ -412,11 +412,10 @@ function Trade() {
                                 chartHeights.current + d.height <
                                 TRADE_CHART_MIN_HEIGHT
                             ) {
-                                if(tradeTableState == 'Expanded'){
+                                if (tradeTableState == 'Expanded') {
                                     setChartHeight(chartHeights.default);
                                     setTradeTableState(undefined);
-                                }
-                                else{
+                                } else {
                                     setChartHeight(4);
                                     setTradeTableState('Expanded');
                                 }

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -45,6 +45,8 @@ import { linkGenMethodsIF, useLinkGen } from '../../utils/hooks/useLinkGen';
 import uriToHttp from '../../utils/functions/uriToHttp';
 import { TradeChartsHeader } from './TradeCharts/TradeChartsHeader/TradeChartsHeader';
 
+const TRADE_CHART_MIN_HEIGHT = 348;
+
 // React functional component
 function Trade() {
     const {
@@ -406,12 +408,13 @@ function Trade() {
                             ) {
                                 setTradeTableState('Collapsed');
                             }
-                            if(
-                                chartHeights.current + d.height < 348
+                            if (
+                                chartHeights.current + d.height <
+                                TRADE_CHART_MIN_HEIGHT
                             ) {
                                 setChartHeight(4);
                                 setTradeTableState('Expanded');
-                            }else{
+                            } else {
                                 setChartHeight(chartHeights.current + d.height);
                             }
                         }}

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -406,7 +406,14 @@ function Trade() {
                             ) {
                                 setTradeTableState('Collapsed');
                             }
-                            setChartHeight(chartHeights.current + d.height);
+                            if(
+                                chartHeights.current + d.height < 348
+                            ) {
+                                setChartHeight(4);
+                                setTradeTableState('Expanded');
+                            }else{
+                                setChartHeight(chartHeights.current + d.height);
+                            }
                         }}
                         handleClasses={
                             isChartFullScreen


### PR DESCRIPTION
### Describe your changes 
Chart will now jump closed when the height of it starts to fail to shrink the chart further. 

### Link the related issue
_Closes #2735_
