### PR TITLE
add info icon and background to trade icons to keep them consistent

### DIFF
--- a/src/assets/images/info.svg
+++ b/src/assets/images/info.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
+<svg width="800px" height="800px" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M12 7C12.8284 7 13.5 6.32843 13.5 5.5C13.5 4.67157 12.8284 4 12 4C11.1716 4 10.5 4.67157 10.5 5.5C10.5 6.32843 11.1716 7 12 7ZM11 9C10.4477 9 10 9.44772 10 10C10 10.5523 10.4477 11 11 11V19C11 19.5523 11.4477 20 12 20C12.5523 20 13 19.5523 13 19V10C13 9.44772 12.5523 9 12 9H11Z" fill="#cdc1ff"/>
+</svg>

--- a/src/components/Global/TabComponent/TabComponent.module.css
+++ b/src/components/Global/TabComponent/TabComponent.module.css
@@ -133,6 +133,19 @@
     display: none;
 }
 
+.tab_icon_container{
+
+    background: var(--dark3);
+    padding: 4px;
+    border-radius: var(--border-radius);
+    cursor: pointer;
+}
+
+.tab_icon_container:hover{
+    cursor: pointer;
+    background: var(--dark2);
+    transition: all var(--animation-speed) ease-in-out;
+}
 .tab_icon {
     display: flex;
 }

--- a/src/components/Global/TabComponent/TabComponent.module.css
+++ b/src/components/Global/TabComponent/TabComponent.module.css
@@ -158,7 +158,7 @@
     border-bottom: 1px solid var(--text1);
 }
 @media (min-width: 800px) {
-    .tab_icon {
+     .tab_icon_container {
         display: none;
     }
 }

--- a/src/components/Global/TabComponent/TabComponent.tsx
+++ b/src/components/Global/TabComponent/TabComponent.tsx
@@ -112,7 +112,7 @@ export default function TabComponent(props: TabPropsIF) {
 
     function handleMobileMenuIcon(icon: string, label: string) {
         return (
-            <div className={styles.tab_iconf}>
+            <div className={styles.tab_icon_container}>
                 <DefaultTooltip
                     title={label}
                     placeholder={'bottom'}

--- a/src/components/Trade/TradeTabs/TradeTabs2.tsx
+++ b/src/components/Trade/TradeTabs/TradeTabs2.tsx
@@ -17,6 +17,7 @@ import Transactions from './Transactions/Transactions';
 import Orders from './Orders/Orders';
 import moment from 'moment';
 import leaderboard from '../../../assets/images/leaderboard.svg';
+import infoSvg from '../../../assets/images/info.svg';
 import openOrdersImage from '../../../assets/images/sidebarImages/openOrders.svg';
 import rangePositionsImage from '../../../assets/images/sidebarImages/rangePositions.svg';
 import recentTransactionsImage from '../../../assets/images/sidebarImages/recentTx.svg';
@@ -45,7 +46,6 @@ import { AppStateContext } from '../../../contexts/AppStateContext';
 import { FlexContainer } from '../../../styled/Common';
 import { ClearButton } from '../../../styled/Components/TransactionTable';
 import TableInfo from '../TableInfo/TableInfo';
-
 interface propsIF {
     filter: CandleData | undefined;
     setTransactionFilter: Dispatch<SetStateAction<CandleData | undefined>>;
@@ -354,7 +354,7 @@ function TradeTabs2(props: propsIF) {
               {
                   label: 'Info',
                   content: <TableInfo />,
-                  icon: leaderboard,
+                  icon: infoSvg,
                   showRightSideOption: false,
                   //   onClick: handleChartHeightOnInfo,
               },


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
add info icon and background to trade icons to keep them consistent
<img width="371" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/f7b9c9e7-6c31-4dea-ac7a-57b6f58c0fd3">

### Link the related issue
_Closes #3001 _

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
