### PR TITLE
move hardcoded usd prices for ETH / USDC to fallback

### DIFF
--- a/src/App/functions/fetchTokenPrice.ts
+++ b/src/App/functions/fetchTokenPrice.ts
@@ -20,42 +20,37 @@ export const fetchTokenPrice = async (
         supportedNetworks[chain].defaultPair;
 
     try {
-        if (address) {
-            if (
-                address.toLowerCase() === defaultPair[1].address.toLowerCase()
-            ) {
-                return {
-                    usdPrice: 0.9995309916951084,
-                    usdPriceFormatted: 1,
-                };
-            } else if (
-                address.toLowerCase() === defaultPair[0].address.toLowerCase()
-            ) {
-                return {
-                    usdPrice: 2000,
-                    usdPriceFormatted: 2000,
-                };
-            }
+        const url =
+            ANALYTICS_URL +
+            new URLSearchParams({
+                service: 'run',
+                config_path: 'price',
+                include_data: '0',
+                token_address: address,
+                asset_platform:
+                    chain === '0x82750' || chain === '0x8274f'
+                        ? 'scroll'
+                        : 'ethereum',
+            });
 
-            const url =
-                ANALYTICS_URL +
-                new URLSearchParams({
-                    service: 'run',
-                    config_path: 'price',
-                    include_data: '0',
-                    token_address: address,
-                    asset_platform:
-                        chain === '0x82750' || chain === '0x8274f'
-                            ? 'scroll'
-                            : 'ethereum',
-                });
+        const response = await fetchTimeout(url);
 
-            const response = await fetchTimeout(url);
-
-            const result = await response.json();
-            return result?.value;
-        }
+        const result = await response.json();
+        return result?.value;
     } catch (error) {
+        if (address.toLowerCase() === defaultPair[1].address.toLowerCase()) {
+            return {
+                usdPrice: 0.9995309916951084,
+                usdPriceFormatted: 1,
+            };
+        } else if (
+            address.toLowerCase() === defaultPair[0].address.toLowerCase()
+        ) {
+            return {
+                usdPrice: 2005.69,
+                usdPriceFormatted: 2005.69,
+            };
+        }
         return undefined;
     }
 };


### PR DESCRIPTION
### Describe your changes 
Prices for ETH and USDC were hardcoded to get returned regardless of server availability to return up-to-date prices. This change moves these hardcoded values to only get returned when the server fails to respond with prices in a timely manner.


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)