### PR TITLE
Add use styled components macro to display class names

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "@reduxjs/toolkit": "^1.8.1",
         "ajv": "^8.11.0",
         "ajv-formats": "^2.1.1",
+        "babel-plugin-styled-components": "^2.1.4",
         "d3": "^7.4.4",
         "d3fc": "^15.2.4",
         "emoji-picker-react": "^3.6.2",

--- a/src/components/Global/Analytics/Analytics.styles.ts
+++ b/src/components/Global/Analytics/Analytics.styles.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { HeaderItem } from './TopPools';
 
 interface TableCellProps {

--- a/src/components/Global/Analytics/TokenDisplay.tsx
+++ b/src/components/Global/Analytics/TokenDisplay.tsx
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 interface TokenProps {
     token0: string | false;

--- a/src/components/Global/DropdownMenu2/DropdownMenu2.styles.ts
+++ b/src/components/Global/DropdownMenu2/DropdownMenu2.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { motion } from 'framer-motion';
 import { FlexContainer } from '../../../styled/Common';
 

--- a/src/components/Global/NotificationCenter/ActivityIndicator/ActivityIndicator.styles.ts
+++ b/src/components/Global/NotificationCenter/ActivityIndicator/ActivityIndicator.styles.ts
@@ -1,4 +1,4 @@
-import styled, { keyframes } from 'styled-components';
+import styled, { keyframes } from 'styled-components/macro';
 import { motion } from 'framer-motion';
 
 const pulsate = keyframes`

--- a/src/components/Global/NotificationCenter/NotificationTable/NotificationTable.styles.ts
+++ b/src/components/Global/NotificationCenter/NotificationTable/NotificationTable.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { FlexContainer } from '../../../../styled/Common';
 
 export const MainContainer = styled.div`

--- a/src/components/Home/Landing/TradeNowButton/TradeNowButton.styles.ts
+++ b/src/components/Home/Landing/TradeNowButton/TradeNowButton.styles.ts
@@ -1,5 +1,5 @@
 import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 interface ButtonProps {
     inNav?: boolean;

--- a/src/components/Trade/TableInfo/TableInfo.styles.ts
+++ b/src/components/Trade/TableInfo/TableInfo.styles.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import backgroundImage from '../../../assets/images/backgrounds/tableInfoBg.png';
 
 // can be extracted to common

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -4,7 +4,7 @@ import TopPools from '../../components/Global/Analytics/TopPools';
 import { ExploreContext } from '../../contexts/ExploreContext';
 import { CrocEnvContext } from '../../contexts/CrocEnvContext';
 import { PoolContext } from '../../contexts/PoolContext';
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 import { useTimeElapsed, useTimeElapsedIF } from './useTimeElapsed';
 import { ChainDataContext } from '../../contexts/ChainDataContext';
 

--- a/src/pages/TestPage/TestPage.tsx
+++ b/src/pages/TestPage/TestPage.tsx
@@ -1,4 +1,4 @@
-import { styled } from 'styled-components';
+import { styled } from 'styled-components/macro';
 import { FlexContainer, FontSize } from '../../styled/Common';
 
 export default function TestPage() {

--- a/src/styled/Common.ts
+++ b/src/styled/Common.ts
@@ -1,4 +1,4 @@
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 
 interface FontProps {
     font?: 'font-logo' | 'font-family' | 'roboto' | 'mono';

--- a/src/styled/Components/Header.ts
+++ b/src/styled/Components/Header.ts
@@ -1,6 +1,6 @@
 import { Link, NavLink } from 'react-router-dom';
 
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { motion } from 'framer-motion';
 
 import { FlexContainer, GridContainer } from '../Common';

--- a/src/styled/Components/Range.ts
+++ b/src/styled/Components/Range.ts
@@ -1,4 +1,4 @@
-import styled from 'styled-components';
+import styled from 'styled-components/macro';
 
 export const Status = styled.div<{
     status: 'ambient' | 'positive' | 'negative';

--- a/src/styled/Components/Sidebar.ts
+++ b/src/styled/Components/Sidebar.ts
@@ -4,7 +4,7 @@ import { BiSearch } from 'react-icons/bi';
 import { GiBackwardTime, GiSaveArrow } from 'react-icons/gi';
 import { LuDroplets, LuFileClock } from 'react-icons/lu';
 import { MdOutlineExpand, MdPlayArrow } from 'react-icons/md';
-import styled, { css } from 'styled-components';
+import styled, { css } from 'styled-components/macro';
 import { FlexContainer, GridContainer } from '../Common';
 
 export const SidebarDiv = styled.div<{ open: boolean }>`

--- a/yarn.lock
+++ b/yarn.lock
@@ -5910,6 +5910,17 @@ babel-plugin-polyfill-regenerator@^0.5.1:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.4.1"
 
+babel-plugin-styled-components@^2.1.4:
+  version "2.1.4"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz#9a1f37c7f32ef927b4b008b529feb4a2c82b1092"
+  integrity sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.22.5"
+    "@babel/helper-module-imports" "^7.22.5"
+    "@babel/plugin-syntax-jsx" "^7.22.5"
+    lodash "^4.17.21"
+    picomatch "^2.3.1"
+
 babel-plugin-syntax-object-rest-spread@^6.8.0:
   version "6.13.0"
   resolved "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz"


### PR DESCRIPTION
<img width="631" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/96197989/0169433d-4346-4194-8298-13c94b939fc5">
Adds class names that will link you back to the component in question. 

Adds babel-plugin-styled-components 