### PR TITLE
fix wallet balance display bug when switching portfolios

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.1.0",
+    "version": "2.1.1",
     "private": true,
     "dependencies": {
         "@covalenthq/client-sdk": "^0.2.6",

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -147,7 +147,8 @@ function Portfolio() {
                 !connectedAccountActive
             ) {
                 try {
-                    const updatedTokens: TokenIF[] = resolvedAddressTokens;
+                    setResolvedAddressTokens([]);
+                    const updatedTokens: TokenIF[] = [];
 
                     const tokenBalanceResults = await cachedFetchTokenBalances(
                         resolvedAddress,

--- a/src/pages/Portfolio/Portfolio.tsx
+++ b/src/pages/Portfolio/Portfolio.tsx
@@ -14,7 +14,6 @@ import { fetchEnsAddress } from '../../ambient-utils/api';
 import { Navigate, useParams } from 'react-router-dom';
 import useMediaQuery from '../../utils/hooks/useMediaQuery';
 import { CrocEnvContext } from '../../contexts/CrocEnvContext';
-import { diffHashSig } from '../../ambient-utils/dataLayer';
 import { ChainDataContext } from '../../contexts/ChainDataContext';
 import { AppStateContext } from '../../contexts/AppStateContext';
 import { TokenContext } from '../../contexts/TokenContext';
@@ -170,20 +169,13 @@ function Portfolio() {
                     });
 
                     tokensWithLogos.map((newToken: TokenIF) => {
-                        const indexOfExistingToken =
-                            resolvedAddressTokens.findIndex(
-                                (existingToken) =>
-                                    existingToken.address === newToken.address,
-                            );
+                        const indexOfExistingToken = updatedTokens.findIndex(
+                            (existingToken) =>
+                                existingToken.address === newToken.address,
+                        );
 
                         if (indexOfExistingToken === -1) {
                             updatedTokens.push(newToken);
-                        } else if (
-                            diffHashSig(
-                                resolvedAddressTokens[indexOfExistingToken],
-                            ) !== diffHashSig(newToken)
-                        ) {
-                            updatedTokens[indexOfExistingToken] = newToken;
                         }
                     });
                     setResolvedAddressTokens(updatedTokens);


### PR DESCRIPTION
### Describe your changes 
re-initialize the token balance list when user switches portfolios (possible without reloading page by clicking a username in chat)

### Link the related issue
previously, the token balance lists were not getting cleared out when a new name was clicked

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
