### PR TITLE
Refactor range button message + InitPool reorder state fxns

### DIFF
--- a/src/App/hooks/useHandleRangeButtonMessage.ts
+++ b/src/App/hooks/useHandleRangeButtonMessage.ts
@@ -11,7 +11,7 @@ export function useHandleRangeButtonMessage(
     isPoolInitialized: boolean,
 ) {
     const { tokenAllowed, rangeButtonErrorMessage } = useMemo(() => {
-        console.log('Token Amount: ', token.symbol, { tokenAmount, token });
+        // console.log('Token Amount: ', token.symbol, { tokenAmount, token });
         let tokenAllowed = false;
         let rangeButtonErrorMessage = '';
         if (!isPoolInitialized) {

--- a/src/App/hooks/useHandleRangeButtonMessage.ts
+++ b/src/App/hooks/useHandleRangeButtonMessage.ts
@@ -1,0 +1,59 @@
+import { useMemo } from 'react';
+import { TokenIF } from '../../utils/interfaces/TokenIF';
+
+export function useHandleRangeButtonMessage(
+    token: TokenIF,
+    tokenAmount: string,
+    tokenBalance: string,
+    tokenDexBalance: string,
+    isTokenInputDisabled: boolean,
+    isWithdrawTokenFromDexChecked: boolean,
+    isPoolInitialized: boolean,
+) {
+    const { tokenAllowed, rangeButtonErrorMessage } = useMemo(() => {
+        console.log('Token Amount: ', token.symbol, { tokenAmount, token });
+        let tokenAllowed = false;
+        let rangeButtonErrorMessage = '';
+        if (!isPoolInitialized) {
+            rangeButtonErrorMessage = 'Pool Not Initialized';
+        } else if (
+            (isNaN(parseFloat(tokenAmount)) || parseFloat(tokenAmount) <= 0) &&
+            !isTokenInputDisabled
+        ) {
+            rangeButtonErrorMessage = 'Enter an Amount';
+        } else {
+            if (isWithdrawTokenFromDexChecked) {
+                if (
+                    parseFloat(tokenAmount) >
+                    parseFloat(tokenDexBalance) + parseFloat(tokenBalance)
+                ) {
+                    rangeButtonErrorMessage = `${token.symbol} Amount Exceeds Combined Wallet and Exchange Balance`;
+                } else {
+                    tokenAllowed = true;
+                }
+            } else {
+                if (parseFloat(tokenAmount) > parseFloat(tokenBalance)) {
+                    rangeButtonErrorMessage = `${token.symbol} Amount Exceeds Wallet Balance`;
+                } else {
+                    tokenAllowed = true;
+                }
+            }
+        }
+        return {
+            tokenAllowed,
+            rangeButtonErrorMessage,
+        };
+    }, [
+        tokenAmount,
+        tokenBalance,
+        tokenDexBalance,
+        isTokenInputDisabled,
+        isWithdrawTokenFromDexChecked,
+        isPoolInitialized,
+    ]);
+
+    return {
+        tokenAllowed,
+        rangeButtonErrorMessage,
+    };
+}

--- a/src/components/Trade/Range/RangeTokenInput/RangeTokenInput.tsx
+++ b/src/components/Trade/Range/RangeTokenInput/RangeTokenInput.tsx
@@ -34,10 +34,6 @@ interface propsIF {
     isOutOfRange: boolean;
     isWithdrawFromDexChecked: { tokenA: boolean; tokenB: boolean };
     isInputDisabled: { tokenA: boolean; tokenB: boolean };
-    handleButtonMessage: {
-        tokenA: (tokenAmount: string) => void;
-        tokenB: (tokenAmount: string) => void;
-    };
     toggleDexSelection: (tokenAorB: 'A' | 'B') => void;
 }
 
@@ -56,10 +52,6 @@ function RangeTokenInput(props: propsIF) {
         isInputDisabled: {
             tokenA: isTokenAInputDisabled,
             tokenB: isTokenBInputDisabled,
-        },
-        handleButtonMessage: {
-            tokenA: handleTokenAButtonMessage,
-            tokenB: handleTokenBButtonMessage,
         },
         toggleDexSelection,
         hidePlus,
@@ -99,11 +91,6 @@ function RangeTokenInput(props: propsIF) {
         }
     }, [poolPriceNonDisplay, depositSkew, tokenA.address]);
 
-    useEffect(() => {
-        handleTokenAButtonMessage(tokenAInputQty);
-        handleTokenBButtonMessage(tokenBInputQty);
-    }, [isWithdrawTokenAFromDexChecked, isWithdrawTokenBFromDexChecked]);
-
     const resetTokenQuantities = () => {
         setTokenAInputQty('');
         setTokenBInputQty('');
@@ -140,13 +127,6 @@ function RangeTokenInput(props: propsIF) {
             setTokenAInputQty(truncatedTokenQty);
             setTokenBInputQty(inputValue);
         }
-
-        handleTokenAButtonMessage(
-            primaryToken === 'A' ? inputValue : truncatedTokenQty,
-        );
-        handleTokenBButtonMessage(
-            primaryToken === 'A' ? truncatedTokenQty : inputValue,
-        );
     };
 
     const reverseTokens = (): void => {

--- a/src/pages/Trade/Range/useRangeInputDisable.tsx
+++ b/src/pages/Trade/Range/useRangeInputDisable.tsx
@@ -3,9 +3,9 @@ import { useEffect, useState } from 'react';
 export function useRangeInputDisable(
     isAmbient: boolean,
     isTokenABase: boolean,
-    defaultHighTick: number,
     currentPoolPriceTick: number,
     defaultLowTick: number,
+    defaultHighTick: number,
     isDenomBase: boolean,
 ) {
     const [isTokenAInputDisabled, setIsTokenAInputDisabled] = useState(false);

--- a/src/pages/Trade/Range/useRangeInputDisable.tsx
+++ b/src/pages/Trade/Range/useRangeInputDisable.tsx
@@ -1,0 +1,65 @@
+import { useEffect, useState } from 'react';
+
+export function useRangeInputDisable(
+    isAmbient: boolean,
+    isTokenABase: boolean,
+    defaultHighTick: number,
+    currentPoolPriceTick: number,
+    defaultLowTick: number,
+    isDenomBase: boolean,
+) {
+    const [isTokenAInputDisabled, setIsTokenAInputDisabled] = useState(false);
+    const [isTokenBInputDisabled, setIsTokenBInputDisabled] = useState(false);
+
+    // TODO: this logic can likely be simplified
+    // Or at least made more readable
+    useEffect(() => {
+        if (!isAmbient) {
+            if (isTokenABase) {
+                if (defaultHighTick < currentPoolPriceTick) {
+                    setIsTokenBInputDisabled(true);
+                    if (defaultHighTick > defaultLowTick) {
+                        setIsTokenAInputDisabled(false);
+                    } else setIsTokenAInputDisabled(true);
+                } else if (defaultLowTick > currentPoolPriceTick) {
+                    setIsTokenAInputDisabled(true);
+                    if (defaultLowTick < defaultHighTick) {
+                        setIsTokenBInputDisabled(false);
+                    } else setIsTokenBInputDisabled(true);
+                } else {
+                    setIsTokenAInputDisabled(false);
+                    setIsTokenBInputDisabled(false);
+                }
+            } else {
+                if (defaultHighTick < currentPoolPriceTick) {
+                    setIsTokenAInputDisabled(true);
+                    if (defaultHighTick > defaultLowTick) {
+                        setIsTokenBInputDisabled(false);
+                    } else setIsTokenBInputDisabled(true);
+                } else if (defaultLowTick > currentPoolPriceTick) {
+                    setIsTokenBInputDisabled(true);
+                    if (defaultLowTick < defaultHighTick) {
+                        setIsTokenAInputDisabled(false);
+                    } else setIsTokenBInputDisabled(true);
+                } else {
+                    setIsTokenBInputDisabled(false);
+                    setIsTokenAInputDisabled(false);
+                }
+            }
+        } else {
+            setIsTokenBInputDisabled(false);
+            setIsTokenAInputDisabled(false);
+        }
+    }, [
+        isAmbient,
+        isTokenABase,
+        currentPoolPriceTick,
+        defaultLowTick,
+        defaultHighTick,
+        isDenomBase,
+    ]);
+    return {
+        isTokenAInputDisabled,
+        isTokenBInputDisabled,
+    };
+}


### PR DESCRIPTION
- [ ] Refactors logic for range component button message - it's been simplified to a useMemo and is made reusable in the initPool page
- [ ] Reorder so that all useStates are at the top and can be used by any subsequent logic - this should be a standard rather than use states throughout the component. 


To test:
- Creating range in normal tap should still function as normal (message when inputting above your balance etc)
- Pool init now has this kind of messaging when trying to create range positions. 