### PR TITLE
APR and Current Price no longer have point mouse

### DIFF
--- a/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.module.css
+++ b/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.module.css
@@ -21,9 +21,13 @@
     flex-direction: row;
     justify-content: space-between;
     align-items: center;
-   
     cursor: pointer;
 }
+
+.no_point {
+    cursor: default;
+}
+
 .price_title, .min_price,
 .current_price,
 .max_price, .apr_price  {

--- a/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
+++ b/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
@@ -74,7 +74,7 @@ function RangePriceInfo(props: propsIF) {
     // JSX frag for estimated APR of position
 
     const aprDisplay = (
-        <div className={styles.price_display}>
+        <div className={`${styles.price_display} ${styles.no_point}`}>
             <h4 className={styles.price_title}>Est. APR</h4>
             <span
                 className={styles.apr_price}
@@ -315,7 +315,7 @@ function RangePriceInfo(props: propsIF) {
                 </div>
             </DefaultTooltip>
         ) : (
-            <div className={styles.price_display} style={{ cursor: 'default' }}>
+            <div className={`${styles.price_display} ${styles.no_point}`}>
                 <h4 className={styles.price_title}>Min Price</h4>
                 <span className={styles.min_price}>{minPrice}</span>
             </div>
@@ -343,7 +343,7 @@ function RangePriceInfo(props: propsIF) {
                 </div>
             </DefaultTooltip>
         ) : (
-            <div className={styles.price_display} style={{ cursor: 'default' }}>
+            <div className={`${styles.price_display} ${styles.no_point}`}>
                 <h4 className={styles.price_title}>Max Price</h4>
                 <span className={styles.max_price}>{maxPrice}</span>
             </div>
@@ -362,7 +362,7 @@ function RangePriceInfo(props: propsIF) {
                 enterDelay={100}
                 leaveDelay={200}
             >
-                <div className={styles.price_display}>
+                <div className={`${styles.price_display} ${styles.no_point}`}>
                     <h4 className={styles.price_title}>Current Price</h4>
                     <span
                         className={styles.current_price}
@@ -378,7 +378,7 @@ function RangePriceInfo(props: propsIF) {
                 </div>
             </DefaultTooltip>
         ) : (
-            <div className={styles.price_display}>
+            <div className={`${styles.price_display} ${styles.no_point}`}>
                 <h4 className={styles.price_title}>Current Price</h4>
                 <span
                     className={styles.current_price}


### PR DESCRIPTION
### Describe your changes 
APR and Current price in Pool side window are no longer going to point, using default cursor on them now

### Link the related issue
Closes #2779