### PR TITLE
fix trade tabs not switching when tx or position selected

### DIFF
--- a/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
+++ b/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
@@ -39,11 +39,8 @@ function OrderRow(props: propsIF) {
     const {
         snackbar: { open: openSnackbar },
     } = useContext(AppStateContext);
-    const {
-        showAllData: showAllDataSelection,
-        currentLimitOrderActive,
-        setCurrentLimitOrderActive,
-    } = useContext(TradeTableContext);
+    const { showAllData: showAllDataSelection, currentLimitOrderActive } =
+        useContext(TradeTableContext);
 
     // only show all data when on trade tabs page
     const showAllData = !isAccountView && showAllDataSelection;
@@ -227,14 +224,6 @@ function OrderRow(props: propsIF) {
         statusDisplay,
     } = orderRowConstants(orderRowConstantsProps);
 
-    function handleRowClick() {
-        if (limitOrder.limitOrderId === currentLimitOrderActive) {
-            return;
-        }
-        setCurrentLimitOrderActive('');
-        openDetailsModal();
-    }
-
     const handleKeyPress: React.KeyboardEventHandler<HTMLDivElement> = (
         event,
     ) => {
@@ -253,7 +242,7 @@ function OrderRow(props: propsIF) {
                 active={limitOrder.limitOrderId === currentLimitOrderActive}
                 user={userNameToDisplay === 'You' && showAllData}
                 id={orderDomId}
-                onClick={handleRowClick}
+                onClick={openDetailsModal}
                 ref={currentLimitOrderActive ? activePositionRef : null}
                 tabIndex={0}
                 onKeyDown={handleKeyPress}

--- a/src/contexts/TradeTableContext.tsx
+++ b/src/contexts/TradeTableContext.tsx
@@ -166,12 +166,23 @@ export const TradeTableContextProvider = (props: {
     const linkGenCurrent: linkGenMethodsIF = useLinkGen();
 
     useEffect(() => {
-        if (
-            !currentTxActiveInTransactions &&
-            !currentPositionActive &&
-            location.pathname.includes('/trade')
-        )
-            toggleTradeTabBasedOnRoute();
+        if (location.pathname.includes('/trade')) toggleTradeTabBasedOnRoute();
+        switch (linkGenCurrent.currentPage) {
+            case 'market':
+                setCurrentPositionActive('');
+                setCurrentLimitOrderActive('');
+                break;
+            case 'limit':
+                setCurrentTxActiveInTransactions('');
+                setCurrentPositionActive('');
+                break;
+            case 'pool':
+                setCurrentTxActiveInTransactions('');
+                setCurrentLimitOrderActive('');
+                break;
+            default:
+                break;
+        }
     }, [linkGenCurrent.currentPage]);
 
     const resetTable = () => {


### PR DESCRIPTION
### Describe your changes 
remove logic that keeps the trade tab from automatically switching when a transaction or liquidity position row is highlighted. Add logic to clear previous row highlighting when switching trade modules.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
