### PR TITLE
disable submit button on confirm modal for limit that will fail

### DIFF
--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -151,6 +151,7 @@ export default function ConfirmLimitModal(props: propsIF) {
             }
             showConfirmation={showConfirmation}
             resetConfirmation={resetConfirmation}
+            isAllowed={limitAllowed}
         />
     );
 }

--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -31,7 +31,6 @@ export default function ConfirmLimitModal(props: propsIF) {
         txErrorMessage,
         resetConfirmation,
         showConfirmation,
-        insideTickDisplayPrice,
         startDisplayPrice,
         middleDisplayPrice,
         endDisplayPrice,
@@ -41,13 +40,6 @@ export default function ConfirmLimitModal(props: propsIF) {
         limitAllowed,
         limitButtonErrorMessage,
     } = props;
-
-    console.log({
-        insideTickDisplayPrice,
-        startDisplayPrice,
-        middleDisplayPrice,
-        endDisplayPrice,
-    });
 
     const { poolPriceDisplay } = useContext(PoolContext);
 

--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -19,6 +19,8 @@ interface propsIF {
     middleDisplayPrice: number;
     endDisplayPrice: number;
     onClose: () => void;
+    limitAllowed: boolean;
+    limitButtonErrorMessage: string;
 }
 
 export default function ConfirmLimitModal(props: propsIF) {
@@ -29,13 +31,23 @@ export default function ConfirmLimitModal(props: propsIF) {
         txErrorMessage,
         resetConfirmation,
         showConfirmation,
+        insideTickDisplayPrice,
         startDisplayPrice,
         middleDisplayPrice,
         endDisplayPrice,
         tokenAInputQty,
         tokenBInputQty,
         onClose = () => null,
+        limitAllowed,
+        limitButtonErrorMessage,
     } = props;
+
+    console.log({
+        insideTickDisplayPrice,
+        startDisplayPrice,
+        middleDisplayPrice,
+        endDisplayPrice,
+    });
 
     const { poolPriceDisplay } = useContext(PoolContext);
 
@@ -132,7 +144,9 @@ export default function ConfirmLimitModal(props: propsIF) {
             txErrorMessage={txErrorMessage}
             statusText={
                 !showConfirmation
-                    ? 'Submit Limit Order'
+                    ? limitAllowed
+                        ? 'Submit Limit Order'
+                        : limitButtonErrorMessage
                     : `Submitting Limit Order to Swap ${tokenAInputQty} ${tokenA.symbol} for ${tokenBInputQty} ${tokenB.symbol}`
             }
             showConfirmation={showConfirmation}

--- a/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
@@ -37,6 +37,7 @@ interface propsIF {
     acknowledgeUpdate?: React.ReactNode;
     extraNotes?: React.ReactNode;
     priceImpactWarning?: JSX.Element | undefined;
+    isAllowed?: boolean;
 }
 
 export default function TradeConfirmationSkeleton(props: propsIF) {
@@ -57,6 +58,7 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
         acknowledgeUpdate,
         extraNotes,
         priceImpactWarning,
+        isAllowed,
     } = props;
 
     const {
@@ -172,7 +174,7 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
                                         initiate();
                                     }}
                                     flat
-                                    disabled={!!acknowledgeUpdate}
+                                    disabled={!isAllowed || !!acknowledgeUpdate}
                                 />
                             </>
                         ) : (

--- a/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
@@ -174,7 +174,10 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
                                         initiate();
                                     }}
                                     flat
-                                    disabled={!isAllowed || !!acknowledgeUpdate}
+                                    disabled={
+                                        isAllowed === false ||
+                                        !!acknowledgeUpdate
+                                    }
                                 />
                             </>
                         ) : (

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -760,6 +760,8 @@ export default function Limit() {
                         startDisplayPrice={startDisplayPrice}
                         middleDisplayPrice={middleDisplayPrice}
                         endDisplayPrice={endDisplayPrice}
+                        limitAllowed={limitAllowed}
+                        limitButtonErrorMessage={limitButtonErrorMessage}
                     />
                 ) : (
                     <></>


### PR DESCRIPTION
### Describe your changes 
disable submit button on confirm modal for limit that will fail; display same error message that would be visible before confirm.

### Link the related issue
When the pool price moves while the user is mid-confirmation for a limit order and that order becomes invalid, the submit button was not getting disabled.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
