### PR TITLE
Fix fetching non-string token name and symbol

### DIFF
--- a/src/App/functions/fetchContractDetails.ts
+++ b/src/App/functions/fetchContractDetails.ts
@@ -37,19 +37,38 @@ export const fetchContractDetails = async (
         name = undefined;
 
     try {
-        decimals = contract.decimals();
-        symbol = contract.symbol();
-        name = contract.name();
+        decimals = await contract.decimals();
     } catch (error) {
         console.warn({ error });
+    }
+
+    try {
+        symbol = await contract.symbol();
+    } catch (error) {
+        // attempt to parse data as bytes32 in case of a non-compliant token
+        try {
+            symbol = ethers.utils.parseBytes32String(error.data);
+        } catch (error) {
+            console.warn({ error });
+        }
+    }
+
+    try {
+        name = await contract.name();
+    } catch (error) {
+        try {
+            name = ethers.utils.parseBytes32String(error.data);
+        } catch (error) {
+            console.warn({ error });
+        }
     }
 
     return {
         address: address,
         chainId: parseInt(_chainId),
-        decimals: await decimals,
-        symbol: await symbol,
-        name: await name,
+        decimals: decimals,
+        symbol: symbol,
+        name: name,
         fromList: 'custom_token',
         logoURI: '',
     };


### PR DESCRIPTION
### Describe your changes 
Some old tokens, most notably MKR, don't fully adhere to ERC-20 ABI and return `bytes32` instead of `string` for `name()` and `symbol()` methods. Currently this breaks transaction and range pages where such tokens are displayed.

This PR fixes that by trying to decode `bytes32` to `string` in the event of an exception while calling those methods. I think this is the simplest solution and should handle all cases, or at least I couldn't find any popular tokens with non-`string` and non-`bytes32` types for those methods. This fix doesn't affect tokens that implement ERC-20 properly.

### Link the related issue
None

### Checklist before requesting a review
- [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [X] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1. Open [MKR/ETH pool](https://ambient.finance/trade/market/chain=0x1&tokenA=0x0000000000000000000000000000000000000000&tokenB=0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2) and look at transaction/range tabs in the table. Currently they don't load due to this issue and this PR addresses that.

**Environmental conditions which may result in expected but differential behavior.**

1. With this PR the code should now correctly handle the most common case of incorrect return type (`bytes32`), as well not fully break the UI under other "broken" cases because all data parsing happens inside a `try` block unlike before. Even if the call reverts for an unrelated reason and `bytes32` parsing fails, the behavior will be still better than what happens currently.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)