### PR TITLE
Resizable bar should no longer be visible in full screen chart view

### DIFF
--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -272,7 +272,7 @@ function Trade() {
                     overflow='hidden'
                 >
                     <ResizableContainer
-                        showResizeable={!isCandleDataNull}
+                        showResizeable={!isCandleDataNull && !isChartFullScreen}
                         enable={{
                             bottom: !isChartFullScreen,
                             top: false,


### PR DESCRIPTION
### Describe your changes 
Fixed resizable bar being visable in chart view.
### Link the related issue
_Closes #3052_