### PR TITLE
Fix wallet dropdown balances

### DIFF
--- a/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
+++ b/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
@@ -30,6 +30,7 @@ import { toDisplayQty } from '@crocswap-libs/sdk';
 import { ethereumMainnet } from '../../../../../utils/networks/ethereumMainnet';
 import { mainnetUSDC } from '../../../../../utils/data/defaultTokens';
 import IconWithTooltip from '../../../../../components/Global/IconWithTooltip/IconWithTooltip';
+import { supportedNetworks } from '../../../../../utils/networks';
 
 interface WalletDropdownPropsIF {
     ensName: string;
@@ -62,6 +63,9 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
 
+    const defaultPair: [TokenIF, TokenIF] =
+        supportedNetworks[chainId].defaultPair;
+
     const tokenBalances: TokenIF[] | undefined = useAppSelector(
         (state) => state.userData.tokenBalances,
     );
@@ -70,7 +74,9 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
         tokenBalances.find((tkn: TokenIF) => tkn.address === ZERO_ADDRESS);
     const usdcData: TokenIF | undefined = useMemo(() => {
         return tokenBalances?.find(
-            (tkn: TokenIF) => tkn.symbol === 'USDC' && tkn.name !== '',
+            (tkn: TokenIF) =>
+                tkn.address.toLowerCase() ===
+                defaultPair[1].address.toLowerCase(),
         );
     }, [tokenBalances]);
     const { cachedFetchTokenPrice } = useContext(CachedDataContext);

--- a/src/utils/interfaces/NetworkIF.ts
+++ b/src/utils/interfaces/NetworkIF.ts
@@ -8,7 +8,7 @@ export interface NetworkIF {
     wagmiChain: any;
     shouldPollBlock: boolean;
     marketData: string;
-    defaultPair: TokenIF[];
+    defaultPair: [TokenIF, TokenIF];
     topPools: TopPool[];
     getGasPriceInGwei: (provider?: Provider) => Promise<number | undefined>;
 }


### PR DESCRIPTION
### Describe your changes 
* Refactor `WalletDropdown.tsx` logic to pull wallet balance and USD equiv for second default token on chain
* Minor update to the shape of `NetworkIF`

### Link the related issue
Closes #3200

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**
1. Connect to each supported network in sequence
2. Confirm the wallet dropdown correctly shows quantity and USD equiv for the default token pair

**Environmental conditions which may result in expected but differential behavior.**
Values rendered are network-specific and not available if the user does not have a connected wallet

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
None, ready for merge!