### PR TITLE
Fix token race condition

### DIFF
--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAppDispatch } from './reduxToolkit';
 import {


### PR DESCRIPTION
### Describe your changes 
Fix token race condition that causes the logoUri to be empty

Issue was that on initial load, there is no token lookup, so it fetches the actual contract (async call intended for custom tokens), which doesn't contain logoUri
Then the token lookup appears, and the lookup is made, which happens immediately 
Finally, the contract call returns, sets the token, which overrides the (correct) lookup 

Solution: Add a flag to the useEffect so that if the lookup occurs during a call to fetch contract, it will accept the first return and stop any subsequent attempts to set token. An assumption is made that the lookup will always return first. 

### Link the related issue
_Closes #2846_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
