### PR TITLE
Refactor char code and key code

### DIFF
--- a/docs/CODING-STYLE.md
+++ b/docs/CODING-STYLE.md
@@ -17,6 +17,7 @@ Please follow these items as close to as possible for your PR. Please add a desc
 - [ ] Has commented-out code been deleted or marked with a note to request preservation?
 - [ ] Does error handling use `console.warn` or `console.error` for handled and unhandled exceptions, respectively? Does this logging reference the generating file?
 - [ ] Have console commands been restricted with environmental variables (eg, dev environment only) as appropriate?
+- [ ] Are keyboard events tracked with `e.key` or `e.code` instead of `e.charCode` or `e.keyCode`?
 
 #### TypeScript
 - [ ] Are all functions given a typed return?

--- a/src/components/Chat/ChatPanel.tsx
+++ b/src/components/Chat/ChatPanel.tsx
@@ -69,14 +69,12 @@ function ChatPanel(props: propsIF) {
     const isUserLoggedIn = userData.isLoggedIn;
     const resolvedAddress = userData.resolvedAddress;
 
-    // eslint-disable-next-line
-    function closeOnEscapeKeyDown(e: any) {
-        if ((e.charCode || e.keyCode) === 27) setIsChatOpen(false);
+    function closeOnEscapeKeyDown(e: KeyboardEvent) {
+        if (e.code === 'Escape') setIsChatOpen(false);
     }
 
-    // eslint-disable-next-line
-    function openChatPanel(e: any) {
-        if (e.keyCode === 67 && e.ctrlKey && e.altKey) {
+    function openChatPanel(e: KeyboardEvent) {
+        if (e.code === 'KeyC' && e.ctrlKey && e.altKey) {
             setIsChatOpen(!isChatOpen);
         }
     }

--- a/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
+++ b/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
@@ -87,23 +87,20 @@ export default function MessageInput(props: MessageInputProps) {
         }
     };
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function openEmojiPanel(e: any) {
-        if (e.keyCode === 88 && e.altKey) {
+    function openEmojiPanel(e: KeyboardEvent) {
+        if (e.code === 'KeyC' && e.altKey) {
             setShowEmojiPicker(true);
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function closeEmojiPanel(e: any) {
-        if (e.keyCode === 81 && e.altKey) {
+    function closeEmojiPanel(e: KeyboardEvent) {
+        if (e.code === 'KeyQ' && e.altKey) {
             setShowEmojiPicker(false);
         }
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    function openInfo(e: any) {
-        if (e.keyCode === 77 && e.ctrlKey) {
+    function openInfo(e: KeyboardEvent) {
+        if (e.code === 'KeyM' && e.ctrlKey) {
             setShowEmojiPicker(true);
             setIsInfoPressed(true);
         }

--- a/src/components/Global/SlippageTolerance/SlippageTolerance.tsx
+++ b/src/components/Global/SlippageTolerance/SlippageTolerance.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
+import { Dispatch, SetStateAction, KeyboardEvent } from 'react';
 import { useSlippageInput } from '../../../utils/hooks/useSlippageInput';
 import styles from './SlippageTolerance.module.css';
 import { OptionButton } from '../Button/OptionButton';
@@ -6,7 +6,7 @@ import { OptionButton } from '../Button/OptionButton';
 interface propsIF {
     persistedSlippage: number;
     setCurrentSlippage: Dispatch<SetStateAction<number>>;
-    handleKeyDown: (event: { keyCode: number }) => void;
+    handleKeyDown: (event: KeyboardEvent<HTMLInputElement>) => void;
     presets: number[];
 }
 

--- a/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
+++ b/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useContext, useState, KeyboardEvent } from 'react';
 import { FiAlertTriangle } from 'react-icons/fi';
 import { skipConfirmIF } from '../../../App/hooks/useSkipConfirm';
 import { SlippageMethodsIF } from '../../../App/hooks/useSlippage';
@@ -34,8 +34,8 @@ export default function TransactionSettingsModal(props: propsIF) {
 
     const isPairStable = isStablePair(tokenA.address, tokenB.address, chainId);
 
-    const handleKeyDown = (event: { keyCode: number }): void => {
-        event.keyCode === 13 && updateSettings();
+    const handleKeyDown = (event: KeyboardEvent<HTMLInputElement>): void => {
+        event.code === 'Enter' && updateSettings();
     };
 
     const persistedSlippage: number = isPairStable

--- a/src/pages/Trade/TradeCharts/TradeCharts.tsx
+++ b/src/pages/Trade/TradeCharts/TradeCharts.tsx
@@ -127,9 +127,8 @@ function TradeCharts(props: propsIF) {
 
     // END OF CHART SETTINGS------------------------------------------------------------
 
-    // eslint-disable-next-line
-    function closeOnEscapeKeyDown(e: any) {
-        if ((e.charCode || e.keyCode) === 27) setIsChartFullScreen(false);
+    function closeOnEscapeKeyDown(e: KeyboardEvent) {
+        if (e.code === 'Escape') setIsChartFullScreen(false);
     }
 
     useEffect(() => {


### PR DESCRIPTION
### Describe your changes 
* Refactor app to respond to keyboard events defined by `KeyboardEvent.code` and `KeyboardEvent.key` over `KeyboardEvent.charCode` and `KeyboardEvent.keyCode`
  * `KeyboardEvent.code` maps to a physical key on the keyboard and is functionally equivalent to `KeyboardEvent.keyCode `
  * `KeyboardEvent.key` maps to a character produced by a keyboard event (ie a keypress) and is functionally equivalent to `KeyboardEvent.charCode`
* Both [KeyboardEvent.charCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/charCode) and [KeyboardEvent.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode) per MDN are deprecated features
* Eliminate use of `any` type annotation in updated function declarations
* Updated docs in `CODING-STYLE.md` to reflect this new standard

### Link the related issue
Closes #2899

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Chatbox
    - <kbd>Ctrl</kbd> + <kbd>Alt</kbd> + <kbd>C</kbd> → opens chatbox (if closed)
    - <kbd>Esc</kbd> → closes chatbox
2. Chat Input
    - <kbd>Alt</kbd> + <kbd>C</kbd> → opens emoji picker
    - <kbd>Alt</kbd> + <kbd>Q</kbd> → closes emoji picker
    - <kbd>Alt</kbd> + <kbd>M</kbd> → opens info menu
3. Transaction Settings Modal
    - every keypress updates persisted user preferences
4. Trade Charts
    - <kbd>Esc</kbd> → exits fullscreen mode

Note that this PR is strictly to address outstanding tech debt and does not introduce new features. All changes should maintain parity with the deployed app.

**Environmental conditions which may result in expected but differential behavior.**
Per [MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent) the `key` and `code` properties of the `KeyboardEvent` object prototype are not universally supported across all browsers. However, checking [Can I Use](https://caniuse.com/) shows that they are supported for all browsers we test and that browsers not supporting these properties also have mixed support for the deprecated properties being replaced.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
None, ready for merge!