### PR TITLE
fix sticky footer

### DIFF
--- a/src/App/components/Sidebar/Sidebar.module.css
+++ b/src/App/components/Sidebar/Sidebar.module.css
@@ -3,6 +3,8 @@
     flex-direction: column;
     align-items: center;
     justify-content: center;
+
+ 
 }
 
 .sidebar {

--- a/src/components/Global/Analytics/Analytics.styles.ts
+++ b/src/components/Global/Analytics/Analytics.styles.ts
@@ -159,9 +159,10 @@ ${({ xl }) => xl && mediaStyles.xl}
 
 const PoolNameWrapper = styled.p`
     margin-left: 1rem;
+    display: none;
 
-    @media (min-width: 640px) {
-        display: none;
+    @media (min-width: 400px) and (max-width: 640px) {
+        display: flex;
     }
 `;
 

--- a/src/components/Global/Analytics/PoolRow.tsx
+++ b/src/components/Global/Analytics/PoolRow.tsx
@@ -3,7 +3,7 @@ import uriToHttp from '../../../utils/functions/uriToHttp';
 import { PoolDataIF } from '../../../contexts/ExploreContext';
 import {
     TableCell,
-    // PoolNameWrapper,
+    PoolNameWrapper,
     TokenWrapper,
     FlexCenter,
     TableRow,
@@ -42,7 +42,7 @@ export default function PoolRow(props: propsIF) {
                             size='2xl'
                         />
                     </TokenWrapper>
-                    {/* <PoolNameWrapper>{pool.name}</PoolNameWrapper> */}
+                    <PoolNameWrapper>{pool.name}</PoolNameWrapper>
                 </FlexCenter>
             </TableCell>
             <TableCell hidden sm left>

--- a/src/components/Global/SIdebarFooter/SidebarFooter.module.css
+++ b/src/components/Global/SIdebarFooter/SidebarFooter.module.css
@@ -2,14 +2,16 @@
 
 .sidebar_footer {
     z-index: 999;
-    width: 100vw;
+    width: 100dvw;
     bottom: 0;
 
     transition: width var(--animation-speed) ease;
 
     background-color: var(--dark1);
     height: 64px;
+    padding-left: 1.5rem;
     display: none;
+   
 }
 
 .position_sticky {
@@ -17,7 +19,7 @@
 }
 
 .position_absolute {
-    margin-left: 15px;
+ 
     position: absolute;
 }
 .sidebar_footer a {
@@ -56,6 +58,7 @@
         height: 5rem;
         background: var(--dark2);
         z-index: 2;
+        
     }
     .sidebar_footer {
         display: flex;

--- a/src/components/Global/SIdebarFooter/SidebarFooter.tsx
+++ b/src/components/Global/SIdebarFooter/SidebarFooter.tsx
@@ -18,7 +18,7 @@ function SidebarFooter() {
     const sidebarPositionStyle =
         currentLocation === '/'
             ? styles.position_sticky
-            : styles.position_absolute;
+            : styles.position_sticky;
 
     const tradeDestination = location.pathname.includes('trade/market')
         ? '/trade/market/'


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
Fix sticky footer moving on mobile devices.

There are small screen widths at which it would make sense to continue showing the combined logo/symbol column after removing the Price column.
-Added a fix where we show the pool names whenever we have the space.
<img width="409" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/447ad11d-b1a1-4389-a760-d0e7fb09a583">
<img width="705" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/777194ad-fa69-4633-a2d6-4315c3f2c820">


### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)