### PR TITLE
hide refresh button when trade table is expanded

### DIFF
--- a/src/components/NoChartData/NoChartData.module.css
+++ b/src/components/NoChartData/NoChartData.module.css
@@ -7,6 +7,7 @@
     display: flex;
     justify-content: center;
     align-items: center;
+   
 }
 .pool_init_bg {
     width: 480px;

--- a/src/components/NoChartData/NoChartData.tsx
+++ b/src/components/NoChartData/NoChartData.tsx
@@ -15,10 +15,12 @@ interface PropsIF {
     tokenA: TokenIF;
     tokenB: TokenIF;
     isCandleDataNull: boolean;
+    isTableExpanded: boolean;
 }
 
 export const NoChartData = (props: PropsIF) => {
-    const { chainId, tokenA, tokenB, isCandleDataNull } = props;
+    const { chainId, tokenA, tokenB, isCandleDataNull, isTableExpanded } =
+        props;
     const { setIsManualCandleFetchRequested } = useContext(CandleContext);
     const isPoolInitialized = useSimulatedIsPoolInitialized();
     const { toggleTradeTable } = useContext(TradeTableContext);
@@ -96,7 +98,10 @@ export const NoChartData = (props: PropsIF) => {
     }
 
     return (
-        <div className={styles.pool_not_initialialized_container}>
+        <div
+            className={styles.pool_not_initialialized_container}
+            style={{ opacity: isTableExpanded ? '0' : '1' }}
+        >
             <div className={styles.pool_init_bg}>
                 <div className={styles.pool_not_initialialized_content}>
                     <div className={styles.pool_not_init_inner}>

--- a/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.module.css
+++ b/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.module.css
@@ -8,8 +8,8 @@
 .settings_icon {
     margin: 0.5rem 0 0.5rem 1rem;
     cursor: pointer;
-    height: 30px;
-    width: 30px;
+    /* height: 30px;
+    width: 30px; */
 }
 
 .close_icon {

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -319,6 +319,7 @@ function Trade() {
                                         : tradeData.baseToken
                                 }
                                 isCandleDataNull
+                                isTableExpanded={tradeTableState == 'Expanded'}
                             />
                         )}
                         {!showNoChartData && isPoolInitialized && (


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
Fix Refresh button  appearing while the trade table is fully expanded
<img width="1248" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/48744e79-988e-40a3-a5aa-7985a78113a7">
<img width="1243" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/0af91fd7-7752-4868-8a3c-efaa4098b5d8">

### Link the related issue
_Closes #3018_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

