### PR TITLE
Collapse sidebar by default

### DIFF
--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -14,7 +14,10 @@ export interface sidebarMethodsIF {
 
 export type SidebarStatus = 'open' | 'closed';
 
-export const useSidebar = (pathname: string): sidebarMethodsIF => {
+export const useSidebar = (
+    pathname: string,
+    showByDefault: boolean,
+): sidebarMethodsIF => {
     // base default status for the sidebar through the app
     const SIDEBAR_GLOBAL_DEFAULT: SidebarStatus = 'closed';
 
@@ -30,7 +33,9 @@ export const useSidebar = (pathname: string): sidebarMethodsIF => {
     // this hook initializes from local storage for returning users
     // will default to 'closed' if no value found (happens on first visit)
     const [sidebar, setSidebar] = useState<SidebarStatus>(
-        getStoredSidebarStatus() ?? SIDEBAR_GLOBAL_DEFAULT,
+        getStoredSidebarStatus() ?? showByDefault
+            ? 'open'
+            : 'closed' ?? SIDEBAR_GLOBAL_DEFAULT,
     );
 
     // reusable logic to update state and optionally persist data in local storage

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -15,18 +15,22 @@ export interface sidebarMethodsIF {
 export type SidebarStatus = 'open' | 'closed';
 
 export const useSidebar = (pathname: string): sidebarMethodsIF => {
+    // base default status for the sidebar through the app
+    const SIDEBAR_GLOBAL_DEFAULT: SidebarStatus = 'closed';
+
     // local storage key for persisted data
     const localStorageKey = 'sidebarStatus';
     const getStoredSidebarStatus = () =>
         getLocalStorageItem<SidebarStatus>(localStorageKey);
 
-    const resetPersist = () => localStorage.setItem(localStorageKey, 'closed');
+    const resetPersist = () =>
+        localStorage.setItem(localStorageKey, SIDEBAR_GLOBAL_DEFAULT);
 
     // hook to track sidebar status in local state
     // this hook initializes from local storage for returning users
     // will default to 'closed' if no value found (happens on first visit)
     const [sidebar, setSidebar] = useState<SidebarStatus>(
-        getStoredSidebarStatus() ?? 'closed',
+        getStoredSidebarStatus() ?? SIDEBAR_GLOBAL_DEFAULT,
     );
 
     // reusable logic to update state and optionally persist data in local storage

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -41,7 +41,7 @@ export const useSidebar = (
                 : showByDefault
         )
             ? 'open'
-            : 'closed' ?? SIDEBAR_GLOBAL_DEFAULT,
+            : 'closed',
     );
 
     // reusable logic to update state and optionally persist data in local storage

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -35,7 +35,9 @@ export const useSidebar = (
     // will check a media query for viewport width if no persisted value is found
     // last fallback is a centrally-defined const
     const [sidebar, setSidebar] = useState<SidebarStatus>(
-        getStoredSidebarStatus() ?? showByDefault
+        (getStoredSidebarStatus() !== null
+            ? getStoredSidebarStatus() === 'open'
+            : undefined) ?? showByDefault
             ? 'open'
             : 'closed' ?? SIDEBAR_GLOBAL_DEFAULT,
     );

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -35,9 +35,11 @@ export const useSidebar = (
     // will check a media query for viewport width if no persisted value is found
     // last fallback is a centrally-defined const
     const [sidebar, setSidebar] = useState<SidebarStatus>(
-        (getStoredSidebarStatus() !== null
-            ? getStoredSidebarStatus() === 'open'
-            : undefined) ?? showByDefault
+        (
+            getStoredSidebarStatus() !== null
+                ? getStoredSidebarStatus() === 'open'
+                : showByDefault
+        )
             ? 'open'
             : 'closed' ?? SIDEBAR_GLOBAL_DEFAULT,
     );

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -2,36 +2,36 @@ import { useMemo, useState } from 'react';
 import { getLocalStorageItem } from '../../ambient-utils/dataLayer';
 
 export interface sidebarMethodsIF {
-    status: SidebarStoredStatus;
+    status: SidebarStatus;
     isOpen: boolean;
     isHiddenOnRoute: boolean;
     open: (persist?: boolean) => void;
     close: (persist?: boolean) => void;
     toggle: (persist?: boolean) => void;
-    getStoredStatus: () => SidebarStoredStatus | null;
+    getStoredStatus: () => SidebarStatus | null;
     resetStoredStatus: () => void;
 }
 
-export type SidebarStoredStatus = 'open' | 'closed';
+export type SidebarStatus = 'open' | 'closed';
 
 export const useSidebar = (pathname: string): sidebarMethodsIF => {
     // local storage key for persisted data
     const localStorageKey = 'sidebarStatus';
     const getStoredSidebarStatus = () =>
-        getLocalStorageItem<SidebarStoredStatus>(localStorageKey);
+        getLocalStorageItem<SidebarStatus>(localStorageKey);
 
     const resetPersist = () => localStorage.setItem(localStorageKey, 'closed');
 
     // hook to track sidebar status in local state
     // this hook initializes from local storage for returning users
-    // will default to 'open' if no value found (happens on first visit)
-    const [sidebar, setSidebar] = useState<SidebarStoredStatus>(
-        getStoredSidebarStatus() || 'open',
+    // will default to 'closed' if no value found (happens on first visit)
+    const [sidebar, setSidebar] = useState<SidebarStatus>(
+        getStoredSidebarStatus() ?? 'closed',
     );
 
     // reusable logic to update state and optionally persist data in local storage
     const changeSidebar = (
-        newStatus: SidebarStoredStatus,
+        newStatus: SidebarStatus,
         persist: boolean,
     ): void => {
         setSidebar(newStatus);

--- a/src/App/hooks/useSidebar.ts
+++ b/src/App/hooks/useSidebar.ts
@@ -26,12 +26,14 @@ export const useSidebar = (
     const getStoredSidebarStatus = () =>
         getLocalStorageItem<SidebarStatus>(localStorageKey);
 
+    // fn to reset the persisted value in local storage to the global default
     const resetPersist = () =>
         localStorage.setItem(localStorageKey, SIDEBAR_GLOBAL_DEFAULT);
 
     // hook to track sidebar status in local state
     // this hook initializes from local storage for returning users
-    // will default to 'closed' if no value found (happens on first visit)
+    // will check a media query for viewport width if no persisted value is found
+    // last fallback is a centrally-defined const
     const [sidebar, setSidebar] = useState<SidebarStatus>(
         getStoredSidebarStatus() ?? showByDefault
             ? 'open'

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -57,15 +57,15 @@ export const SidebarContextProvider = (props: { children: ReactNode }) => {
         [lastReceipt],
     );
 
+    // determine whether the user screen width is less than min width to show the sidebar
+    const smallScreen: boolean = useMediaQuery('(max-width: 500px)');
+    const showSidebarByDefault: boolean = useMediaQuery('(min-width: 1600px)');
+
     // hook to manage sidebar state (probably doesn't need to be extracted anymore)
-    const sidebar = useSidebar(location.pathname);
+    const sidebar = useSidebar(location.pathname, showSidebarByDefault);
 
     // hook to manage recent pool data in-session
     const recentPools: recentPoolsMethodsIF = useRecentPools(chainData.chainId);
-
-    // determine whether the user screen width is less than min width to show the sidebar
-    const smallScreen: boolean = useMediaQuery('(max-width: 500px)');
-    const showSidebarByDefault: boolean = useMediaQuery('(min-width: 1850px)');
 
     // value showing whether the screen size warrants hiding the sidebar
     const [hideOnMobile, setHideOnMobile] = useState<boolean>(true);

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -18,6 +18,7 @@ import { diffHashSig, isJsonString } from '../ambient-utils/dataLayer';
 import { AppStateContext } from './AppStateContext';
 import { CrocEnvContext } from './CrocEnvContext';
 import { ReceiptContext } from './ReceiptContext';
+import { TransactionReceipt } from '@ethersproject/abstract-provider';
 
 interface SidebarStateIF {
     recentPools: recentPoolsMethodsIF;
@@ -31,17 +32,28 @@ export const SidebarContext = createContext<SidebarStateIF>(
 );
 
 export const SidebarContextProvider = (props: { children: ReactNode }) => {
+    // logic to open a snackbar notification
     const {
         snackbar: { open: openSnackbar },
     } = useContext(AppStateContext);
+
+    // data on the active chain in the app
     const { chainData } = useContext(CrocEnvContext);
+
+    // all receipts stored in the current user session (array of stringified JSONs)
     const { allReceipts } = useContext(ReceiptContext);
-    const lastReceipt =
+
+    // parsed JSON on the most recent receipt in the stack
+    const lastReceipt: TransactionReceipt | null =
         allReceipts.length > 0 && isJsonString(allReceipts[0])
             ? JSON.parse(allReceipts[0])
             : null;
-    const isLastReceiptSuccess = lastReceipt?.status === 1;
-    const lastReceiptHash = useMemo(
+
+    // boolean representing whether most recent receipt parsed successfully
+    const isLastReceiptSuccess: boolean = lastReceipt?.status === 1;
+
+    // hash representation of the most recent receipt
+    const lastReceiptHash = useMemo<string | undefined>(
         () => (lastReceipt ? diffHashSig(lastReceipt) : undefined),
         [lastReceipt],
     );

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -82,15 +82,11 @@ export const SidebarContextProvider = (props: { children: ReactNode }) => {
 
     // logic to open or close the sidebar automatically when the URL route changes
     useEffect(() => {
-        if (sidebar.getStoredStatus() === 'open') {
-            sidebar.open(true);
-        } else if (
-            currentLocation === '/' ||
-            currentLocation === '/swap' ||
-            currentLocation.includes('/account')
+        if (
+            sidebar.getStoredStatus() === 'open' ||
+            showSidebarByDefault ||
+            smallScreen
         ) {
-            sidebar.close();
-        } else if (showSidebarByDefault || smallScreen) {
             sidebar.open();
         } else {
             sidebar.close();

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -7,7 +7,6 @@ import {
     useContext,
     useState,
 } from 'react';
-import { useLocation } from 'react-router-dom';
 import {
     recentPoolsMethodsIF,
     useRecentPools,
@@ -57,9 +56,6 @@ export const SidebarContextProvider = (props: { children: ReactNode }) => {
         () => (lastReceipt ? diffHashSig(lastReceipt) : undefined),
         [lastReceipt],
     );
-
-    // current URL pathway in the app
-    const { pathname: currentLocation } = useLocation();
 
     // hook to manage sidebar state (probably doesn't need to be extracted anymore)
     const sidebar = useSidebar(location.pathname);


### PR DESCRIPTION
### Describe your changes 
* Change the global default status for the sidebar to be closed (overridden by persisted data and user actions)
* General code cleanup in `SidebarContext.tsx` and `useSidebar.tsx` files

### Link the related issue
Closes #3416

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**
1. Open various pages on the app and see if the sidebar renders per expected patterns.
  - Always closed by default unless a preference otherwise is persisted
  - Opens if relevant depending on page and user actions
2. No page in the app should render with the sidebar open and have it immediately close

**Environmental conditions that may result in expected but differential behavior.**
none

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
