### PR TITLE
update verbiage to 'View on Block Explorer'

### DIFF
--- a/src/components/Global/NotificationCenter/ReceiptDisplay/ReceiptDisplay.tsx
+++ b/src/components/Global/NotificationCenter/ReceiptDisplay/ReceiptDisplay.tsx
@@ -143,7 +143,7 @@ export default function ReceiptDisplay(props: ReceiptDisplayPropsIF) {
                         target='_blank'
                         rel='noreferrer'
                         tabIndex={0}
-                        aria-label='View on Etherscan'
+                        aria-label='View on Block Explorer'
                     >
                         <RiExternalLinkLine size={20} color='#7371fc ' />
                     </a>

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TransactionSubmitted.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TransactionSubmitted.tsx
@@ -70,9 +70,9 @@ export default function TransactionSubmitted(props: PropsIF) {
             target='_blank'
             rel='noreferrer'
             className={styles.view_etherscan}
-            aria-label='view on etherscan'
+            aria-label='view on block explorer'
         >
-            View on Etherscan
+            View on Block Explorer
             <FiExternalLink size={18} color='var(--text1)' />
         </a>
     );

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TxSubmiitedSimplify.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TxSubmiitedSimplify.tsx
@@ -25,9 +25,9 @@ export default function TxSubmittedSimplify(props: PropsIF) {
             target='_blank'
             rel='noreferrer'
             className={styles.view_etherscan}
-            aria-label='view on etherscan'
+            aria-label='view on block explorer'
         >
-            View on Etherscan
+            View on Block Explorer
             <FiExternalLink size={20} color='var(--text1)' />
         </a>
     );

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -610,9 +610,9 @@ function Reposition() {
             target='_blank'
             rel='noreferrer'
             className={styles.view_etherscan}
-            aria-label='view on etherscan'
+            aria-label='view on block explorer'
         >
-            View on Etherscan
+            View on Block Explorer
             <FiExternalLink size={12} color='var(--text1)' />
         </a>
     );


### PR DESCRIPTION
### Describe your changes 
updates hardcoded instances of buttons displaying the text 'View on Etherscan' to 'View on Block Explorer' in order to be correct on the scroll network.
