### PR TITLE
move active mobile component to trade context

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/OrdersMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/OrdersMenu.tsx
@@ -60,7 +60,8 @@ export default function OrdersMenu(props: propsIF) {
     const {
         sidebar: { isOpen: isSidebarOpen },
     } = useContext(SidebarContext);
-    const { handlePulseAnimation } = useContext(TradeTableContext);
+    const { handlePulseAnimation, setActiveMobileComponent } =
+        useContext(TradeTableContext);
 
     const tradeData = useAppSelector((state) => state.tradeData);
 
@@ -71,6 +72,8 @@ export default function OrdersMenu(props: propsIF) {
 
     // -----------------SNACKBAR----------------
     function handleCopyOrder() {
+        setActiveMobileComponent('trade');
+
         handlePulseAnimation('limitOrder');
         dispatch(setLimitTickCopied(true));
 

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -71,7 +71,8 @@ export default function RangesMenu(props: propsIF) {
         setCurrentRangeInAdd,
     } = useContext(RangeContext);
     const { sidebar } = useContext(SidebarContext);
-    const { handlePulseAnimation } = useContext(TradeTableContext);
+    const { handlePulseAnimation, setActiveMobileComponent } =
+        useContext(TradeTableContext);
 
     const { isAmbient } = rangeDetailsProps;
 
@@ -133,6 +134,8 @@ export default function RangesMenu(props: propsIF) {
         userMatchesConnectedAccount && isUserLoggedIn;
 
     const handleCopyClick = () => {
+        setActiveMobileComponent('trade');
+
         dispatch(setRangeTicksCopied(true));
         handlePulseAnimation('range');
 

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
@@ -56,7 +56,8 @@ export default function TransactionsMenu(props: propsIF) {
     const {
         sidebar: { isOpen: isSidebarOpen },
     } = useContext(SidebarContext);
-    const { handlePulseAnimation } = useContext(TradeTableContext);
+    const { handlePulseAnimation, setActiveMobileComponent } =
+        useContext(TradeTableContext);
 
     const [isDetailsModalOpen, openDetailsModal, closeDetailsModal] =
         useModal();
@@ -81,6 +82,7 @@ export default function TransactionsMenu(props: propsIF) {
     const linkGenPool: linkGenMethodsIF = useLinkGen('pool');
 
     const handleCopyClick = () => {
+        setActiveMobileComponent('trade');
         if (tx.entityType === 'swap') {
             handlePulseAnimation('swap');
         } else if (tx.entityType === 'limitOrder') {

--- a/src/contexts/TradeTableContext.tsx
+++ b/src/contexts/TradeTableContext.tsx
@@ -23,6 +23,9 @@ interface TradeTableContextIF {
     outsideControl: boolean;
     setOutsideControl: (val: boolean) => void;
     handlePulseAnimation: (type: 'swap' | 'limitOrder' | 'range') => void;
+
+    activeMobileComponent: string;
+    setActiveMobileComponent: (val: string) => void;
 }
 
 export const TradeTableContext = createContext<TradeTableContextIF>(
@@ -53,6 +56,7 @@ export const TradeTableContextProvider = (props: {
         useState(false);
     const [selectedOutsideTab, setSelectedOutsideTab] = useState(0);
     const [outsideControl, setOutsideControl] = useState(false);
+    const [activeMobileComponent, setActiveMobileComponent] = useState('trade');
 
     const tradeTableContext = {
         showAllData,
@@ -92,6 +96,8 @@ export const TradeTableContextProvider = (props: {
         setSelectedOutsideTab,
         outsideControl,
         setOutsideControl,
+        activeMobileComponent,
+        setActiveMobileComponent,
     };
 
     function handlePulseAnimation(type: 'swap' | 'limitOrder' | 'range') {

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -64,8 +64,12 @@ function Trade() {
     const isPoolInitialized = useSimulatedIsPoolInitialized();
 
     const { tokens } = useContext(TokenContext);
-    const { setOutsideControl, setSelectedOutsideTab } =
-        useContext(TradeTableContext);
+    const {
+        setOutsideControl,
+        setSelectedOutsideTab,
+        activeMobileComponent,
+        setActiveMobileComponent,
+    } = useContext(TradeTableContext);
 
     const routes = [
         {
@@ -105,8 +109,6 @@ function Trade() {
             ))}
         </SelectorContainer>
     );
-
-    const [activeMobileComponent, setActiveMobileComponent] = useState('trade');
 
     const [hasInitialized, setHasInitialized] = useState(false);
 


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
clicking or tapping a Copy button from a trade or account page should now load the relevant module as the active mobile component.
### Link the related issue
Closes #2922 

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

