### PR TITLE
Fixing overlap of token name and symbol when token name is long

### DIFF
--- a/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.module.css
+++ b/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.module.css
@@ -1,6 +1,6 @@
 .token_info {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: auto 40%;
     width: 100%;
     align-items: center;
     color: var(--text1);

--- a/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.module.css
+++ b/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.module.css
@@ -1,6 +1,6 @@
 .token_info {
     display: grid;
-    grid-template-columns: auto 40%;
+    grid-template-columns: minmax(18ch, 2fr) 3fr;
     width: 100%;
     align-items: center;
     color: var(--text1);
@@ -45,10 +45,4 @@
     display: flex;
     justify-content: flex-end;
     color: var(--text1);
-}
-
-@media only screen and (min-width: 768px) {
-    .token_info {
-        width: 50%;
-    }
 }

--- a/src/components/Global/Account/AccountTabs/Wallet/WalletCard.module.css
+++ b/src/components/Global/Account/AccountTabs/Wallet/WalletCard.module.css
@@ -1,6 +1,6 @@
 .token_info {
     display: grid;
-    grid-template-columns: 1fr 1fr;
+    grid-template-columns: auto 40%;
     width: 100%;
     align-items: center;
     color: var(--text1);

--- a/src/components/Global/Account/AccountTabs/Wallet/WalletCard.module.css
+++ b/src/components/Global/Account/AccountTabs/Wallet/WalletCard.module.css
@@ -1,6 +1,6 @@
 .token_info {
     display: grid;
-    grid-template-columns: auto 40%;
+    grid-template-columns: minmax(18ch, 2fr) 3fr;
     width: 100%;
     align-items: center;
     color: var(--text1);
@@ -45,10 +45,4 @@
     display: flex;
     justify-content: flex-end;
     color: var(--text1);
-}
-
-@media only screen and (min-width: 768px) {
-    .token_info {
-        width: 50%;
-    }
 }


### PR DESCRIPTION
### Describe your changes 
- Auto aligning the symbol and giving the token name 40% of space in the exchange balance and wallet balance rows
<img width="970" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/45405267/f6dfe2e6-af07-4328-8214-e3f4760d30cb">


### Link the related issue
Closes https://github.com/CrocSwap/ambient-ts-app/issues/3121

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)