### PR TITLE
hotfix: USD token value queries on scroll

### DIFF
--- a/src/App/functions/fetchTokenPrice.ts
+++ b/src/App/functions/fetchTokenPrice.ts
@@ -21,6 +21,7 @@ export const fetchTokenPrice = async (
                         config_path: 'price',
                         include_data: '0',
                         token_address: address,
+                        asset_platform: 'scroll',
                     }),
             );
             const result = await response.json();


### PR DESCRIPTION
### Describe your changes 
USDC value queries to the Analytics server were failing due to a missing parameter. Adding the asset_platform parameter should fix the TVL calculations in the Top Pools. 
