### PR TITLE
prevent tx modal from disappearing when tx row no longer on displayed page

### DIFF
--- a/src/components/Global/Pagination/usePagination.tsx
+++ b/src/components/Global/Pagination/usePagination.tsx
@@ -5,6 +5,7 @@ interface PaginationResult<T> {
     prev: () => void;
     jump: (page: number) => void;
     currentData: T[];
+    fullData: T[];
     currentPage: number;
     maxPage: number;
     showingFrom: number;
@@ -96,6 +97,7 @@ function usePagination<T>(
         prev,
         jump,
         currentData: currentData(),
+        fullData: data,
         currentPage,
         maxPage,
         showingFrom,

--- a/src/components/Trade/TradeTabs/Orders/Orders.tsx
+++ b/src/components/Trade/TradeTabs/Orders/Orders.tsx
@@ -320,6 +320,7 @@ function Orders(props: propsIF) {
         rowsPerPage,
         changeRowsPerPage,
         count,
+        fullData,
     } = _DATA;
     const handleChange = (e: React.ChangeEvent<unknown>, p: number) => {
         setPage(p);
@@ -447,6 +448,7 @@ function Orders(props: propsIF) {
                 <TableRows
                     type='Order'
                     data={_DATA.currentData}
+                    fullData={fullData}
                     tableView={tableView}
                     isAccountView={isAccountView}
                 />

--- a/src/components/Trade/TradeTabs/Ranges/Leaderboard.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Leaderboard.tsx
@@ -222,6 +222,7 @@ function Leaderboard() {
                     <TableRows
                         type='Range'
                         data={usePaginateDataOrNull}
+                        fullData={usePaginateDataOrNull}
                         isAccountView={false}
                         isLeaderboard={true}
                         tableView={tableView}

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -171,6 +171,7 @@ function Ranges(props: propsIF) {
         rowsPerPage,
         changeRowsPerPage,
         count,
+        fullData,
     } = _DATA;
     const handleChange = (e: React.ChangeEvent<unknown>, p: number) => {
         setPage(p);
@@ -426,6 +427,7 @@ function Ranges(props: propsIF) {
                 <TableRows
                     type='Range'
                     data={_DATA.currentData}
+                    fullData={fullData}
                     isAccountView={isAccountView}
                     tableView={tableView}
                 />

--- a/src/components/Trade/TradeTabs/TableRows.tsx
+++ b/src/components/Trade/TradeTabs/TableRows.tsx
@@ -21,6 +21,7 @@ import OrderDetailsModal from '../../OrderDetails/OrderDetailsModal/OrderDetails
 interface propsIF {
     type: 'Transaction' | 'Order' | 'Range';
     data: TransactionIF[] | LimitOrderIF[] | PositionIF[];
+    fullData: TransactionIF[] | LimitOrderIF[] | PositionIF[];
     tableView: 'small' | 'medium' | 'large';
     isAccountView: boolean;
     isLeaderboard?: boolean;
@@ -32,6 +33,7 @@ type ActiveRecord = TransactionIF | LimitOrderIF | PositionIF | undefined;
 function TableRows({
     type,
     data,
+    fullData,
     isAccountView,
     tableView,
     isLeaderboard,
@@ -116,26 +118,26 @@ function TableRows({
     useEffect(() => {
         if (type === 'Range') {
             setActiveRecord(
-                (data as PositionIF[]).find((position) => {
+                (fullData as PositionIF[]).find((position) => {
                     return position.positionId === currentPositionActive;
                 }),
             );
         } else if (type === 'Order') {
             setActiveRecord(
-                (data as LimitOrderIF[]).find((order) => {
+                (fullData as LimitOrderIF[]).find((order) => {
                     return order.limitOrderId === currentLimitOrderActive;
                 }),
             );
         } else {
             setActiveRecord(
-                (data as TransactionIF[]).find((tx) => {
+                (fullData as TransactionIF[]).find((tx) => {
                     return tx.txId === currentTxActiveInTransactions;
                 }),
             );
         }
     }, [
         type,
-        data,
+        fullData,
         currentPositionActive,
         currentLimitOrderActive,
         currentTxActiveInTransactions,

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -448,6 +448,7 @@ function Transactions(props: propsIF) {
         rowsPerPage,
         changeRowsPerPage,
         count,
+        fullData,
     } = _DATA;
     const handleChange = (e: React.ChangeEvent<unknown>, p: number) => {
         setPage(p);
@@ -655,6 +656,7 @@ function Transactions(props: propsIF) {
                 <TableRows
                     type='Transaction'
                     data={_DATA.currentData}
+                    fullData={fullData}
                     tableView={tableView}
                     isAccountView={isAccountView}
                 />


### PR DESCRIPTION
### Describe your changes 
pull data for details modals from full data set, rather than just the data currently displayed on the paginated table

### Link the related issue
transaction details modals would disappear if the table updates and the transaction being viewed in the modal was no longer visible on the table.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
