### PR TITLE
Add isValidProp to keep from forwarding styled-component props

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "dependencies": {
         "@crocswap-libs/sdk": "^0.2.75",
         "@d3fc/d3fc-extent": "^4.0.2",
+        "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@material-ui/core": "^4.12.4",

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -6,7 +6,8 @@ import { Provider } from 'react-redux';
 import './index.css';
 import App from './App/App';
 import './i18n/config';
-
+import { StyleSheetManager } from 'styled-components';
+import isValidProp from '@emotion/is-prop-valid';
 import { WagmiConfig, createClient, configureChains } from 'wagmi';
 
 import { infuraProvider } from 'wagmi/providers/infura';
@@ -95,7 +96,14 @@ if (!doReload) {
                 <Provider store={store}>
                     <BrowserRouter>
                         <GlobalContexts>
-                            <App />
+                            <StyleSheetManager
+                                shouldForwardProp={(propName) =>
+                                    isValidProp(propName)
+                                }
+                            >
+                                <App />
+                            </StyleSheetManager>
+
                             <div id={GLOBAL_MODAL_PORTAL_ID} />
                         </GlobalContexts>
                     </BrowserRouter>


### PR DESCRIPTION
![Screenshot 2023-09-07 at 3 03 14 PM](https://github.com/CrocSwap/ambient-ts-app/assets/96197989/33969b54-a777-47e0-be13-7dedeacffe82)
A bunch of these warnings were appearing since the addition of styled components.  This keeps from forwarding those props.

Solution from https://github.com/styled-components/styled-components/issues/4049