### PR TITLE
aggregate scroll and mainnet dex stats on homepage

### DIFF
--- a/src/components/Home/Stats/AmbientStats.tsx
+++ b/src/components/Home/Stats/AmbientStats.tsx
@@ -70,12 +70,6 @@ export default function Stats() {
         string | undefined
     >();
 
-    // Refresh chain stats in 15 minute windows
-    const STATS_WINDOW_GRANULARITY = 15 * 60 * 1000;
-    const randomNum = Math.random();
-
-    const randomOffset = STATS_WINDOW_GRANULARITY * randomNum;
-
     useEffect(() => {
         if (isServerEnabled) {
             const mainnetCrocEnv = mainnetProvider
@@ -168,11 +162,7 @@ export default function Stats() {
                 }
             });
         }
-    }, [
-        isServerEnabled,
-        mainnetProvider !== undefined && scrollProvider !== undefined,
-        Math.floor((Date.now() + randomOffset) / STATS_WINDOW_GRANULARITY),
-    ]);
+    }, [mainnetProvider !== undefined && scrollProvider !== undefined]);
 
     const statCardData = [
         {

--- a/src/components/Home/Stats/AmbientStats.tsx
+++ b/src/components/Home/Stats/AmbientStats.tsx
@@ -90,6 +90,7 @@ export default function Stats() {
                 volumeTotalUsd = 0,
                 feesTotalUsd = 0;
 
+            const numChainsToAggregate = 2; // currently only Mainnet and Scroll
             let resultsReceived = 0;
 
             if (!mainnetCrocEnv || !scrollCrocEnv) return;
@@ -108,7 +109,7 @@ export default function Stats() {
 
                 resultsReceived += 1;
 
-                if (resultsReceived === 2) {
+                if (resultsReceived === numChainsToAggregate) {
                     setTotalTvlString(
                         getFormattedNumber({
                             value: tvlTotalUsd,
@@ -144,7 +145,7 @@ export default function Stats() {
                 volumeTotalUsd += dexStats.volumeTotalUsd;
                 feesTotalUsd += dexStats.feesTotalUsd;
                 resultsReceived += 1;
-                if (resultsReceived === 2) {
+                if (resultsReceived === numChainsToAggregate) {
                     setTotalTvlString(
                         getFormattedNumber({
                             value: tvlTotalUsd,

--- a/src/components/Home/Stats/AmbientStats.tsx
+++ b/src/components/Home/Stats/AmbientStats.tsx
@@ -90,6 +90,8 @@ export default function Stats() {
                 volumeTotalUsd = 0,
                 feesTotalUsd = 0;
 
+            let resultsReceived = 0;
+
             if (!mainnetCrocEnv || !scrollCrocEnv) return;
             getChainStats(
                 '0x1',
@@ -104,25 +106,29 @@ export default function Stats() {
                 volumeTotalUsd += dexStats.volumeTotalUsd;
                 feesTotalUsd += dexStats.feesTotalUsd;
 
-                setTotalTvlString(
-                    getFormattedNumber({
-                        value: tvlTotalUsd,
-                        prefix: '$',
-                        isTvl: true,
-                    }),
-                );
-                setTotalVolumeString(
-                    getFormattedNumber({
-                        value: volumeTotalUsd,
-                        prefix: '$',
-                    }),
-                );
-                setTotalFeesString(
-                    getFormattedNumber({
-                        value: feesTotalUsd,
-                        prefix: '$',
-                    }),
-                );
+                resultsReceived += 1;
+
+                if (resultsReceived === 2) {
+                    setTotalTvlString(
+                        getFormattedNumber({
+                            value: tvlTotalUsd,
+                            prefix: '$',
+                            isTvl: true,
+                        }),
+                    );
+                    setTotalVolumeString(
+                        getFormattedNumber({
+                            value: volumeTotalUsd,
+                            prefix: '$',
+                        }),
+                    );
+                    setTotalFeesString(
+                        getFormattedNumber({
+                            value: feesTotalUsd,
+                            prefix: '$',
+                        }),
+                    );
+                }
             });
 
             getChainStats(
@@ -137,32 +143,33 @@ export default function Stats() {
                 tvlTotalUsd += dexStats.tvlTotalUsd;
                 volumeTotalUsd += dexStats.volumeTotalUsd;
                 feesTotalUsd += dexStats.feesTotalUsd;
-
-                setTotalTvlString(
-                    getFormattedNumber({
-                        value: tvlTotalUsd,
-                        prefix: '$',
-                        isTvl: true,
-                    }),
-                );
-                setTotalVolumeString(
-                    getFormattedNumber({
-                        value: volumeTotalUsd,
-                        prefix: '$',
-                    }),
-                );
-                setTotalFeesString(
-                    getFormattedNumber({
-                        value: feesTotalUsd,
-                        prefix: '$',
-                    }),
-                );
+                resultsReceived += 1;
+                if (resultsReceived === 2) {
+                    setTotalTvlString(
+                        getFormattedNumber({
+                            value: tvlTotalUsd,
+                            prefix: '$',
+                            isTvl: true,
+                        }),
+                    );
+                    setTotalVolumeString(
+                        getFormattedNumber({
+                            value: volumeTotalUsd,
+                            prefix: '$',
+                        }),
+                    );
+                    setTotalFeesString(
+                        getFormattedNumber({
+                            value: feesTotalUsd,
+                            prefix: '$',
+                        }),
+                    );
+                }
             });
         }
     }, [
         isServerEnabled,
-        mainnetProvider,
-        scrollProvider,
+        mainnetProvider !== undefined && scrollProvider !== undefined,
         Math.floor((Date.now() + randomOffset) / STATS_WINDOW_GRANULARITY),
     ]);
 


### PR DESCRIPTION
### Describe your changes 
the homepage should now show the sum of mainnet and scroll dex stats 
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/00f70230-be2b-4a48-ae0f-92421bb26e2e)


### Link the related issue
dex stats were appearing differently on Mainnet and Scroll

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/464bc4ec-276e-4a42-92be-3e24e9fd7763)
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/da0dcb53-1e60-4615-82c2-96a4fc40727d)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
