### PR TITLE
Temp fix for re-resizable container

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
         "moment": "^2.29.4",
         "moralis": "^2.11.0",
         "numbro": "^2.3.6",
-        "re-resizable": "^6.9.9",
+        "re-resizable": "^6.6.11",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
         "react-i18next": "^11.18.3",

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -275,6 +275,13 @@ function Trade() {
                         showResizeable={!isCandleDataNull}
                         enable={{
                             bottom: !isChartFullScreen,
+                            top: false,
+                            left: false,
+                            topLeft: false,
+                            bottomLeft: false,
+                            right: false,
+                            topRight: false,
+                            bottomRight: false,
                         }}
                         size={{
                             width: '100%',

--- a/src/styled/Components/Trade.ts
+++ b/src/styled/Components/Trade.ts
@@ -74,6 +74,11 @@ export const ResizableContainer = styled(Resizable)<{
         background-color: var(--dark3);
         z-index: 99;
     }
+    
+    & > div:last-child > div:nth-child(2), & > div:last-child > div:nth-child(4) {
+        z-index: -1;
+        display: none;
+    }
     `}
 `;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13779,10 +13779,10 @@ raw-body@2.5.1:
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
-re-resizable@^6.9.9:
-  version "6.9.9"
-  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.9.tgz#99e8b31c67a62115dc9c5394b7e55892265be216"
-  integrity sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==
+re-resizable@^6.6.11:
+  version "6.9.11"
+  resolved "https://registry.yarnpkg.com/re-resizable/-/re-resizable-6.9.11.tgz#f356e27877f12d926d076ab9ad9ff0b95912b475"
+  integrity sha512-a3hiLWck/NkmyLvGWUuvkAmN1VhwAz4yOhS6FdMTaxCUVN9joIWkT11wsO68coG/iEYuwn+p/7qAmfQzRhiPLQ==
 
 react-app-polyfill@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
### Describe your changes 

- This visually fixes the two pivot points/handles that are present courtesy of the re-resizable container. 
- The actual fix for this bug is to disable the pivot points/handles for all locations except bottom. Having tried that and looking at their implementation, there seems to be a bug with their library. Leaving the actual fix in there for when it gets resolved
- Our chart is actually capable of being resized from its bottom corners which results in some interesting sizing (I wouldn't recommend doing that)

Before:
<img width="1422" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/45405267/f5fcc1b9-2c0a-4bf6-8e53-ffc80d0ddff0">

After:
<img width="1432" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/45405267/36b25095-40a5-4642-b02d-ca562e571ce9">


### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)