### PR TITLE
fix warning box button overflow issue

### DIFF
--- a/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
@@ -299,7 +299,7 @@ export const SoloTokenSelectModal = (props: propsIF) => {
                                         }
                                     }}
                                 >
-                                    use WETH
+                                    I understand, use WETH
                                 </button>
                             }
                         />

--- a/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
@@ -299,7 +299,7 @@ export const SoloTokenSelectModal = (props: propsIF) => {
                                         }
                                     }}
                                 >
-                                    I understand, use WETH
+                                    use WETH
                                 </button>
                             }
                         />

--- a/src/components/RangeActionModal/WarningBox/WarningBox.module.css
+++ b/src/components/RangeActionModal/WarningBox/WarningBox.module.css
@@ -56,8 +56,20 @@
     outline: none;
     border: none;
     border-radius: var(--border-radius);
-    width: 210px;
     padding: 6px 8px;
+    border: 1px solid transparent;
+    white-space: nowrap;
+
+    
+    
+}
+
+.warning_box button:hover, .text_only button:hover{
+    background-color: transparent;
+    border: 1px solid var(--other-red);
+    transition: all var(--animation-speed) ease-in-out;
+    color: var(--text1);
+
 }
 
 .warning_box svg,


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
Increasing the width of the warning box button to accommodate the text causes an overflow issue.
As tgus us a reusable component, we should avoid adding an explicit width or height to any of its elements.
This PR resolves that issue.

The warning text for WETH has been changed from 'I understand, use WETH' to simply 'use WETH'.
This is to make sure the text fits nicely inside of the modal without messing up the existing layout.

The text can be changed to any other text but let's keep it on the short side if possible.

Another option is to simply move that button unto the next line. We couldn't need it in the same row as the text in that case.
<img width="532" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/3ac2615a-8a67-47ac-be38-b7c8dca6da9b">

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

