### PR TITLE
fix top pool card mobile on scroll

### DIFF
--- a/src/components/Global/PoolCard/PoolCard.module.css
+++ b/src/components/Global/PoolCard/PoolCard.module.css
@@ -161,13 +161,6 @@
 
         background: var(--dark2);
     }
-    /* .pool_card{
-        padding: 0 1rem;
-    } */
-    .pool_card,
-    .main_container {
-        width: 100%;
-    }
 
     .pool_card:hover,
     .pool_card:focus-visible {


### PR DESCRIPTION
### Describe your changes 
_Describe the purpose + content of these changes_
Currently, the mobile version of the top pool card when on a scroll network is not the expected dimension.
This should resolve it.
<img width="395" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/70d6b058-76d4-4c48-83f5-42485f1e6d1f">
<img width="395" alt="image" src="https://github.com/CrocSwap/ambient-ts-app/assets/83131501/6b03f709-fe63-4e9d-8e9f-d25c226e2eb0">

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?


