### PR TITLE
adjust noGoZone boundaries basked on ticks

### DIFF
--- a/src/pages/Chart/Chart.tsx
+++ b/src/pages/Chart/Chart.tsx
@@ -1365,15 +1365,22 @@ export default function Chart(props: propsIF) {
     function setLimitForNoGoZone(newLimitValue: number) {
         const { noGoZoneMin, noGoZoneMax } = getNoZoneData();
 
-        const diffNoGoZoneMin = Math.abs(newLimitValue - noGoZoneMin);
-        const diffNoGoZoneMax = Math.abs(newLimitValue - noGoZoneMax);
-        if (newLimitValue >= noGoZoneMin && newLimitValue <= noGoZoneMax) {
-            if (diffNoGoZoneMin > diffNoGoZoneMax) {
-                newLimitValue = noGoZoneMax;
-            } else {
-                newLimitValue = noGoZoneMin;
+        if (newLimitValue > noGoZoneMin && newLimitValue < noGoZoneMax) {
+            if (newLimitValue > noGoZoneMin) {
+                if (newLimitValue < limit) {
+                    newLimitValue = noGoZoneMax;
+                } else {
+                    newLimitValue = noGoZoneMin;
+                }
+            } else if (newLimitValue < noGoZoneMax) {
+                if (newLimitValue > limit) {
+                    newLimitValue = noGoZoneMin;
+                } else {
+                    newLimitValue = noGoZoneMax;
+                }
             }
         }
+
         return newLimitValue;
     }
 
@@ -3486,8 +3493,8 @@ export default function Chart(props: propsIF) {
 
                     if (
                         !(
-                            newLimitValue >= noGoZoneMin &&
-                            newLimitValue <= noGoZoneMax
+                            newLimitValue > noGoZoneMin &&
+                            newLimitValue < noGoZoneMax
                         )
                     ) {
                         onBlurLimitRate(limit, newLimitValue);


### PR DESCRIPTION
Ben Wolski, [Dec 12, 2023 at 4:37:42 PM]:
This PR adjusts the boundaries of the noGoZone. I think the only thing left to investigate/fix is the unexpected trade direction reversal when you drop the limit line exactly on the boundary. Sometimes this causes the trade direction to reverse and sometimes it does not. https://github.com/CrocSwap/ambient-ts-app/pull/3282

The test for proper functionality is that when you drop the limit line on the high boundary and click the minus button, then the 'Limit Below Minimum Price' message should appear. Conversely, when you drop the limit line on the low boundary and click the plus button, then the 'Limit Above Maximum Price' message should appear. You shouldn't have to click the minus/plus buttons multiple times to get that message to appear after dropping the limit line on a boundary.

Ben Wolski, [Dec 12, 2023 at 5:10:56 PM]:
I think I understand why the reversal is happening....the newLimitValue sent to the onBlurLimitRate() function is within the noGoZone, which triggers the reversal...but I'm not sure how to fix that

I think we'll need to base whether or not to reverse on the boundary price (as shown in on the y-axis) while the user's cursor is in the noGoZone, rather than the price under the cursor within the noGoZone