### PR TITLE
Refactor new trade tables: for speed

### DIFF
--- a/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
+++ b/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
@@ -116,7 +116,7 @@ export default function Transactions2(props: propsIF) {
                 tx.changeType !== 'cross',
         );
         return output;
-    }, [changesByPool]); //
+    }, [changesByPool]);
 
     // ref holding the container in which we render the table, this gatekeeps code to render the
     // ... table until the container renders and tells us how much width (pixels) is available
@@ -198,7 +198,7 @@ export default function Transactions2(props: propsIF) {
     // array of row elements to render in the DOM, the base underlying data used for generation
     // ... is updated frequently but this memoization on recalculates if other items change
 
-    const getFashHash = (tx: TransactionIF) => {
+    const getFastHash = (tx: TransactionIF) => {
         // Slightly faster than JSON.stringify
         let theId = '';
         if (tx.txId) theId = theId + tx.txId.toString();
@@ -218,7 +218,7 @@ export default function Transactions2(props: propsIF) {
     const transactionRows = useMemo<JSX.Element[]>(
         () =>
             transactionsData.map((tx: TransactionIF) => {
-                const txString = getFashHash(tx);
+                const txString = getFastHash(tx);
                 return (
                     <TransactionRow2
                         key={txString}

--- a/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
+++ b/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
@@ -10,31 +10,31 @@ import TxHeader from './TxHeader';
 const columnMetaInfo = {
     timeStamp: {
         width: 60,
-        readable: 'Timestamp'
+        readable: 'Timestamp',
     },
     txId: {
         width: 120,
-        readable: 'ID'
+        readable: 'ID',
     },
     txWallet: {
         width: 120,
-        readable: 'Wallet'
+        readable: 'Wallet',
     },
     txPrice: {
         width: 100,
-        readable: 'Price'
+        readable: 'Price',
     },
     txValue: {
         width: 100,
-        readable: 'Value'
+        readable: 'Value',
     },
     txSide: {
         width: 80,
-        readable: 'Side'
+        readable: 'Side',
     },
     txType: {
         width: 80,
-        readable: 'Type'
+        readable: 'Type',
     },
     txBase: {
         width: 100,
@@ -42,51 +42,51 @@ const columnMetaInfo = {
     },
     txQuote: {
         width: 100,
-        readable: ''
+        readable: '',
     },
     overflowBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     editBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     harvestBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     addBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     leafBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     removeBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     shareBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     exportBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     walletBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     copyBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
     downloadBtn: {
         width: 30,
-        readable: ''
+        readable: '',
     },
 };
 
@@ -101,7 +101,6 @@ interface propsIF {
 export default function Transactions2(props: propsIF) {
     const { isAccountPage, candleData } = props;
     false && candleData;
-
     // active token pair
     const { baseToken, quoteToken } = useContext(TradeDataContext);
 
@@ -109,6 +108,8 @@ export default function Transactions2(props: propsIF) {
     const { changesByPool } = useContext(GraphDataContext);
 
     const transactionsData = useMemo<TransactionIF[]>(() => {
+        console.log('Re-running transactionsData');
+
         const output: TransactionIF[] = changesByPool.changes.filter(
             (tx: TransactionIF) =>
                 tx.base.toLowerCase() === baseToken.address.toLowerCase() &&
@@ -117,7 +118,7 @@ export default function Transactions2(props: propsIF) {
                 tx.changeType !== 'cross',
         );
         return output;
-    }, [changesByPool]);
+    }, [changesByPool]); //
 
     // ref holding the container in which we render the table, this gatekeeps code to render the
     // ... table until the container renders and tells us how much width (pixels) is available
@@ -126,7 +127,6 @@ export default function Transactions2(props: propsIF) {
     // list of columns to display in the DOM as determined by priority and space available
     // this is recalculated every time the elem changes width, but later memoization prevents
     // ... unnecessary re-renders from happening
-    const columnsToRender = useRef<[columnSlugsType, number, string][]>([]);
 
     // array to define column priority in the DOM, columns listed last will be removed from the
     // ... DOM first when space is limited
@@ -152,10 +152,62 @@ export default function Transactions2(props: propsIF) {
         'copyBtn',
         'downloadBtn',
     ];
+    const [containerWidth, setContainerWidth] = useState(1000);
 
-    // add an observer to watch for element to be re-sized
-    // later this should go to the parent so every table tab has it available
+    // Calculate columns to render
+    const columnsToRender = useMemo(() => {
+        const columnList: [columnSlugsType, number, string][] = [];
+        let totalWidthNeeded = 0;
+
+        for (let i = 0; i < priority.length; i++) {
+            const columnId: columnSlugsType = priority[i];
+            const columnSize: number = columnMetaInfo[columnId].width;
+            const columnTitle: string = columnMetaInfo[columnId].readable;
+
+            if (totalWidthNeeded + columnSize <= containerWidth) {
+                columnList.push([columnId, columnSize, columnTitle]);
+                totalWidthNeeded += columnSize;
+            }
+        }
+
+        return columnList;
+    }, [containerWidth]); // Dependency array includes containerWidth
+
+    // Resize observer to update containerWidth state
     useEffect(() => {
+        const adjustColumnization = () => {
+            if (containerRef.current) {
+                console.log(
+                    'SETTING TARGET WIDTH' +
+                        containerRef.current.clientWidth.toString(),
+                );
+                setContainerWidth(containerRef.current.clientWidth);
+            }
+        };
+
+        const resizeObserver = new ResizeObserver(adjustColumnization);
+        if (containerRef.current) {
+            resizeObserver.observe(containerRef.current);
+        }
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, []);
+
+    /*
+     Old Render Method:
+    const columnsToRender = useRef<[columnSlugsType, number, string][]>([]);
+    useEffect(() => {
+        console.log('RE-RENDER HAPPENING');
+        if (isRendering==true)
+        {
+            console.log('RE-RENDER Skip');
+            return;
+        }
+        isRendering = true;
+        console.time('2Tracking-table');
+        console.time('3Tracking-table');
         // fn to log the width of the element in the DOM (number of pixels)
         function adjustColumnization() {
             // make sure the container in which we'll render the table exists
@@ -193,10 +245,20 @@ export default function Transactions2(props: propsIF) {
         );
         containerRef.current && resizeObserver.observe(containerRef.current);
         // cleanup the observer from the DOM when component dismounts
+        console.timeEnd('2Tracking-table');
+        isRendering = false;
+        console.log('RE-RENDER FINISH ');
         return () => {
+            console.time('4Tracking-table');
+            console.log('RE-RENDER FINISH1');
             resizeObserver.disconnect();
+            console.timeEnd('4Tracking-table');
+            console.timeEnd('3Tracking-table');
+            console.log('RE-RENDER FINISH2');
         };
-    }, []);
+        
+        
+    }, []); */
 
     const [openMenuRow, setOpenMenuRow] = useState<string | null>(null);
 
@@ -206,26 +268,72 @@ export default function Transactions2(props: propsIF) {
 
     // array of row elements to render in the DOM, the base underlying data used for generation
     // ... is updated frequently but this memoization on recalculates if other items change
+
+    const getHash = (tx: TransactionIF) => {
+        let theId = '';
+        if (tx.txId) theId = theId + tx.txId.toString();
+        else theId = theId + 'null_id';
+
+        if (tx.askTick) theId = theId + tx.bidTick.toString();
+        else theId = theId + 'bidEmpty';
+        if (tx.askTick) theId = theId + tx.bidTick.toString();
+        else theId = theId + 'askEmpty';
+
+        if (tx.txHash) theId = theId + tx.txHash.toString();
+        else theId = theId + 'txHash';
+        return theId;
+    };
+
     const transactionRows = useMemo<JSX.Element[]>(
         () =>
-            transactionsData.map((tx: TransactionIF) => (
+            transactionsData.map((tx: TransactionIF) => {
+                console.log('Re-running memo');
+                console.log(
+                    'Re-running memo' + transactionsData.length.toString(),
+                );
+                const txString = getHash(tx);
+                return (
+                    <TransactionRow2
+                        key={txString}
+                        tx={tx}
+                        columnsToShow={columnsToRender}
+                        isAccountPage={isAccountPage}
+                        isMenuOpen={openMenuRow === txString}
+                        onMenuToggle={() => handleMenuToggle(txString)}
+                        hideMenu={() => handleMenuToggle('')}
+                    />
+                );
+            }),
+        [transactionsData.length, columnsToRender.length],
+    );
+
+    /*
+    const transactionRows = transactionsData.map((tx: TransactionIF) => {
+            console.log('Re-running without memo 2');
+            const txString = getHash(tx); 
+            return (
                 <TransactionRow2
-                    key={JSON.stringify(tx)}
+                    key={txString}
                     tx={tx}
-                    columnsToShow={columnsToRender.current}
+                    columnsToShow={columnsToRender}
                     isAccountPage={isAccountPage}
-                    isMenuOpen={openMenuRow === JSON.stringify(tx)}
-                    onMenuToggle={() => handleMenuToggle(JSON.stringify(tx))}
+                    isMenuOpen={openMenuRow === txString}
+                    onMenuToggle={() => handleMenuToggle(txString)}
                     hideMenu={() => handleMenuToggle('')}
                 />
-            )),
-        [columnsToRender.current.length, openMenuRow, transactionsData.length],
-    );
+            );
+        });*/
+
+    console.log('I should render here 2');
+    console.log(transactionsData.length);
+    console.log(transactionRows.length);
+    console.log({ columnsToRender });
 
     return (
         <ol className={styles.tx_ol} ref={containerRef}>
-            {false && <TxHeader activeColumns={columnsToRender.current} />}
+            {<TxHeader activeColumns={columnsToRender} />}
             {transactionRows}
         </ol>
     );
+    /* {transactionRows} />} */
 }

--- a/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
+++ b/src/components/Trade/TradeTabs/Transactions2/Transactions2.tsx
@@ -150,7 +150,11 @@ export default function Transactions2(props: propsIF) {
         'copyBtn',
         'downloadBtn',
     ];
-    const [containerWidth, setContainerWidth] = useState(1000);
+    const containerWidthRef = useRef(1000);
+    const getContainerWidth = () => containerWidthRef.current;
+    const setContainerWidth = (newWidth: number) => {
+        containerWidthRef.current = newWidth;
+    };
 
     // STEP 1: What is our target width, and how do we monitor it?
     useEffect(() => {
@@ -180,14 +184,14 @@ export default function Transactions2(props: propsIF) {
             const columnSize: number = columnMetaInfo[columnId].width;
             const columnTitle: string = columnMetaInfo[columnId].readable;
 
-            if (totalWidthNeeded + columnSize <= containerWidth) {
+            if (totalWidthNeeded + columnSize <= getContainerWidth()) {
                 columnList.push([columnId, columnSize, columnTitle]);
                 totalWidthNeeded += columnSize;
             }
         }
 
         return columnList;
-    }, [containerWidth]);
+    }, [getContainerWidth()]);
 
     const [openMenuRow, setOpenMenuRow] = useState<string | null>(null);
 
@@ -198,7 +202,7 @@ export default function Transactions2(props: propsIF) {
     // array of row elements to render in the DOM, the base underlying data used for generation
     // ... is updated frequently but this memoization on recalculates if other items change
 
-    const getFastHash = (tx: TransactionIF) => {
+    const getFastHash = (tx: TransactionIF): string => {
         // Slightly faster than JSON.stringify
         let theId = '';
         if (tx.txId) theId = theId + tx.txId.toString();

--- a/src/components/Trade/TradeTabs/Transactions2/TxHeader.module.css
+++ b/src/components/Trade/TradeTabs/Transactions2/TxHeader.module.css
@@ -3,6 +3,7 @@
     flex-flow: row nowrap;
     justify-content: space-between;
     width: auto;
+    font-size: 10px;
 }
 
 .col_header {

--- a/src/components/Trade/TradeTabs/Transactions2/TxHeader.tsx
+++ b/src/components/Trade/TradeTabs/Transactions2/TxHeader.tsx
@@ -10,22 +10,18 @@ export default function TxHeader(props: propsIF) {
 
     return (
         <header className={styles.header_row}>
-            {
-                activeColumns.map(
-                    (header) => {
-                        const width: number = header[1];
-                        const readable: string = header[2];
-                        return (
-                            <div
-                                key={JSON.stringify(header)}
-                                style={{ width: width }}
-                            >
-                                {readable}
-                            </div>
-                        );
-                    }
-                )
-            }
+            {activeColumns.map((header) => {
+                // const width: number = header[1];
+                const readable: string = header[2];
+                return (
+                    <div
+                        key={JSON.stringify(header)}
+                        // style={{ width: width }}
+                    >
+                        {readable}
+                    </div>
+                );
+            })}
         </header>
     );
 }


### PR DESCRIPTION
### Describe your changes 
Speed up the trade tables, and make sure they consistently render to completion. The major change is a split of the width monitor from the column storage code. The columns are now memoized, instead, (vs useRef) which speeds things up. The reason for the speed up, is that the code in the useRef was recalculated every time the parent code updated, which was several times a second. After fixing this, The table also seemed to render blank upon load.

There seems to be a lingering and intermittent issue related to dynamic resizing. When resizing the window from large to small, the event observer seems to stop firing. This is an unsolved issue that may need solving in a new PR
```
    // STEP 1: What is our target width, and how do we monitor it?
    useEffect(() => {
        const adjustColumnization = () => {
            if (containerRef.current) {
                setContainerWidth(containerRef.current.clientWidth);
            }
        };
        const resizeObserver = new ResizeObserver(adjustColumnization);
        if (containerRef.current) {
            resizeObserver.observe(containerRef.current);
        }
        return () => {
            resizeObserver.disconnect();
        };
    }, []);

```


