### PR TITLE
prevent harvest confirmation modal from updating values after tx sent

### DIFF
--- a/src/components/RangeActionModal/RangeActionModal.tsx
+++ b/src/components/RangeActionModal/RangeActionModal.tsx
@@ -594,6 +594,30 @@ function RangeActionModal(props: propsIF) {
             : mintSlippage.updateVolatile(currentSlippage);
     };
 
+    // logic to prevent harvest button updating during/after harvest completion
+    const [memoIsActionReset, setMemoIsActionReset] = useState<
+        boolean | undefined
+    >();
+    const [memoBaseHarvestNum, setMemoBaseHarvestNum] = useState<
+        number | undefined
+    >();
+    const [memoQuoteHarvestNum, setMemoQuoteHarvestNum] = useState<
+        number | undefined
+    >();
+
+    useEffect(() => {
+        if (newTransactionHash === '') {
+            setMemoIsActionReset(!areFeesAvailableToWithdraw);
+            setMemoBaseHarvestNum(baseHarvestNum);
+            setMemoQuoteHarvestNum(quoteHarvestNum);
+        }
+    }, [
+        newTransactionHash,
+        areFeesAvailableToWithdraw,
+        baseHarvestNum,
+        quoteHarvestNum,
+    ]);
+
     const buttonToDisplay = (
         <div className={styles.button_container}>
             {showSettings ? (
@@ -612,7 +636,7 @@ function RangeActionModal(props: propsIF) {
                 <SubmitTransaction
                     type={
                         type === 'Harvest'
-                            ? !areFeesAvailableToWithdraw
+                            ? memoIsActionReset
                                 ? 'Reset'
                                 : 'Harvest'
                             : type === 'Remove'
@@ -637,7 +661,7 @@ function RangeActionModal(props: propsIF) {
                             (type === 'Remove'
                                 ? liquidityToBurn === undefined ||
                                   liquidityToBurn.isZero()
-                                : !areFeesAvailableToWithdraw) || showSettings
+                                : memoIsActionReset) || showSettings
                         )
                             ? type === 'Remove'
                                 ? 'Remove Liquidity'
@@ -727,8 +751,8 @@ function RangeActionModal(props: propsIF) {
                             quoteTokenSymbol={quoteTokenSymbol}
                             baseTokenLogoURI={baseTokenLogoURI}
                             quoteTokenLogoURI={quoteTokenLogoURI}
-                            baseHarvestNum={baseHarvestNum}
-                            quoteHarvestNum={quoteHarvestNum}
+                            baseHarvestNum={memoBaseHarvestNum}
+                            quoteHarvestNum={memoQuoteHarvestNum}
                         />
                     )}
                     <ExtraControls />


### PR DESCRIPTION
### Describe your changes 
prevent harvest confirmation modal from updating values after tx sent

### Link the related issue
harvest confirmation modals were updating after the position was reindexed to no longer contain accumulated fees

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
