### PR TITLE
Fix RangeActionModal showing incorrect position after submitting transaction

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -312,6 +312,19 @@ export default function RangesMenu(props: propsIF) {
         } else return;
     }, [showDropdownMenu]);
 
+    const [cachedPosition, setCachedPosition] = useState<
+        PositionIF | undefined
+    >();
+
+    useEffect(() => {
+        if (
+            !cachedPosition ||
+            position.positionId === cachedPosition.positionId
+        ) {
+            setCachedPosition({ ...position } as PositionIF);
+        }
+    }, [position]);
+
     return (
         <FlexContainer justifyContent='flex-end'>
             <div
@@ -322,19 +335,19 @@ export default function RangesMenu(props: propsIF) {
                 {rangesMenu}
                 {dropdownRangesMenu}
             </div>
-            {isRangeDetailsModalOpen && (
+            {isRangeDetailsModalOpen && cachedPosition && (
                 <RangeDetailsModal
-                    position={position}
+                    position={cachedPosition}
                     onClose={closeRangeDetailsModal}
                     {...rangeDetailsProps}
                 />
             )}
-            {isRangeActionModalOpen && (
+            {isRangeActionModalOpen && cachedPosition && (
                 <RangeActionModal
                     type={rangeModalAction}
                     isOpen={isRangeActionModalOpen}
                     onClose={handleActionModalClose}
-                    position={position}
+                    position={cachedPosition}
                     {...rangeDetailsProps}
                 />
             )}

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -317,13 +317,17 @@ export default function RangesMenu(props: propsIF) {
     >();
 
     useEffect(() => {
-        if (
-            !cachedPosition ||
-            position.positionId === cachedPosition.positionId
-        ) {
-            setCachedPosition({ ...position } as PositionIF);
+        if (isRangeActionModalOpen || isRangeDetailsModalOpen) {
+            if (
+                !cachedPosition ||
+                position.positionId === cachedPosition.positionId
+            ) {
+                setCachedPosition({ ...position } as PositionIF);
+            }
+        } else {
+            setCachedPosition(undefined);
         }
-    }, [position]);
+    }, [isRangeActionModalOpen, isRangeDetailsModalOpen, position]);
 
     return (
         <FlexContainer justifyContent='flex-end'>

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -22,7 +22,7 @@ interface propsIF {
 }
 
 function RangesRow(props: propsIF) {
-    const { tableView, position, isAccountView, isLeaderboard } = props;
+    const { tableView, position, isAccountView, isLeaderboard, rank } = props;
     const {
         snackbar: { open: openSnackbar },
     } = useContext(AppStateContext);
@@ -92,8 +92,8 @@ function RangesRow(props: propsIF) {
         baseTokenLogoURI: position.baseTokenLogoURI,
         quoteTokenLogoURI: position.quoteTokenLogoURI,
         isDenomBase: isDenomBase,
-        baseTokenAddress: props.position.base,
-        quoteTokenAddress: props.position.quote,
+        baseTokenAddress: position.base,
+        quoteTokenAddress: position.quote,
         positionApy: position.apy,
         minRangeDenomByMoneyness: minRangeDenomByMoneyness,
         maxRangeDenomByMoneyness: maxRangeDenomByMoneyness,
@@ -105,7 +105,7 @@ function RangesRow(props: propsIF) {
         isPositionEmpty: isPositionEmpty,
         positionData: position,
         position: position,
-        isAccountView: props.isAccountView,
+        isAccountView: isAccountView,
         isPositionInRange: isPositionInRange,
     };
 
@@ -203,7 +203,7 @@ function RangesRow(props: propsIF) {
         baseTokenSymbol,
         quoteTokenSymbol,
         isLeaderboard,
-        rank: props.rank,
+        rank: rank,
         elapsedTimeString,
         maxRangeDenomByMoneyness,
         isAccountView,
@@ -238,7 +238,7 @@ function RangesRow(props: propsIF) {
     } = rangeRowConstants(rangeRowConstantsProps);
 
     function handleRowClick() {
-        if (position.firstMintTx === currentPositionActive) {
+        if (position?.firstMintTx === currentPositionActive) {
             return;
         }
         setCurrentPositionActive('');


### PR DESCRIPTION
### Describe your changes 
- position data is linked to the specific row in the transactions table
- when a pool transaction is submitted, it changes row positions automatically (sorted by latest transaction)
- this results in the confirmation modal "updating" itself to show position data for the pool transaction for the previous row 

- we now cache the position data such that the position data is only passed down to the modals if its for the same position or the modal's being opened

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)