### PR TITLE
refactor trade mobile padding and dropdown size

### DIFF
--- a/src/components/Global/ContentContainer/ContentContainer.module.css
+++ b/src/components/Global/ContentContainer/ContentContainer.module.css
@@ -19,8 +19,7 @@
 }
 
 .swap_main_content {
-   
-    padding: 24px;
+  
     box-shadow: var(--gradient-box-shadow);
 }
 
@@ -81,6 +80,12 @@
     .no_background:hover,
     .no_background:focus-within {
         box-shadow: none;
+    }
+
+    .swap_main_content {
+   
+        padding: 24px;
+       
     }
     
 }

--- a/src/components/Global/ContentContainer/ContentContainer.tsx
+++ b/src/components/Global/ContentContainer/ContentContainer.tsx
@@ -7,6 +7,7 @@ interface ContentContainerPropsIF {
     customWidthAuto?: boolean;
     isOnTradeRoute?: boolean;
     noPadding?: boolean;
+    noStyle?: boolean;
 }
 
 export default function ContentContainer(props: ContentContainerPropsIF) {
@@ -16,6 +17,7 @@ export default function ContentContainer(props: ContentContainerPropsIF) {
         customWidth,
         customWidthAuto,
         noPadding,
+        noStyle,
     } = props;
 
     const customWidthStyle = customWidth ? styles.customWidth_container : null;
@@ -26,6 +28,8 @@ export default function ContentContainer(props: ContentContainerPropsIF) {
     const customWidthAutoStyle = customWidthAuto
         ? styles.customWidthAuto
         : styles.container;
+
+    if (noStyle) return <>{children}</>;
 
     return (
         <section

--- a/src/components/Trade/TradeModules/TradeModuleSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeModuleSkeleton.tsx
@@ -16,6 +16,7 @@ import TutorialOverlay from '../../Global/TutorialOverlay/TutorialOverlay';
 import Button from '../../Form/Button';
 
 import TradeLinks from './TradeLinks';
+import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 
 interface PropsIF {
     chainId: string;
@@ -98,9 +99,10 @@ export const TradeModuleSkeleton = (props: PropsIF) => {
         /\b(not)\b/g,
         '<span style="color: var(--negative); text-transform: uppercase;">$1</span>',
     );
+    const smallScreen = useMediaQuery('(max-width: 500px)');
 
     return (
-        <section>
+        <>
             {isTutorialActive && (
                 <FlexContainer
                     fullWidth
@@ -113,7 +115,10 @@ export const TradeModuleSkeleton = (props: PropsIF) => {
                     </TutorialButton>
                 </FlexContainer>
             )}{' '}
-            <ContentContainer isOnTradeRoute={!isSwapPage}>
+            <ContentContainer
+                isOnTradeRoute={!isSwapPage}
+                noPadding={smallScreen && !isSwapPage}
+            >
                 {header}
                 {isSwapPage || (
                     <TradeLinks
@@ -213,6 +218,6 @@ export const TradeModuleSkeleton = (props: PropsIF) => {
                 setIsTutorialEnabled={setIsTutorialEnabled}
                 steps={tutorialSteps}
             />
-        </section>
+        </>
     );
 };

--- a/src/pages/Trade/Trade.tsx
+++ b/src/pages/Trade/Trade.tsx
@@ -171,6 +171,7 @@ function Trade() {
     ]);
 
     const showActiveMobileComponent = useMediaQuery('(max-width: 1200px)');
+    const smallScreen = useMediaQuery('(max-width: 500px)');
 
     const [isChartLoading, setIsChartLoading] = useState<boolean>(true);
 
@@ -243,7 +244,7 @@ function Trade() {
             )}
 
             {activeMobileComponent === 'trade' && (
-                <ContentContainer noPadding>
+                <ContentContainer noPadding noStyle={smallScreen}>
                     <Outlet
                         context={{
                             tradeData: tradeData,

--- a/src/styled/Components/Trade.ts
+++ b/src/styled/Components/Trade.ts
@@ -36,6 +36,10 @@ export const TradeDropdown = styled.div`
     text-transform: capitalize;
     margin: 0 auto;
     background: var(--dark2);
+
+    @media (max-width: 500px) {
+        width: 95%;
+    }
 `;
 
 export const TradeDropdownButton = styled.button<{ activeText?: boolean }>`


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
The padding on the trade module on mobile devices occupies too much space.
This PR should reduce that and give us more horizontal space to work with:
<img width="344" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/48332c08-e130-49b9-bd34-3af6daf0bbac">

<img width="350" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/2699c9bf-a72e-4796-92e7-eb088da575b9">
<img width="353" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/e22f7218-793a-46c8-897e-bd920fb5cf85">

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)