### PR TITLE
remove `POOL_COUNT` limiter from `TopPools.tsx` component file

### DIFF
--- a/src/components/Global/Analytics/TopPools.tsx
+++ b/src/components/Global/Analytics/TopPools.tsx
@@ -47,9 +47,6 @@ function TopPools(props: propsIF) {
     // logic to take raw pool list and sort them based on user input
     const sortedPools: SortedPoolMethodsIF = useSortedPools(allPools);
 
-    // number of pools to show in the DOM
-    const POOL_COUNT = 20;
-
     // !important:  any changes to `sortable` values must be accompanied by an update
     // !important:  ... to the type definition `sortType` in `useSortedPools.ts`
     const topPoolsHeaderItems: HeaderItem[] = [
@@ -114,7 +111,6 @@ function TopPools(props: propsIF) {
                                         (pool: PoolIF) =>
                                             !checkPoolForWETH(pool, chainId),
                                     )
-                                    .slice(0, POOL_COUNT)
                                     .map((pool: PoolDataIF, idx: number) => (
                                         <PoolRow
                                             key={JSON.stringify(pool) + idx}


### PR DESCRIPTION
### Describe your changes 
Remove the limiter on line items to display in `TopPools.tsx` in the `Explore.tsx` module

### Link the related issue
Closes #2794

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Navigate to the `/explore` URL path
2. Observe the pools rendered in the DOM
3. Sort by various sortable criterial (click column headers) and observe if any pools disappear

**Environmental conditions which may result in expected but differential behavior.**
1. Number of pools on `0x5` (Goërli) may not hit the limiter

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
Open to requests to tweak any of the sort logic. Otherwise ready for merge UwU