### PR TITLE
increase precision to 6 digits in swap/limit estimations

### DIFF
--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -223,7 +223,7 @@ function SwapTokenInput(props: propsIF) {
 
             const truncatedTokenBQty = rawTokenBQty
                 ? rawTokenBQty < 2
-                    ? rawTokenBQty.toPrecision(3)
+                    ? rawTokenBQty.toPrecision(6)
                     : truncateDecimals(rawTokenBQty, rawTokenBQty < 100 ? 3 : 2)
                 : '';
 
@@ -264,7 +264,7 @@ function SwapTokenInput(props: propsIF) {
 
             const truncatedTokenAQty = rawTokenAQty
                 ? rawTokenAQty < 2
-                    ? rawTokenAQty.toPrecision(3)
+                    ? rawTokenAQty.toPrecision(6)
                     : truncateDecimals(rawTokenAQty, rawTokenAQty < 100 ? 3 : 2)
                 : '';
             setSellQtyString(truncatedTokenAQty);

--- a/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
+++ b/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
@@ -150,7 +150,7 @@ function LimitTokenInput(props: propsIF) {
 
         const truncatedTokenBQty = rawTokenBQty
             ? rawTokenBQty < 2
-                ? rawTokenBQty.toPrecision(3)
+                ? rawTokenBQty.toPrecision(6)
                 : truncateDecimals(rawTokenBQty, 2)
             : '';
 
@@ -193,7 +193,7 @@ function LimitTokenInput(props: propsIF) {
         }
         const truncatedTokenAQty = rawTokenAQty
             ? rawTokenAQty < 2
-                ? rawTokenAQty.toPrecision(3)
+                ? rawTokenAQty.toPrecision(6)
                 : truncateDecimals(rawTokenAQty, 2)
             : '';
 


### PR DESCRIPTION
### Describe your changes 
adds three significant digits to small estimated input/output quantities for swaps/limits

e.g.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/2e59f2b4-c5d5-4fce-8c01-6cfc88d5c0f9)


### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewer
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
