### PR TITLE
fix dropdown menu being obscured on mobile

### DIFF
--- a/src/styled/Components/Trade.ts
+++ b/src/styled/Components/Trade.ts
@@ -21,7 +21,6 @@ export const MainSection = styled.section`
         display: flex;
         flex-direction: column;
         gap: 4px;
-        padding: 0 8px;
     }
 `;
 
@@ -42,7 +41,8 @@ export const TradeDropdownButton = styled.button`
     border: none;
     color: var(--text2);
     padding: 8px;
-    width: 100%;
+    width: 90%;
+    margin: 0 auto;
     cursor: pointer;
     transition: all var(--animation-speed) ease-in-out;
     border-radius: var(--border-radius);


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
fix dropdown menu being partially obscured on mobile
<img width="250" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/46311315-f94c-4b9b-8bd7-9cc26bc8251b">
<img width="487" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/f303537d-35b8-42c9-9b4a-aa30b70639a2">

### Link the related issue
_Closes #3020 _

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

