### PR TITLE
Fix Extra Info persistent logic

### DIFF
--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -74,7 +74,7 @@ export const ExtraInfo = (props: PropsIF) => {
                     />
                 )}
             </button>
-            {showExtraInfo && (
+            {showExtraInfo && showDropdown && (
                 <div className={styles.extra_details_container}>
                     <div className={styles.extra_details}>
                         {extraInfo.map((item, idx) => (


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
There is an ongoing issue where the `ExtraInfo` remains visible even when the input fields are empty. To replicate this, please enter an amount in the 'swap quantities' field, expand the extra information by selecting the dropdown, and then remove the entered amount. The expected functionality is for the extra information to retract, but it persists in its expanded state. This pull request is intended to rectify this behavior.

Current:
<img width="531" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/37e44a8e-0b47-492c-ac3c-c8fa54e73647">
Expected:
<img width="522" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/dd96592d-8933-42bd-adc8-0574c8dcb9cb">


### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

