### PR TITLE
update canto external URL

### DIFF
--- a/src/App/components/PageHeader/NetworkSelector/NetworkSelector.tsx
+++ b/src/App/components/PageHeader/NetworkSelector/NetworkSelector.tsx
@@ -124,7 +124,7 @@ export default function NetworkSelector(props: propsIF) {
     const cantoNetwork: JSX.Element = (
         <NetworkItem
             id='canto_network_selector'
-            onClick={() => window.open('http://beta.canto.io/lp', '_blank')}
+            onClick={() => window.open('http://canto.io/lp', '_blank')}
             key='canto'
             custom={chains.length + 1}
             variants={ItemEnterAnimation}


### PR DESCRIPTION
Jeff asked to change Canto link from `beta.canto.io/lp` to `canto.io/lp`