### PR TITLE
complete logic to clear the sidebar search input on an escape keypress

### DIFF
--- a/src/App/components/Sidebar/Sidebar.tsx
+++ b/src/App/components/Sidebar/Sidebar.tsx
@@ -1,5 +1,12 @@
 // START: Import React and Dongles
-import { useState, useRef, useContext, memo } from 'react';
+import {
+    useState,
+    useRef,
+    useContext,
+    ChangeEvent,
+    KeyboardEvent,
+    memo,
+} from 'react';
 import { BiSearch } from 'react-icons/bi';
 
 // START: Import JSX Elements
@@ -149,15 +156,6 @@ function Sidebar() {
     const [searchMode, setSearchMode] = useState(false);
     false && searchMode;
 
-    const handleInputClear = () => {
-        setSearchInput('');
-        setSearchMode(false);
-        const currentInput = document.getElementById(
-            'search_input',
-        ) as HTMLInputElement;
-        currentInput.value = '';
-    };
-
     // ------------------------------------------
     // ---------------------------Explore SEARCH CONTAINER-----------------------
 
@@ -174,6 +172,11 @@ function Sidebar() {
         searchData.setInput(e.target.value);
         setSearchInput(e.target.value);
     };
+
+    // id for search input HTML elem in the DOM
+    // defined in a const because we reference this multiple places
+    const searchInputElementId = 'sidebar_search_input';
+
     const searchContainer = (
         <SearchContainer
             flexDirection='row'
@@ -195,19 +198,34 @@ function Sidebar() {
             </FlexContainer>
             <SearchInput
                 type='text'
-                id='search_input'
-                value={searchInput}
+                id={searchInputElementId}
+                value={searchData.rawInput}
                 placeholder='Search...'
-                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                onChange={(e: ChangeEvent<HTMLInputElement>) =>
                     handleSearchInput(e)
                 }
+                onKeyDown={(e: KeyboardEvent<HTMLInputElement>) => {
+                    if (e.code === 'Escape') {
+                        // prevent keypress from de-focusing the input
+                        e.stopPropagation();
+                        // clear search input, DOM will update
+                        searchData.clearInput();
+                    }
+                }}
                 spellCheck='false'
                 autoComplete='off'
                 tabIndex={1}
             />
             {searchInput && (
                 <FlexContainer
-                    onClick={handleInputClear}
+                    onClick={() => {
+                        // clear search input, DOM will update
+                        searchData.clearInput();
+                        // manually focus DOM on the search input
+                        const searchInput =
+                            document.getElementById(searchInputElementId);
+                        searchInput && searchInput.focus();
+                    }}
                     role='button'
                     tabIndex={0}
                 >

--- a/src/App/hooks/useSidebarSearch.ts
+++ b/src/App/hooks/useSidebarSearch.ts
@@ -20,7 +20,9 @@ import { tokenListURIs } from '../../utils/data/tokenListURIs';
 import { PoolContext } from '../../contexts/PoolContext';
 
 export interface sidebarSearchIF {
+    rawInput: string;
     setInput: Dispatch<SetStateAction<string>>;
+    clearInput: () => void;
     isInputValid: boolean;
     pools: PoolIF[];
     positions: PositionIF[];
@@ -48,6 +50,11 @@ export const useSidebarSearch = (
 
     // search type ➜ '' or 'address' or 'nameOrAddress'
     const [searchAs, setSearchAs] = useState<string | null>(null);
+
+    // fn to clear the search input
+    function clearInput(): void {
+        setRawInput('');
+    }
 
     // cleaned and validated version of raw user input
     const validatedInput = useMemo<string>(() => {
@@ -315,7 +322,9 @@ export const useSidebarSearch = (
     }, [limitOrderList.length, validatedInput]);
 
     return {
+        rawInput,
         setInput: setRawInput,
+        clearInput: clearInput,
         isInputValid: !!searchAs,
         pools: outputPools,
         positions: outputPositions,


### PR DESCRIPTION
### Describe your changes 
* Clear the sidebar search input element on <kbd>Esc<kbd> if element is selected
* Fix bug where sidebar loses focus in DOM when user clears input with `X` button click in DOM
* Accomplished WITHOUT USING SIDE EFFECTS 🎉

### Link the related issue
Closes #2960

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Enter any text input to the sidebar search input field
2. Ensure that search input is cleared and focus maintained on <kbd>Esc</kbd> keypress
3. Ensure identical behavior when clicking the `X` button in the DOM to clear input

**Environmental conditions which may result in expected but differential behavior.**
The action is coded as an `onKeyPress` built into the input field; no action should be logged for an <kbd>Esc</kbd> keypress if the field is not actively focused in the DOM

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
None, ready for merge!