### PR TITLE
limit trade tab navigation automation to when module switches

### DIFF
--- a/src/contexts/TradeTableContext.tsx
+++ b/src/contexts/TradeTableContext.tsx
@@ -5,6 +5,7 @@ import { ChartContext } from './ChartContext';
 import { useSimulatedIsPoolInitialized } from '../App/hooks/useSimulatedIsPoolInitialized';
 import { UserDataContext } from './UserDataContext';
 import { DataLoadingContext } from './DataLoadingContext';
+import { linkGenMethodsIF, useLinkGen } from '../utils/hooks/useLinkGen';
 
 // 54 is the height of the trade table header
 export const TRADE_TABLE_HEADER_HEIGHT = 54;
@@ -162,6 +163,8 @@ export const TradeTableContextProvider = (props: {
         }
     }
 
+    const linkGenCurrent: linkGenMethodsIF = useLinkGen();
+
     useEffect(() => {
         if (
             !currentTxActiveInTransactions &&
@@ -169,7 +172,7 @@ export const TradeTableContextProvider = (props: {
             location.pathname.includes('/trade')
         )
             toggleTradeTabBasedOnRoute();
-    }, [location.pathname]);
+    }, [linkGenCurrent.currentPage]);
 
     const resetTable = () => {
         if (


### PR DESCRIPTION
### Describe your changes 
prevent trade table from automatically switching when user reverses trade direction or updates limit line

### Link the related issue
trade table was automatically switching away from the limit or liquidity table when user reverses swap direction and away from transactions or liquidity when the limit line changes.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
