### PR TITLE
Add Wallet tokens to modal

### DIFF
--- a/src/App/hooks/useTokenSearch.ts
+++ b/src/App/hooks/useTokenSearch.ts
@@ -63,6 +63,12 @@ export const useTokenSearch = (
     // hook to track tokens to output and render in DOM
     const [outputTokens, setOutputTokens] = useState<TokenIF[]>([]);
 
+    // list of addresses of tokens in connected wallet
+    const walletTknAddresses = useMemo<string[]>(
+        () => walletTokens.map((wTkn: TokenIF) => wTkn.address.toLowerCase()),
+        [walletTokens.length],
+    );
+
     // hook to update the value of outputTokens based on user input
     useEffect(() => {
         // fn to run a token search by contract address
@@ -158,6 +164,10 @@ export const useTokenSearch = (
                         priority = 100;
                     } else if (tknAddress === addresses.USDC) {
                         priority = 90;
+                    } else if (
+                        walletTknAddresses.includes(tkn.address.toLowerCase())
+                    ) {
+                        priority = 80;
                     } else if (tkn.listedBy) {
                         priority = tkn.listedBy.length;
                     } else {
@@ -179,7 +189,7 @@ export const useTokenSearch = (
     }, [
         chainId,
         tokens.defaultTokens,
-        walletTokens.length,
+        walletTknAddresses,
         getRecentTokens().length,
         validatedInput,
     ]);


### PR DESCRIPTION
### Describe your changes 
Add a sort priority level in `useTokenSearch.ts` to tokens in the universe for tokens that are also in the user's connected wallet

### Link the related issue
Closes #2823

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Open the app and connect a wallet
2. Open the token selector modal
3. Selectable tokens should appear in the following order when no search input has been entered: native token => USDC => tokens in the user's wallet AND a recognized list => other tokens in lists

**Environmental conditions which may result in expected but differential behavior.**
1. Will only be testable when a wallet is connected to the app
2. User must have a token in their wallet which is on one of the recognized lists (currently Ambient, Uniswap, CoinGecko) and on the current chain other than USDC or native ether

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
none