### PR TITLE
fix missing unsupported network modal on network specific deploy

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "private": true,
     "dependencies": {
         "@covalenthq/client-sdk": "^0.2.6",

--- a/src/App/hooks/useAppChain.ts
+++ b/src/App/hooks/useAppChain.ts
@@ -163,12 +163,30 @@ export const useAppChain = (): {
 
     const defaultChain = getDefaultChainId();
 
+    // boolean showing if the current chain in connected wallet is supported
+    // this is used to launch the network switcher automatically
+    const isWalletChainSupported = useMemo<boolean>(() => {
+        // output variable, true by default (when no wallet is connected)
+        let isSupported = true;
+        // if a wallet is connected, try to validate network
+        if (chns.length && chainNetwork) {
+            // array of supported chains (number)
+            const supportedChains: number[] = chns.map((chn) => chn.id);
+            // chain Id of connected network in wallet
+            const walletChain: number = chainNetwork.id;
+            // determine if connected wallet has a supported chain
+            isSupported = supportedChains.includes(walletChain);
+        }
+        // return output variable
+        return isSupported;
+    }, [chainNetwork]);
+
     // metadata about the active network in the app
     const [activeNetwork, setActiveNetwork] = useState<NetworkIF>(
         findNetworkData(
-            chainInURLValidated ??
-                localStorage.getItem(CHAIN_LS_KEY) ??
-                defaultChain,
+            chainInURLValidated && isWalletChainSupported
+                ? localStorage.getItem(CHAIN_LS_KEY) ?? defaultChain
+                : defaultChain,
         ),
     );
 
@@ -226,24 +244,6 @@ export const useAppChain = (): {
         // return output varibale (chain data)
         return output;
     }, [activeNetwork.chainId]);
-
-    // boolean showing if the current chain in connected wallet is supported
-    // this is used to launch the network switcher automatically
-    const isWalletChainSupported = useMemo<boolean>(() => {
-        // output variable, true by default (when no wallet is connected)
-        let isSupported = true;
-        // if a wallet is connected, try to validate network
-        if (chns.length && chainNetwork) {
-            // array of supported chains (number)
-            const supportedChains: number[] = chns.map((chn) => chn.id);
-            // chain Id of connected network in wallet
-            const walletChain: number = chainNetwork.id;
-            // determine if connected wallet has a supported chain
-            isSupported = supportedChains.includes(walletChain);
-        }
-        // return output variable
-        return isSupported;
-    }, [chainNetwork]);
 
     return {
         chainData,

--- a/src/App/hooks/useAppChain.ts
+++ b/src/App/hooks/useAppChain.ts
@@ -184,7 +184,7 @@ export const useAppChain = (): {
     // metadata about the active network in the app
     const [activeNetwork, setActiveNetwork] = useState<NetworkIF>(
         findNetworkData(
-            chainInURLValidated && isWalletChainSupported
+            isWalletChainSupported
                 ? localStorage.getItem(CHAIN_LS_KEY) ?? defaultChain
                 : defaultChain,
         ),

--- a/src/ambient-utils/constants/networks/index.ts
+++ b/src/ambient-utils/constants/networks/index.ts
@@ -16,6 +16,11 @@ export const IS_PRODUCTION_SITE =
         ? process.env.REACT_APP_IS_PRODUCTION_SITE.toLowerCase() === 'true'
         : false;
 
+export const IS_TESTNET_SITE =
+    process.env.REACT_APP_IS_TESTNET_SITE !== undefined
+        ? process.env.REACT_APP_IS_TESTNET_SITE.toLowerCase() === 'true'
+        : false;
+
 export const supportedNetworks: { [x: string]: NetworkIF } = IS_SCROLL_SITE
     ? {
           [scrollMainnet.chainId]: scrollMainnet,
@@ -24,6 +29,11 @@ export const supportedNetworks: { [x: string]: NetworkIF } = IS_SCROLL_SITE
     ? {
           [ethereumMainnet.chainId]: ethereumMainnet,
           [scrollMainnet.chainId]: scrollMainnet,
+      }
+    : IS_TESTNET_SITE
+    ? {
+          [ethereumSepolia.chainId]: ethereumSepolia,
+          [scrollSepolia.chainId]: scrollSepolia,
       }
     : {
           [ethereumMainnet.chainId]: ethereumMainnet,

--- a/src/ambient-utils/constants/networks/index.ts
+++ b/src/ambient-utils/constants/networks/index.ts
@@ -6,14 +6,33 @@ import { ethereumMainnet } from './ethereumMainnet';
 import { scrollMainnet } from './scrollMainnet';
 import { scrollSepolia } from './scrollSepolia';
 
-export const supportedNetworks: { [x: string]: NetworkIF } = {
-    [ethereumMainnet.chainId]: ethereumMainnet,
-    [ethereumGoerli.chainId]: ethereumGoerli,
-    [ethereumSepolia.chainId]: ethereumSepolia,
-    [arbitrumGoerli.chainId]: arbitrumGoerli,
-    [scrollSepolia.chainId]: scrollSepolia,
-    [scrollMainnet.chainId]: scrollMainnet,
-};
+export const IS_SCROLL_SITE =
+    process.env.REACT_APP_IS_SCROLL_SITE !== undefined
+        ? process.env.REACT_APP_IS_SCROLL_SITE.toLowerCase() === 'true'
+        : false;
+
+export const IS_PRODUCTION_SITE =
+    process.env.REACT_APP_IS_PRODUCTION_SITE !== undefined
+        ? process.env.REACT_APP_IS_PRODUCTION_SITE.toLowerCase() === 'true'
+        : false;
+
+export const supportedNetworks: { [x: string]: NetworkIF } = IS_SCROLL_SITE
+    ? {
+          [scrollMainnet.chainId]: scrollMainnet,
+      }
+    : IS_PRODUCTION_SITE
+    ? {
+          [ethereumMainnet.chainId]: ethereumMainnet,
+          [scrollMainnet.chainId]: scrollMainnet,
+      }
+    : {
+          [ethereumMainnet.chainId]: ethereumMainnet,
+          [ethereumGoerli.chainId]: ethereumGoerli,
+          [ethereumSepolia.chainId]: ethereumSepolia,
+          [arbitrumGoerli.chainId]: arbitrumGoerli,
+          [scrollSepolia.chainId]: scrollSepolia,
+          [scrollMainnet.chainId]: scrollMainnet,
+      };
 
 export function getDefaultPairForChain(chainId: string): [TokenIF, TokenIF] {
     return [


### PR DESCRIPTION
### Describe your changes 
add logic to use different lists of supported networks on different domains

### Link the related issue

It was possible to have the app on scroll.ambient.finance initialize connected to mainnet and send a swap to the scroll contract address on mainnet
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/94602fdd-7c01-48e7-86e9-d7114652f8df)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
