### PR TITLE
use ETH-USDC pool price as ETH value fallback

### DIFF
--- a/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
+++ b/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
@@ -26,8 +26,6 @@ import { FlexContainer } from '../../../../../styled/Common';
 import { ZERO_ADDRESS } from '../../../../../constants';
 import { BigNumber } from 'ethers';
 import { toDisplayQty } from '@crocswap-libs/sdk';
-import { ethereumMainnet } from '../../../../../utils/networks/ethereumMainnet';
-import { mainnetUSDC } from '../../../../../utils/data/defaultTokens';
 import IconWithTooltip from '../../../../../components/Global/IconWithTooltip/IconWithTooltip';
 import { TokenBalanceContext } from '../../../../../contexts/TokenBalanceContext';
 import { supportedNetworks } from '../../../../../utils/networks';
@@ -103,10 +101,23 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
         string | undefined
     >();
 
-    const { ethMainnetUsdPrice, crocEnv } = useContext(CrocEnvContext);
+    const [ethMainnetUsdPrice, setEthMainnetUsdPrice] = useState<
+        number | undefined
+    >();
+
+    const { crocEnv } = useContext(CrocEnvContext);
 
     useEffect(() => {
         if (!crocEnv) return;
+        Promise.resolve(
+            cachedFetchTokenPrice(ZERO_ADDRESS, chainId, crocEnv),
+        ).then((price) => {
+            if (price?.usdPrice !== undefined) {
+                setEthMainnetUsdPrice(price.usdPrice);
+            } else {
+                setEthMainnetUsdPrice(undefined);
+            }
+        });
         if (usdcData === undefined) {
             setUsdcUsdValueForDom(undefined);
             setUsdcBalanceForDom(undefined);
@@ -135,11 +146,7 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
 
         setUsdcBalanceForDom(usdcCombinedBalanceDisplayTruncated);
         Promise.resolve(
-            cachedFetchTokenPrice(
-                mainnetUSDC.address,
-                ethereumMainnet.chainId,
-                crocEnv,
-            ),
+            cachedFetchTokenPrice(usdcData.address, chainId, crocEnv),
         ).then((price) => {
             if (price?.usdPrice !== undefined) {
                 const usdValueNum: number =

--- a/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
+++ b/src/App/components/PageHeader/Account/WalletDropdown/WalletDropdown.tsx
@@ -102,7 +102,11 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
     const [usdcUsdValueForDom, setUsdcUsdValueForDom] = useState<
         string | undefined
     >();
+
+    const { ethMainnetUsdPrice, crocEnv } = useContext(CrocEnvContext);
+
     useEffect(() => {
+        if (!crocEnv) return;
         if (usdcData === undefined) {
             setUsdcUsdValueForDom(undefined);
             setUsdcBalanceForDom(undefined);
@@ -130,9 +134,12 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
                 : '0.00';
 
         setUsdcBalanceForDom(usdcCombinedBalanceDisplayTruncated);
-
         Promise.resolve(
-            cachedFetchTokenPrice(mainnetUSDC.address, ethereumMainnet.chainId),
+            cachedFetchTokenPrice(
+                mainnetUSDC.address,
+                ethereumMainnet.chainId,
+                crocEnv,
+            ),
         ).then((price) => {
             if (price?.usdPrice !== undefined) {
                 const usdValueNum: number =
@@ -149,9 +156,7 @@ export default function WalletDropdown(props: WalletDropdownPropsIF) {
                 setUsdcUsdValueForDom(undefined);
             }
         });
-    }, [chainId, JSON.stringify(usdcData)]);
-
-    const { ethMainnetUsdPrice } = useContext(CrocEnvContext);
+    }, [crocEnv, chainId, JSON.stringify(usdcData)]);
 
     const nativeCombinedBalance =
         nativeData?.walletBalance !== undefined

--- a/src/App/functions/fetchCandleSeries.ts
+++ b/src/App/functions/fetchCandleSeries.ts
@@ -228,8 +228,8 @@ async function expandPoolStats(
     const baseDecimals = crocEnv.token(base).decimals;
     const quoteDecimals = crocEnv.token(quote).decimals;
 
-    const basePricePromise = cachedFetchTokenPrice(base, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quote, chainId);
+    const basePricePromise = cachedFetchTokenPrice(base, chainId, crocEnv);
+    const quotePricePromise = cachedFetchTokenPrice(quote, chainId, crocEnv);
 
     const basePrice = (await basePricePromise)?.usdPrice || 0.0;
     const quotePrice = (await quotePricePromise)?.usdPrice || 0.0;

--- a/src/App/functions/fetchPoolLiquidity.ts
+++ b/src/App/functions/fetchPoolLiquidity.ts
@@ -54,8 +54,8 @@ async function expandLiquidityData(
     const pool = crocEnv.pool(base, quote);
     const curveTick = pool.spotTick();
 
-    const basePricePromise = cachedFetchTokenPrice(base, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quote, chainId);
+    const basePricePromise = cachedFetchTokenPrice(base, chainId, crocEnv);
+    const quotePricePromise = cachedFetchTokenPrice(quote, chainId, crocEnv);
 
     const basePrice = (await basePricePromise)?.usdPrice || 0.0;
     const quotePrice = (await quotePricePromise)?.usdPrice || 0.0;

--- a/src/App/functions/fetchTokenPrice.ts
+++ b/src/App/functions/fetchTokenPrice.ts
@@ -9,6 +9,7 @@ import { supportedNetworks } from '../../utils/networks';
 import { fetchTimeout } from '../../utils/functions/fetchTimeout';
 import { CrocEnv, toDisplayPrice } from '@crocswap-libs/sdk';
 import { querySpotPrice } from './querySpotPrice';
+import truncateDecimals from '../../utils/data/truncateDecimals';
 
 export const fetchTokenPrice = async (
     dispToken: string,
@@ -52,7 +53,6 @@ export const fetchTokenPrice = async (
             address.toLowerCase() === defaultPair[0].address.toLowerCase()
         ) {
             if (!crocEnv) return;
-            console.log({ crocEnv });
             const spotPrice = await querySpotPrice(
                 crocEnv,
                 defaultPair[0].address.toLowerCase(),
@@ -62,7 +62,11 @@ export const fetchTokenPrice = async (
             );
             const displayPrice: number =
                 1 / toDisplayPrice(spotPrice ?? 0.0005, 18, 6);
-            return displayPrice;
+            const usdPriceFormatted = truncateDecimals(displayPrice, 2);
+            return {
+                usdPrice: displayPrice,
+                usdPriceFormatted: usdPriceFormatted,
+            };
         }
         return undefined;
     }

--- a/src/App/functions/fetchTokenPrice.ts
+++ b/src/App/functions/fetchTokenPrice.ts
@@ -7,10 +7,13 @@ import { translateTestnetToken } from '../../utils/data/testnetTokenMap';
 import { TokenIF } from '../../utils/interfaces/TokenIF';
 import { supportedNetworks } from '../../utils/networks';
 import { fetchTimeout } from '../../utils/functions/fetchTimeout';
+import { CrocEnv, toDisplayPrice } from '@crocswap-libs/sdk';
+import { querySpotPrice } from './querySpotPrice';
 
 export const fetchTokenPrice = async (
     dispToken: string,
     chain: string,
+    crocEnv: CrocEnv,
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _lastTime: number,
 ) => {
@@ -38,18 +41,28 @@ export const fetchTokenPrice = async (
         const result = await response.json();
         return result?.value;
     } catch (error) {
+        // if token is USDC, return 0.999
         if (address.toLowerCase() === defaultPair[1].address.toLowerCase()) {
             return {
                 usdPrice: 0.9995309916951084,
                 usdPriceFormatted: 1,
             };
         } else if (
+            // if token is ETH, return current value of ETH-USDC pool
             address.toLowerCase() === defaultPair[0].address.toLowerCase()
         ) {
-            return {
-                usdPrice: 2005.69,
-                usdPriceFormatted: 2005.69,
-            };
+            if (!crocEnv) return;
+            console.log({ crocEnv });
+            const spotPrice = await querySpotPrice(
+                crocEnv,
+                defaultPair[0].address.toLowerCase(),
+                defaultPair[1].address.toLowerCase(),
+                chain,
+                _lastTime,
+            );
+            const displayPrice: number =
+                1 / toDisplayPrice(spotPrice ?? 0.0005, 18, 6);
+            return displayPrice;
         }
         return undefined;
     }
@@ -58,6 +71,7 @@ export const fetchTokenPrice = async (
 export type TokenPriceFn = (
     address: string,
     chain: string,
+    crocEnv: CrocEnv,
 ) => Promise<
     | {
           nativePrice?:
@@ -82,10 +96,11 @@ const randomOffset = PRICE_WINDOW_GRANULARITY * randomNum;
 
 export function memoizeTokenPrice(): TokenPriceFn {
     const memoFn = memoizePromiseFn(fetchTokenPrice);
-    return (address: string, chain: string) =>
+    return (address: string, chain: string, crocEnv: CrocEnv) =>
         memoFn(
             address,
             chain,
+            crocEnv,
             Math.floor((Date.now() + randomOffset) / PRICE_WINDOW_GRANULARITY),
         );
 }

--- a/src/App/functions/getLimitOrderData.ts
+++ b/src/App/functions/getLimitOrderData.ts
@@ -49,8 +49,16 @@ export const getLimitOrderData = async (
         ? ''
         : (await cachedEnsResolve(order.user)) ?? '';
 
-    const basePricePromise = cachedFetchTokenPrice(baseTokenAddress, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quoteTokenAddress, chainId);
+    const basePricePromise = cachedFetchTokenPrice(
+        baseTokenAddress,
+        chainId,
+        crocEnv,
+    );
+    const quotePricePromise = cachedFetchTokenPrice(
+        quoteTokenAddress,
+        chainId,
+        crocEnv,
+    );
 
     const DEFAULT_DECIMALS = 18;
     const baseTokenDecimals =

--- a/src/App/functions/getPoolStats.ts
+++ b/src/App/functions/getPoolStats.ts
@@ -90,8 +90,8 @@ async function expandPoolStats(
 ): Promise<PoolStatsIF> {
     const pool = crocEnv.pool(base, quote);
 
-    const basePricePromise = cachedFetchTokenPrice(base, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quote, chainId);
+    const basePricePromise = cachedFetchTokenPrice(base, chainId, crocEnv);
+    const quotePricePromise = cachedFetchTokenPrice(quote, chainId, crocEnv);
 
     const basePrice = (await basePricePromise)?.usdPrice || 0.0;
     const quotePrice = (await quotePricePromise)?.usdPrice || 0.0;
@@ -319,10 +319,11 @@ async function expandTokenStats(
     cachedFetchTokenPrice: TokenPriceFn,
 ): Promise<DexAggStatsIF> {
     const decimals = crocEnv.token(stats.tokenAddr).decimals;
-
-    const usdPrice = cachedFetchTokenPrice(stats.tokenAddr, chainId).then(
-        (p) => p?.usdPrice || 0.0,
-    );
+    const usdPrice = cachedFetchTokenPrice(
+        stats.tokenAddr,
+        chainId,
+        crocEnv,
+    ).then((p) => p?.usdPrice || 0.0);
 
     const mult = (await usdPrice) / Math.pow(10, await decimals);
     return {

--- a/src/App/functions/getPositionData.ts
+++ b/src/App/functions/getPositionData.ts
@@ -48,8 +48,16 @@ export const getPositionData = async (
     const baseMetadata = cachedTokenDetails(provider, position.base, chainId);
     const quoteMetadata = cachedTokenDetails(provider, position.quote, chainId);
 
-    const basePricePromise = cachedFetchTokenPrice(baseTokenAddress, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quoteTokenAddress, chainId);
+    const basePricePromise = cachedFetchTokenPrice(
+        baseTokenAddress,
+        chainId,
+        crocEnv,
+    );
+    const quotePricePromise = cachedFetchTokenPrice(
+        quoteTokenAddress,
+        chainId,
+        crocEnv,
+    );
 
     newPosition.ensResolution = skipENSFetch
         ? ''

--- a/src/App/functions/getTransactionData.ts
+++ b/src/App/functions/getTransactionData.ts
@@ -40,8 +40,16 @@ export const getTransactionData = async (
 
     // const ensRequest = cachedEnsResolve(tx.user);
 
-    const basePricePromise = cachedFetchTokenPrice(baseTokenAddress, chainId);
-    const quotePricePromise = cachedFetchTokenPrice(quoteTokenAddress, chainId);
+    const basePricePromise = cachedFetchTokenPrice(
+        baseTokenAddress,
+        chainId,
+        crocEnv,
+    );
+    const quotePricePromise = cachedFetchTokenPrice(
+        quoteTokenAddress,
+        chainId,
+        crocEnv,
+    );
 
     newTx.ensResolution = skipENSFetch
         ? ''

--- a/src/components/Form/TokenInputWithWalletBalance.tsx
+++ b/src/components/Form/TokenInputWithWalletBalance.tsx
@@ -58,6 +58,7 @@ function TokenInputWithWalletBalance(props: propsIF) {
 
     const {
         chainData: { chainId },
+        crocEnv,
     } = useContext(CrocEnvContext);
 
     const amountToReduceEthMainnet = 0.01; // .01 ETH
@@ -76,29 +77,30 @@ function TokenInputWithWalletBalance(props: propsIF) {
     const pricedToken = translateTestnetToken(token.address);
 
     useEffect(() => {
-        Promise.resolve(cachedFetchTokenPrice(pricedToken, chainId)).then(
-            (price) => {
-                if (price?.usdPrice !== undefined) {
-                    const usdValueNum: number | undefined =
-                        price !== undefined && tokenInput !== ''
-                            ? price.usdPrice * parseFloat(tokenInput)
-                            : undefined;
-                    const usdValueTruncated =
-                        usdValueNum !== undefined
-                            ? getFormattedNumber({
-                                  value: usdValueNum,
-                                  isUSD: true,
-                              })
-                            : undefined;
-                    usdValueTruncated !== undefined
-                        ? setUsdValueForDom(usdValueTruncated)
-                        : setUsdValueForDom('');
-                } else {
-                    setUsdValueForDom(undefined);
-                }
-            },
-        );
-    }, [chainId, pricedToken, tokenInput]);
+        if (!crocEnv) return;
+        Promise.resolve(
+            cachedFetchTokenPrice(pricedToken, chainId, crocEnv),
+        ).then((price) => {
+            if (price?.usdPrice !== undefined) {
+                const usdValueNum: number | undefined =
+                    price !== undefined && tokenInput !== ''
+                        ? price.usdPrice * parseFloat(tokenInput)
+                        : undefined;
+                const usdValueTruncated =
+                    usdValueNum !== undefined
+                        ? getFormattedNumber({
+                              value: usdValueNum,
+                              isUSD: true,
+                          })
+                        : undefined;
+                usdValueTruncated !== undefined
+                    ? setUsdValueForDom(usdValueTruncated)
+                    : setUsdValueForDom('');
+            } else {
+                setUsdValueForDom(undefined);
+            }
+        });
+    }, [crocEnv, chainId, pricedToken, tokenInput]);
 
     const toDecimal = (val: string) =>
         isTokenEth ? parseFloat(val).toFixed(18) : parseFloat(val).toString();

--- a/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
+++ b/src/components/Global/Account/AccountTabs/Exchange/ExchangeCard.tsx
@@ -24,6 +24,7 @@ export default function ExchangeCard(props: propsIF) {
 
     const {
         chainData: { chainId },
+        crocEnv,
     } = useContext(CrocEnvContext);
 
     const tokenFromMap = token?.address
@@ -46,11 +47,13 @@ export default function ExchangeCard(props: propsIF) {
 
     useEffect(() => {
         (async () => {
+            if (!crocEnv) return;
             try {
                 if (tokenFromMap?.symbol) {
                     const price = await cachedFetchTokenPrice(
                         tokenFromMap.address,
                         chainId,
+                        crocEnv,
                     );
                     if (price) setTokenPrice(price);
                 }
@@ -58,7 +61,7 @@ export default function ExchangeCard(props: propsIF) {
                 console.error(err);
             }
         })();
-    }, [token?.address, chainId]);
+    }, [crocEnv, token?.address, chainId]);
 
     const tokenUsdPrice = tokenPrice?.usdPrice ?? 0;
 

--- a/src/components/Global/Account/AccountTabs/Wallet/WalletCard.tsx
+++ b/src/components/Global/Account/AccountTabs/Wallet/WalletCard.tsx
@@ -23,6 +23,7 @@ export default function WalletCard(props: propsIF) {
     } = useContext(TokenContext);
     const {
         chainData: { chainId },
+        crocEnv,
     } = useContext(CrocEnvContext);
 
     const tokenMapKey = token?.address?.toLowerCase() + '_' + chainId;
@@ -47,11 +48,13 @@ export default function WalletCard(props: propsIF) {
 
     useEffect(() => {
         (async () => {
+            if (!crocEnv) return;
             try {
                 if (tokenFromMap?.symbol) {
                     const price = await cachedFetchTokenPrice(
                         tokenFromMap.address,
                         chainId,
+                        crocEnv,
                     );
                     if (price) setTokenPrice(price);
                 }
@@ -59,7 +62,7 @@ export default function WalletCard(props: propsIF) {
                 console.error(err);
             }
         })();
-    }, [tokenMapKey]);
+    }, [crocEnv, tokenMapKey]);
 
     const tokenUsdPrice = tokenPrice?.usdPrice ?? 0;
 

--- a/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
+++ b/src/components/Trade/Range/RangePriceInfo/RangePriceInfo.tsx
@@ -53,6 +53,7 @@ function RangePriceInfo(props: propsIF) {
     const { cachedFetchTokenPrice } = useContext(CachedDataContext);
     const {
         chainData: { chainId },
+        crocEnv,
     } = useContext(CrocEnvContext);
 
     const { isDenomBase, tokenA, tokenB, baseToken, quoteToken } =
@@ -114,9 +115,18 @@ function RangePriceInfo(props: propsIF) {
     const isEitherTokenStable = isStableTokenA || isStableTokenB;
 
     const updateMainnetPricesAsync = async () => {
-        const tokenAPrice = await cachedFetchTokenPrice(tokenAAddress, chainId);
+        if (!crocEnv) return;
+        const tokenAPrice = await cachedFetchTokenPrice(
+            tokenAAddress,
+            chainId,
+            crocEnv,
+        );
 
-        const tokenBPrice = await cachedFetchTokenPrice(tokenBAddress, chainId);
+        const tokenBPrice = await cachedFetchTokenPrice(
+            tokenBAddress,
+            chainId,
+            crocEnv,
+        );
 
         setTokenAPrice(tokenAPrice?.usdPrice);
         setTokenBPrice(tokenBPrice?.usdPrice);
@@ -126,7 +136,7 @@ function RangePriceInfo(props: propsIF) {
         setUserFlippedMaxMinDisplay(false);
 
         updateMainnetPricesAsync();
-    }, [tokenAAddress + tokenBAddress, isDenomTokenA]);
+    }, [crocEnv, tokenAAddress + tokenBAddress, isDenomTokenA]);
 
     useEffect(() => {
         if (!pinnedMinPrice || !pinnedMaxPrice) return;

--- a/src/contexts/CrocEnvContext.tsx
+++ b/src/contexts/CrocEnvContext.tsx
@@ -164,19 +164,20 @@ export const CrocEnvContextProvider = (props: { children: ReactNode }) => {
     ]);
 
     useEffect(() => {
-        if (provider) {
+        if (provider && crocEnv) {
             (async () => {
                 IS_LOCAL_ENV &&
                     console.debug('fetching WETH price from mainnet');
                 const mainnetEthPrice = await cachedFetchTokenPrice(
                     mainnetETH.address,
                     ethereumMainnet.chainId,
+                    crocEnv,
                 );
                 const usdPrice = mainnetEthPrice?.usdPrice;
                 setEthMainnetUsdPrice(usdPrice);
             })();
         }
-    }, [provider]);
+    }, [crocEnv, provider]);
     useEffect(() => {
         setDefaultUrlParams(createDefaultUrlParams(chainData.chainId));
     }, [chainData.chainId]);

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -470,14 +470,16 @@ export default function InitPool() {
         useState(false);
 
     const refreshReferencePrice = async () => {
-        if (tradeDataMatchesURLParams) {
+        if (tradeDataMatchesURLParams && crocEnv) {
             const basePricePromise = cachedFetchTokenPrice(
                 baseToken.address,
                 chainId,
+                crocEnv,
             );
             const quotePricePromise = cachedFetchTokenPrice(
                 quoteToken.address,
                 chainId,
+                crocEnv,
             );
 
             const basePrice = await basePricePromise;
@@ -543,6 +545,7 @@ export default function InitPool() {
     useEffect(() => {
         refreshReferencePrice();
     }, [
+        crocEnv,
         baseToken,
         quoteToken,
         isDenomBase,


### PR DESCRIPTION
### Describe your changes 
this change removes the hardcoded fallback value for ETH and replaces it with an on-chain call for the current price of the ETH-USDC pool on the active chain.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions which may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)