### PR TITLE
bug fix: deposit button not disabled when balance/approval insufficient

### DIFF
--- a/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
+++ b/src/components/Portfolio/ExchangeBalance/Deposit/Deposit.tsx
@@ -125,7 +125,7 @@ export default function Deposit(props: propsIF) {
             tokenAllowance && isDepositQtyValid && !!depositQtyNonDisplay
                 ? BigNumber.from(tokenAllowance).gte(depositQtyNonDisplay)
                 : false,
-        [tokenAllowance, isDepositQtyValid],
+        [tokenAllowance, isDepositQtyValid, depositQtyNonDisplay],
     );
 
     const isWalletBalanceSufficientToCoverGas = useMemo(() => {
@@ -149,7 +149,11 @@ export default function Deposit(props: propsIF) {
                   ).gte(BigNumber.from(0))
                 ? true
                 : false,
-        [tokenWalletBalanceAdjustedNonDisplayString, isDepositQtyValid],
+        [
+            tokenWalletBalanceAdjustedNonDisplayString,
+            isDepositQtyValid,
+            depositQtyNonDisplay,
+        ],
     );
 
     const [isApprovalPending, setIsApprovalPending] = useState(false);


### PR DESCRIPTION
### Describe your changes 
deposit button was not getting disabled when the user had input a quantity greater than their approval or wallet balance.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)