### PR TITLE
fix position scroll issue when firstMintTx = ''

### DIFF
--- a/src/App/components/Sidebar/SidebarSearchResults/PositionsSearchResults.tsx
+++ b/src/App/components/Sidebar/SidebarSearchResults/PositionsSearchResults.tsx
@@ -96,7 +96,7 @@ export default function PositionsSearchResults(props: propsIF) {
     const handleClick = (position: PositionIF): void => {
         setOutsideControl(true);
         setSelectedOutsideTab(2);
-        setCurrentPositionActive(position.lastMintTx);
+        setCurrentPositionActive(position.positionId);
         setShowAllData(false);
         const { base, quote } = position;
         // URL params for link to pool page

--- a/src/components/Global/Sidebar/SidebarRangePositions/SidebarRangePositions.tsx
+++ b/src/components/Global/Sidebar/SidebarRangePositions/SidebarRangePositions.tsx
@@ -58,7 +58,7 @@ export default function SidebarRangePositions(props: propsIF) {
     const handleRangePositionClick = (pos: PositionIF): void => {
         setOutsideControl(true);
         setSelectedOutsideTab(tabToSwitchToBasedOnRoute);
-        setCurrentPositionActive(pos.firstMintTx);
+        setCurrentPositionActive(pos.positionId);
         setShowAllData(false);
         // URL params for link to pool page
         const poolLinkParams: poolParamsIF = {

--- a/src/components/Global/TabComponent/TabComponent.module.css
+++ b/src/components/Global/TabComponent/TabComponent.module.css
@@ -128,9 +128,7 @@
     display: flex;
     flex-direction: row;
 }
-.tap_option_right {
-    display: none;
-}
+
 
 .tab_icon_container {
     background: var(--dark3);

--- a/src/components/Trade/TradeTabs/PositionsOnlyToggle/PositionsOnlyToggle.tsx
+++ b/src/components/Trade/TradeTabs/PositionsOnlyToggle/PositionsOnlyToggle.tsx
@@ -7,6 +7,7 @@ import { CandleDataIF } from '../../../../ambient-utils/types';
 import { ChartContext } from '../../../../contexts/ChartContext';
 import { FlexContainer, Text } from '../../../../styled/Common';
 import { UserDataContext } from '../../../../contexts/UserDataContext';
+import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 
 interface PositionsOnlyToggleProps {
     setTransactionFilter: Dispatch<SetStateAction<CandleDataIF | undefined>>;
@@ -98,6 +99,8 @@ export default function PositionsOnlyToggle(props: PositionsOnlyToggleProps) {
         setIsCandleSelected(false);
     };
 
+    const isDesktopScreen = useMediaQuery('(min-width: 600px)');
+
     return (
         <FlexContainer
             alignItems='center'
@@ -131,8 +134,8 @@ export default function PositionsOnlyToggle(props: PositionsOnlyToggleProps) {
                     {toggleOrNull}
                 </FlexContainer>
             )}
-            {tradeTableState !== 'Collapsed' && collapseIcon}
-            {tradeTableState !== 'Expanded' && expandIcon}
+            {tradeTableState !== 'Collapsed' && isDesktopScreen && collapseIcon}
+            {tradeTableState !== 'Expanded' && isDesktopScreen && expandIcon}
         </FlexContainer>
     );
 }

--- a/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/RangesTable/RangesRow.tsx
@@ -108,8 +108,8 @@ function RangesRow(props: propsIF) {
     };
 
     const positionDomId =
-        position.firstMintTx === currentPositionActive
-            ? `position-${position.firstMintTx}`
+        position.positionId === currentPositionActive
+            ? `position-${position.positionId}`
             : '';
 
     const activePositionRef = useRef(null);
@@ -148,7 +148,7 @@ function RangesRow(props: propsIF) {
     }
 
     useEffect(() => {
-        position.firstMintTx === currentPositionActive ? scrollToDiv() : null;
+        position.positionId === currentPositionActive ? scrollToDiv() : null;
     }, [currentPositionActive]);
 
     const usernameColor: 'text1' | 'accent1' | 'accent2' =
@@ -236,11 +236,8 @@ function RangesRow(props: propsIF) {
     } = rangeRowConstants(rangeRowConstantsProps);
 
     function handleRowClick() {
-        if (position?.firstMintTx === currentPositionActive) {
-            return;
-        }
-        setCurrentPositionActive('');
         openDetailsModal();
+        setCurrentPositionActive('');
     }
 
     return (
@@ -250,7 +247,7 @@ function RangesRow(props: propsIF) {
                 account={isAccountView}
                 leaderboard={isLeaderboard}
                 active={
-                    position.firstMintTx === currentPositionActive ||
+                    position.positionId === currentPositionActive ||
                     position.positionId === currentRangeInReposition ||
                     position.positionId === currentRangeInAdd
                 }


### PR DESCRIPTION
one odd position didn't have a firstMintTx value, causing the app to automatically scroll to that position when the user didn't have an active position selection (the default) since '' === ''. This PR changes the position matching to be based on positionId, rather than firstMintTx