### PR TITLE
Update l2 slippage

### DIFF
--- a/public/ambient-token-list.json
+++ b/public/ambient-token-list.json
@@ -70,7 +70,7 @@
             "name": "USDB",
             "address": "0x4300000000000000000000000000000000000003",
             "symbol": "USDB",
-            "decimals": 6,
+            "decimals": 18,
             "chainId": 81457,
             "logoURI": "https://assets-global.website-files.com/65a6baa1a3f8ed336f415cb4/65c67f0ebf2f6a1bd0feb13c_usdb-icon-yellow.png"
         },

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -85,7 +85,7 @@ export const useSlippage = (
     // updateStable ➡ accepts a new `stable` value from the DOM
     // updateVolatile ➡ accepts a new `volatile` value from the DOM
     // !important:  fields will preferentially consume an L2 value as relevant
-    return useMemo(
+    return useMemo<SlippageMethodsIF>(
         () => ({
             stable: isActiveNetworkL2 ? l2 : stable,
             volatile: isActiveNetworkL2 ? l2 : volatile,

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -4,7 +4,7 @@ import {
     DEFAULT_SLIPPAGE_VALUES,
     slippageDefaultsIF,
     slippagePresetsType,
-    slippageTypes,
+    slippageDefaultTypes,
 } from '../../ambient-utils/constants';
 import { ChainDataContext } from '../../contexts/ChainDataContext';
 
@@ -17,7 +17,6 @@ export interface SlippageMethodsIF {
     presets: {
         stable: slippagePresetsType;
         volatile: slippagePresetsType;
-        l2: slippagePresetsType;
     };
 }
 
@@ -28,7 +27,9 @@ export interface SlippageMethodsIF {
 // custom hook to manage and interact a given slippage pair
 // @param slippageType ➡ denotes swap, mint, or reposition
 // @param defaults ➡ default values to use for slippage
-export const useSlippage = (txType: slippageTypes): SlippageMethodsIF => {
+export const useSlippage = (
+    txType: slippageDefaultTypes,
+): SlippageMethodsIF => {
     // default slippage values to consume depending on transaction type
     const defaults = DEFAULT_SLIPPAGE_VALUES[txType];
 
@@ -91,7 +92,14 @@ export const useSlippage = (txType: slippageTypes): SlippageMethodsIF => {
             volatile: isActiveNetworkL2 ? volatile : l2,
             updateStable: isActiveNetworkL2 ? setStable : setL2,
             updateVolatile: isActiveNetworkL2 ? setVolatile : setL2,
-            presets: defaults.presets,
+            presets: {
+                stable: isActiveNetworkL2
+                    ? defaults.presets.stable
+                    : defaults.presets.l2,
+                volatile: isActiveNetworkL2
+                    ? defaults.presets.volatile
+                    : defaults.presets.l2,
+            },
         }),
         [stable, volatile, l2],
     );

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -1,15 +1,9 @@
 // START: Import React and Dongles
 import { useEffect, useMemo, useState } from 'react';
-
-// interface for a Slippage Pair (not needed outside this file)
-interface SlippagePairIF {
-    stable: number;
-    volatile: number;
-    presets: {
-        stable: number[];
-        volatile: number[];
-    };
-}
+import {
+    slippageDefaultsIF,
+    slippagePresetsType,
+} from '../../ambient-utils/constants';
 
 // interface for object returned by this hook
 export interface SlippageMethodsIF {
@@ -17,7 +11,7 @@ export interface SlippageMethodsIF {
     volatile: number;
     updateStable: (val: number) => void;
     updateVolatile: (val: number) => void;
-    presets: { stable: number[]; volatile: number[] };
+    presets: { stable: slippagePresetsType; volatile: slippagePresetsType };
 }
 
 export interface allSlippageMethodsIF {
@@ -31,14 +25,14 @@ export interface allSlippageMethodsIF {
 // @param defaults ➡ default values to use for slippage
 export const useSlippage = (
     slippageType: string,
-    defaults: SlippagePairIF,
+    defaults: slippageDefaultsIF,
 ): SlippageMethodsIF => {
     // fn to get relevant slippage pair from local storage and return
     // ... a value to use productively for stable or volatile slippage
-    const getSlippage = (whichOne: string): number => {
+    const getSlippage = (whichOne: 'stable' | 'volatile'): number => {
         // retrieve the relevant slippage pair from local storage
         // query will return `null` if the key-value pair does not exist
-        const pair: SlippagePairIF | null = JSON.parse(
+        const pair: slippageDefaultsIF | null = JSON.parse(
             localStorage.getItem(`slippage_${slippageType}`) as string,
         );
         // declare an output value for the function

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -1,9 +1,10 @@
 // START: Import React and Dongles
-import { useEffect, useMemo, useState } from 'react';
+import { useContext, useEffect, useMemo, useState } from 'react';
 import {
     slippageDefaultsIF,
     slippagePresetsType,
 } from '../../ambient-utils/constants';
+import { ChainDataContext } from '../../contexts/ChainDataContext';
 
 // interface for object returned by this hook
 export interface SlippageMethodsIF {
@@ -27,6 +28,10 @@ export const useSlippage = (
     slippageType: string,
     defaults: slippageDefaultsIF,
 ): SlippageMethodsIF => {
+    // check if active network is an L2 for differential handling
+    const { isActiveNetworkL2 } = useContext(ChainDataContext);
+    false && isActiveNetworkL2;
+
     // fn to get relevant slippage pair from local storage and return
     // ... a value to use productively for stable or volatile slippage
     const getSlippage = (whichOne: 'stable' | 'volatile'): number => {

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -31,7 +31,7 @@ export const useSlippage = (
     txType: slippageDefaultTypes,
 ): SlippageMethodsIF => {
     // default slippage values to consume depending on transaction type
-    const defaults = DEFAULT_SLIPPAGE_VALUES[txType];
+    const defaults: slippageDefaultsIF = DEFAULT_SLIPPAGE_VALUES[txType];
 
     // keygen logic for local storage
     const LS_KEY: string = 'slippage_' + txType;
@@ -92,14 +92,7 @@ export const useSlippage = (
             volatile: isActiveNetworkL2 ? l2 : volatile,
             updateStable: isActiveNetworkL2 ? setL2 : setStable,
             updateVolatile: isActiveNetworkL2 ? setL2 : setVolatile,
-            presets: {
-                stable: isActiveNetworkL2
-                    ? defaults.presets.l2
-                    : defaults.presets.stable,
-                volatile: isActiveNetworkL2
-                    ? defaults.presets.l2
-                    : defaults.presets.volatile,
-            },
+            presets: defaults.getPresets(isActiveNetworkL2),
         }),
         [stable, volatile, l2],
     );

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -44,22 +44,21 @@ export const useSlippage = (
     const getSlippage = (whichOne: 'stable' | 'volatile' | 'l2'): number => {
         // retrieve the relevant slippage pair from local storage
         // query will return `null` if the key-value pair does not exist
-        const pair: slippageDefaultsIF | null = JSON.parse(
-            localStorage.getItem(LS_KEY) as string,
-        );
+        const pair: { stable: number; volatile: number; l2: number } | null =
+            JSON.parse(localStorage.getItem(LS_KEY) as string);
         // declare an output value for the function
         let output: number;
         // router to get the stable or volatile value as specified by params
         // will use default value if local storage did not have a key-val pair
         switch (whichOne) {
             case 'stable':
-                output = pair?.stable ?? defaults.stable;
+                output = pair?.stable ?? defaults.vals.stable;
                 break;
             case 'volatile':
-                output = pair?.volatile ?? defaults.volatile;
+                output = pair?.volatile ?? defaults.vals.volatile;
                 break;
             case 'l2':
-                output = pair?.l2 ?? defaults.l2;
+                output = pair?.l2 ?? defaults.vals.l2;
                 break;
             default:
                 output = 0.1;
@@ -85,7 +84,7 @@ export const useSlippage = (
     // volatile ➡ number, active slippage value for non-stable pairs
     // updateStable ➡ accepts a new `stable` value from the DOM
     // updateVolatile ➡ accepts a new `volatile` value from the DOM
-    // !important:  most fields will preferentially consume an L2 value as relevant
+    // !important:  fields will preferentially consume an L2 value as relevant
     return useMemo(
         () => ({
             stable: isActiveNetworkL2 ? l2 : stable,

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -21,6 +21,10 @@ export interface allSlippageMethodsIF {
     repoSlippage: SlippageMethodsIF;
 }
 
+// !important:  this hook supports differential values on L2 networks, this is not
+// !important:  ... written in the prettiest way but is allows for differential
+// !important:  ... handling without changing any fn calls in the app proper
+
 // custom hook to manage and interact a given slippage pair
 // @param slippageType ➡ denotes swap, mint, or reposition
 // @param defaults ➡ default values to use for slippage
@@ -28,7 +32,7 @@ export const useSlippage = (
     slippageType: 'swap' | 'mint' | 'repo',
     defaults: slippageDefaultsIF,
 ): SlippageMethodsIF => {
-    //
+    // keygen logic for local storage
     const LS_KEY: string = 'slippage_' + slippageType;
 
     // check if active network is an L2 for differential handling
@@ -63,7 +67,8 @@ export const useSlippage = (
         return output;
     };
 
-    // hooks to hold stable and volatile values in state
+    // hooks to hold different slippage values in state
+    // l2 is stored separately but preferentially consumed when relevant
     // do NOT refactor these as useMemo() hooks, it will not work
     const [stable, setStable] = useState<number>(getSlippage('stable'));
     const [volatile, setVolatile] = useState<number>(getSlippage('volatile'));
@@ -79,6 +84,7 @@ export const useSlippage = (
     // volatile ➡ number, active slippage value for non-stable pairs
     // updateStable ➡ accepts a new `stable` value from the DOM
     // updateVolatile ➡ accepts a new `volatile` value from the DOM
+    // !important:  most fields will preferentially consume an L2 value as relevant
     return useMemo(
         () => ({
             stable: isActiveNetworkL2 ? stable : l2,

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -25,9 +25,12 @@ export interface allSlippageMethodsIF {
 // @param slippageType ➡ denotes swap, mint, or reposition
 // @param defaults ➡ default values to use for slippage
 export const useSlippage = (
-    slippageType: string,
+    slippageType: 'swap' | 'mint' | 'repo',
     defaults: slippageDefaultsIF,
 ): SlippageMethodsIF => {
+    //
+    const LS_KEY: string = 'slippage_' + slippageType;
+
     // check if active network is an L2 for differential handling
     const { isActiveNetworkL2 } = useContext(ChainDataContext);
 
@@ -37,7 +40,7 @@ export const useSlippage = (
         // retrieve the relevant slippage pair from local storage
         // query will return `null` if the key-value pair does not exist
         const pair: slippageDefaultsIF | null = JSON.parse(
-            localStorage.getItem(`slippage_${slippageType}`) as string,
+            localStorage.getItem(LS_KEY) as string,
         );
         // declare an output value for the function
         let output: number;
@@ -68,10 +71,7 @@ export const useSlippage = (
 
     // update persisted value in local storage whenever user changes slippage tolerance
     useEffect(() => {
-        localStorage.setItem(
-            `slippage_${slippageType}`,
-            JSON.stringify({ stable, volatile, l2 }),
-        );
+        localStorage.setItem(LS_KEY, JSON.stringify({ stable, volatile, l2 }));
     }, [stable, volatile, l2]);
 
     // return data object

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -15,12 +15,6 @@ export interface SlippageMethodsIF {
     presets: { stable: slippagePresetsType; volatile: slippagePresetsType };
 }
 
-export interface allSlippageMethodsIF {
-    swapSlippage: SlippageMethodsIF;
-    mintSlippage: SlippageMethodsIF;
-    repoSlippage: SlippageMethodsIF;
-}
-
 // !important:  this hook supports differential values on L2 networks, this is not
 // !important:  ... written in the prettiest way but is allows for differential
 // !important:  ... handling without changing any fn calls in the app proper
@@ -61,7 +55,7 @@ export const useSlippage = (
                 output = pair?.l2 ?? defaults.l2;
                 break;
             default:
-                output = 0;
+                output = 0.1;
         }
         // return output value
         return output;

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -93,6 +93,6 @@ export const useSlippage = (
             updateVolatile: isActiveNetworkL2 ? setVolatile : setL2,
             presets: defaults.presets,
         }),
-        [stable, volatile],
+        [stable, volatile, l2],
     );
 };

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -12,7 +12,11 @@ export interface SlippageMethodsIF {
     volatile: number;
     updateStable: (val: number) => void;
     updateVolatile: (val: number) => void;
-    presets: { stable: slippagePresetsType; volatile: slippagePresetsType };
+    presets: {
+        stable: slippagePresetsType;
+        volatile: slippagePresetsType;
+        l2: slippagePresetsType;
+    };
 }
 
 // !important:  this hook supports differential values on L2 networks, this is not

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -1,8 +1,10 @@
 // START: Import React and Dongles
 import { useContext, useEffect, useMemo, useState } from 'react';
 import {
+    DEFAULT_SLIPPAGE_VALUES,
     slippageDefaultsIF,
     slippagePresetsType,
+    slippageTypes,
 } from '../../ambient-utils/constants';
 import { ChainDataContext } from '../../contexts/ChainDataContext';
 
@@ -26,12 +28,12 @@ export interface SlippageMethodsIF {
 // custom hook to manage and interact a given slippage pair
 // @param slippageType ➡ denotes swap, mint, or reposition
 // @param defaults ➡ default values to use for slippage
-export const useSlippage = (
-    slippageType: 'swap' | 'mint' | 'repo',
-    defaults: slippageDefaultsIF,
-): SlippageMethodsIF => {
+export const useSlippage = (txType: slippageTypes): SlippageMethodsIF => {
+    // default slippage values to consume depending on transaction type
+    const defaults = DEFAULT_SLIPPAGE_VALUES[txType];
+
     // keygen logic for local storage
-    const LS_KEY: string = 'slippage_' + slippageType;
+    const LS_KEY: string = 'slippage_' + txType;
 
     // check if active network is an L2 for differential handling
     const { isActiveNetworkL2 } = useContext(ChainDataContext);

--- a/src/App/hooks/useSlippage.ts
+++ b/src/App/hooks/useSlippage.ts
@@ -88,17 +88,17 @@ export const useSlippage = (
     // !important:  most fields will preferentially consume an L2 value as relevant
     return useMemo(
         () => ({
-            stable: isActiveNetworkL2 ? stable : l2,
-            volatile: isActiveNetworkL2 ? volatile : l2,
-            updateStable: isActiveNetworkL2 ? setStable : setL2,
-            updateVolatile: isActiveNetworkL2 ? setVolatile : setL2,
+            stable: isActiveNetworkL2 ? l2 : stable,
+            volatile: isActiveNetworkL2 ? l2 : volatile,
+            updateStable: isActiveNetworkL2 ? setL2 : setStable,
+            updateVolatile: isActiveNetworkL2 ? setL2 : setVolatile,
             presets: {
                 stable: isActiveNetworkL2
-                    ? defaults.presets.stable
-                    : defaults.presets.l2,
+                    ? defaults.presets.l2
+                    : defaults.presets.stable,
                 volatile: isActiveNetworkL2
-                    ? defaults.presets.volatile
-                    : defaults.presets.l2,
+                    ? defaults.presets.l2
+                    : defaults.presets.volatile,
             },
         }),
         [stable, volatile, l2],

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -68,7 +68,7 @@ const MINT_DEFAULTS: defaultsConstructorArgsIF = {
     vals: {
         stable: 1,
         volatile: 3,
-        l2: 1,
+        l2: 3,
     },
     presets: {
         stable: [1, 2, 3],

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -8,6 +8,7 @@ export interface slippageDefaultsIF {
     presets: {
         stable: slippagePresetsType;
         volatile: slippagePresetsType;
+        l2: slippagePresetsType;
     };
 }
 
@@ -18,6 +19,7 @@ const swap: slippageDefaultsIF = {
     presets: {
         stable: [0.1, 0.3, 0.5],
         volatile: [0.1, 0.3, 0.5],
+        l2: [1, 2, 3],
     },
 };
 
@@ -28,6 +30,7 @@ const mint: slippageDefaultsIF = {
     presets: {
         stable: [1, 2, 3],
         volatile: [1, 2, 3],
+        l2: [1, 2, 3],
     },
 };
 
@@ -38,6 +41,7 @@ const reposition: slippageDefaultsIF = {
     presets: {
         stable: [0.1, 0.3, 0.5],
         volatile: [0.1, 0.3, 0.5],
+        l2: [1, 2, 3],
     },
 };
 

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -1,77 +1,105 @@
 // slippage quick select presets in the DOM (three numbers)
 export type slippagePresetsType = [number, number, number];
-// shape of data object to hold slippage presets
-export interface slippageDefaultsIF {
-    stable: number;
-    volatile: number;
-    l2: 1;
+
+// shape of data taken by class constructor for slippage defaults obj
+interface defaultsConstructorArgsIF {
+    vals: {
+        stable: number;
+        volatile: number;
+        l2: number;
+    };
     presets: {
         stable: slippagePresetsType;
         volatile: slippagePresetsType;
         l2: slippagePresetsType;
     };
+}
+
+// shape of data created by the SlippageDefaults class
+// this is an extension of the input args (adds a method to get presets on L2)
+export interface slippageDefaultsIF extends defaultsConstructorArgsIF {
     getPresets: (isL2: boolean) => {
         stable: slippagePresetsType;
         volatile: slippagePresetsType;
     };
 }
 
+// class constructor to organize slippage default values for app to consume
+class SlippageDefaults implements slippageDefaultsIF {
+    vals: {
+        stable: number;
+        volatile: number;
+        l2: number;
+    };
+    presets: {
+        stable: slippagePresetsType;
+        volatile: slippagePresetsType;
+        l2: slippagePresetsType;
+    };
+    getPresets(isL2: boolean) {
+        const { stable, volatile, l2 } = this.presets;
+        return {
+            stable: isL2 ? l2 : stable,
+            volatile: isL2 ? l2 : volatile,
+        };
+    }
+    constructor(args: defaultsConstructorArgsIF) {
+        this.vals = args.vals;
+        this.presets = args.presets;
+    }
+}
+
+// default values to consume for a swap tx
+const SWAP_DEFAULTS: defaultsConstructorArgsIF = {
+    vals: {
+        stable: 0.1,
+        volatile: 0.1,
+        l2: 1,
+    },
+    presets: {
+        stable: [0.1, 0.3, 0.5],
+        volatile: [0.1, 0.3, 0.5],
+        l2: [0.5, 1, 3],
+    },
+};
+
+// default values to consume for a mint tx
+const MINT_DEFAULTS: defaultsConstructorArgsIF = {
+    vals: {
+        stable: 1,
+        volatile: 3,
+        l2: 1,
+    },
+    presets: {
+        stable: [1, 2, 3],
+        volatile: [1, 2, 3],
+        l2: [0.5, 1, 3],
+    },
+};
+
+// default values to consume for a reposition tx
+const REPO_DEFAULTS: defaultsConstructorArgsIF = {
+    vals: {
+        stable: 0.1,
+        volatile: 0.5,
+        l2: 1,
+    },
+    presets: {
+        stable: [0.1, 0.3, 0.5],
+        volatile: [0.1, 0.3, 0.5],
+        l2: [0.5, 1, 3],
+    },
+};
+
+// data structure exporting the slippage default data organized by class constructor
 export const DEFAULT_SLIPPAGE_VALUES: {
     swap: slippageDefaultsIF;
     mint: slippageDefaultsIF;
     repo: slippageDefaultsIF;
 } = {
-    swap: {
-        stable: 0.1,
-        volatile: 0.1,
-        l2: 1,
-        presets: {
-            stable: [0.1, 0.3, 0.5],
-            volatile: [0.1, 0.3, 0.5],
-            l2: [0.5, 1, 3],
-        },
-        getPresets(isL2: boolean) {
-            const { stable, volatile, l2 } = this.presets;
-            return {
-                stable: isL2 ? l2 : stable,
-                volatile: isL2 ? l2 : volatile,
-            };
-        },
-    },
-    mint: {
-        stable: 1,
-        volatile: 3,
-        l2: 1,
-        presets: {
-            stable: [1, 2, 3],
-            volatile: [1, 2, 3],
-            l2: [0.5, 1, 3],
-        },
-        getPresets(isL2: boolean) {
-            const { stable, volatile, l2 } = this.presets;
-            return {
-                stable: isL2 ? l2 : stable,
-                volatile: isL2 ? l2 : volatile,
-            };
-        },
-    },
-    repo: {
-        stable: 0.1,
-        volatile: 0.5,
-        l2: 1,
-        presets: {
-            stable: [0.1, 0.3, 0.5],
-            volatile: [0.1, 0.3, 0.5],
-            l2: [0.5, 1, 3],
-        },
-        getPresets(isL2: boolean) {
-            const { stable, volatile, l2 } = this.presets;
-            return {
-                stable: isL2 ? l2 : stable,
-                volatile: isL2 ? l2 : volatile,
-            };
-        },
-    },
+    swap: new SlippageDefaults(SWAP_DEFAULTS),
+    mint: new SlippageDefaults(MINT_DEFAULTS),
+    repo: new SlippageDefaults(REPO_DEFAULTS),
 };
 
 // string-literal union type of keys in `SLIPPAGE`

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -10,6 +10,10 @@ export interface slippageDefaultsIF {
         volatile: slippagePresetsType;
         l2: slippagePresetsType;
     };
+    getPresets: (isL2: boolean) => {
+        stable: slippagePresetsType;
+        volatile: slippagePresetsType;
+    };
 }
 
 export const DEFAULT_SLIPPAGE_VALUES: {
@@ -26,6 +30,13 @@ export const DEFAULT_SLIPPAGE_VALUES: {
             volatile: [0.1, 0.3, 0.5],
             l2: [1, 2, 3],
         },
+        getPresets(isL2: boolean) {
+            const { stable, volatile, l2 } = this.presets;
+            return {
+                stable: isL2 ? l2 : stable,
+                volatile: isL2 ? l2 : volatile,
+            };
+        },
     },
     mint: {
         stable: 1,
@@ -36,6 +47,13 @@ export const DEFAULT_SLIPPAGE_VALUES: {
             volatile: [1, 2, 3],
             l2: [1, 2, 3],
         },
+        getPresets(isL2: boolean) {
+            const { stable, volatile, l2 } = this.presets;
+            return {
+                stable: isL2 ? l2 : stable,
+                volatile: isL2 ? l2 : volatile,
+            };
+        },
     },
     repo: {
         stable: 0.1,
@@ -45,6 +63,13 @@ export const DEFAULT_SLIPPAGE_VALUES: {
             stable: [0.1, 0.3, 0.5],
             volatile: [0.1, 0.3, 0.5],
             l2: [1, 2, 3],
+        },
+        getPresets(isL2: boolean) {
+            const { stable, volatile, l2 } = this.presets;
+            return {
+                stable: isL2 ? l2 : stable,
+                volatile: isL2 ? l2 : volatile,
+            };
         },
     },
 };

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -50,4 +50,4 @@ export const DEFAULT_SLIPPAGE_VALUES: {
 };
 
 // string-literal union type of keys in `SLIPPAGE`
-export type slippageTypes = keyof typeof DEFAULT_SLIPPAGE_VALUES;
+export type slippageDefaultTypes = keyof typeof DEFAULT_SLIPPAGE_VALUES;

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -12,37 +12,42 @@ export interface slippageDefaultsIF {
     };
 }
 
-const swap: slippageDefaultsIF = {
-    stable: 0.1,
-    volatile: 0.1,
-    l2: 1,
-    presets: {
-        stable: [0.1, 0.3, 0.5],
-        volatile: [0.1, 0.3, 0.5],
-        l2: [1, 2, 3],
+export const DEFAULT_SLIPPAGE_VALUES: {
+    swap: slippageDefaultsIF;
+    mint: slippageDefaultsIF;
+    repo: slippageDefaultsIF;
+} = {
+    swap: {
+        stable: 0.1,
+        volatile: 0.1,
+        l2: 1,
+        presets: {
+            stable: [0.1, 0.3, 0.5],
+            volatile: [0.1, 0.3, 0.5],
+            l2: [1, 2, 3],
+        },
+    },
+    mint: {
+        stable: 1,
+        volatile: 3,
+        l2: 1,
+        presets: {
+            stable: [1, 2, 3],
+            volatile: [1, 2, 3],
+            l2: [1, 2, 3],
+        },
+    },
+    repo: {
+        stable: 0.1,
+        volatile: 0.5,
+        l2: 1,
+        presets: {
+            stable: [0.1, 0.3, 0.5],
+            volatile: [0.1, 0.3, 0.5],
+            l2: [1, 2, 3],
+        },
     },
 };
 
-const mint: slippageDefaultsIF = {
-    stable: 1,
-    volatile: 3,
-    l2: 1,
-    presets: {
-        stable: [1, 2, 3],
-        volatile: [1, 2, 3],
-        l2: [1, 2, 3],
-    },
-};
-
-const reposition: slippageDefaultsIF = {
-    stable: 0.1,
-    volatile: 0.5,
-    l2: 1,
-    presets: {
-        stable: [0.1, 0.3, 0.5],
-        volatile: [0.1, 0.3, 0.5],
-        l2: [1, 2, 3],
-    },
-};
-
-export const slippage = { swap, mint, reposition };
+// string-literal union type of keys in `SLIPPAGE`
+export type slippageTypes = keyof typeof DEFAULT_SLIPPAGE_VALUES;

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -1,4 +1,16 @@
-const swap = {
+// slippage quick select presets in the DOM (three numbers)
+export type slippagePresetsType = [number, number, number];
+// shape of data object to hold slippage presets
+export interface slippageDefaultsIF {
+    stable: number;
+    volatile: number;
+    presets: {
+        stable: slippagePresetsType;
+        volatile: slippagePresetsType;
+    };
+}
+
+const swap: slippageDefaultsIF = {
     stable: 0.1,
     volatile: 0.1,
     presets: {
@@ -7,7 +19,7 @@ const swap = {
     },
 };
 
-const mint = {
+const mint: slippageDefaultsIF = {
     stable: 1,
     volatile: 3,
     presets: {
@@ -16,7 +28,7 @@ const mint = {
     },
 };
 
-const reposition = {
+const reposition: slippageDefaultsIF = {
     stable: 0.1,
     volatile: 0.5,
     presets: {

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -28,7 +28,7 @@ export const DEFAULT_SLIPPAGE_VALUES: {
         presets: {
             stable: [0.1, 0.3, 0.5],
             volatile: [0.1, 0.3, 0.5],
-            l2: [1, 2, 3],
+            l2: [0.5, 1, 3],
         },
         getPresets(isL2: boolean) {
             const { stable, volatile, l2 } = this.presets;
@@ -45,7 +45,7 @@ export const DEFAULT_SLIPPAGE_VALUES: {
         presets: {
             stable: [1, 2, 3],
             volatile: [1, 2, 3],
-            l2: [1, 2, 3],
+            l2: [0.5, 1, 3],
         },
         getPresets(isL2: boolean) {
             const { stable, volatile, l2 } = this.presets;
@@ -62,7 +62,7 @@ export const DEFAULT_SLIPPAGE_VALUES: {
         presets: {
             stable: [0.1, 0.3, 0.5],
             volatile: [0.1, 0.3, 0.5],
-            l2: [1, 2, 3],
+            l2: [0.5, 1, 3],
         },
         getPresets(isL2: boolean) {
             const { stable, volatile, l2 } = this.presets;

--- a/src/ambient-utils/constants/slippage.ts
+++ b/src/ambient-utils/constants/slippage.ts
@@ -4,6 +4,7 @@ export type slippagePresetsType = [number, number, number];
 export interface slippageDefaultsIF {
     stable: number;
     volatile: number;
+    l2: 1;
     presets: {
         stable: slippagePresetsType;
         volatile: slippagePresetsType;
@@ -13,6 +14,7 @@ export interface slippageDefaultsIF {
 const swap: slippageDefaultsIF = {
     stable: 0.1,
     volatile: 0.1,
+    l2: 1,
     presets: {
         stable: [0.1, 0.3, 0.5],
         volatile: [0.1, 0.3, 0.5],
@@ -22,6 +24,7 @@ const swap: slippageDefaultsIF = {
 const mint: slippageDefaultsIF = {
     stable: 1,
     volatile: 3,
+    l2: 1,
     presets: {
         stable: [1, 2, 3],
         volatile: [1, 2, 3],
@@ -31,6 +34,7 @@ const mint: slippageDefaultsIF = {
 const reposition: slippageDefaultsIF = {
     stable: 0.1,
     volatile: 0.5,
+    l2: 1,
     presets: {
         stable: [0.1, 0.3, 0.5],
         volatile: [0.1, 0.3, 0.5],

--- a/src/contexts/ChainDataContext.tsx
+++ b/src/contexts/ChainDataContext.tsx
@@ -30,6 +30,7 @@ interface ChainDataContextIF {
     client: Client;
     connectedUserXp: UserXpDataIF;
     isActiveNetworkBlast: boolean;
+    isActiveNetworkL2: boolean;
 }
 
 export const ChainDataContext = createContext<ChainDataContextIF>(
@@ -58,12 +59,16 @@ export const ChainDataContextProvider = (props: {
         chainData.chainId,
     );
 
-    // const isActiveNetworkL2 = [
-    //     '0x13e31',
-    //     '0xa0c71fd',
-    //     '0x82750',
-    //     '0x8274f',
-    // ].includes(chainData.chainId);
+    // array of network IDs for supported L2 networks
+    const L2_NETWORKS: string[] = [
+        '0x13e31',
+        '0xa0c71fd',
+        '0x82750',
+        '0x8274f',
+    ];
+
+    // boolean representing whether the active network is an L2
+    const isActiveNetworkL2: boolean = L2_NETWORKS.includes(chainData.chainId);
 
     async function pollBlockNum(): Promise<void> {
         // if default RPC is Infura, use key from env variable
@@ -227,6 +232,7 @@ export const ChainDataContextProvider = (props: {
         setGasPriceinGwei,
         isActiveNetworkBlast,
         client,
+        isActiveNetworkL2,
     };
 
     return (

--- a/src/contexts/ChainDataContext.tsx
+++ b/src/contexts/ChainDataContext.tsx
@@ -54,12 +54,9 @@ export const ChainDataContextProvider = (props: {
     const [lastBlockNumber, setLastBlockNumber] = useState<number>(0);
     const [gasPriceInGwei, setGasPriceinGwei] = useState<number | undefined>();
 
-    const isActiveNetworkBlast = [
-        '0x5d50',
-        '0xa0c71fd',
-        '0xee',
-        '0x13e31',
-    ].includes(chainData.chainId);
+    const isActiveNetworkBlast = ['0x13e31', '0xa0c71fd'].includes(
+        chainData.chainId,
+    );
 
     async function pollBlockNum(): Promise<void> {
         // if default RPC is Infura, use key from env variable

--- a/src/contexts/UserPreferenceContext.tsx
+++ b/src/contexts/UserPreferenceContext.tsx
@@ -6,7 +6,7 @@ import {
 import { favePoolsMethodsIF, useFavePools } from '../App/hooks/useFavePools';
 import { skipConfirmIF, useSkipConfirm } from '../App/hooks/useSkipConfirm';
 import { SlippageMethodsIF, useSlippage } from '../App/hooks/useSlippage';
-import { IS_LOCAL_ENV, slippage } from '../ambient-utils/constants';
+import { IS_LOCAL_ENV } from '../ambient-utils/constants';
 import { CrocEnvContext } from './CrocEnvContext';
 import { TradeTokenContext } from './TradeTokenContext';
 import { TradeDataContext } from './TradeDataContext';
@@ -46,9 +46,9 @@ export const UserPreferenceContextProvider = (props: {
 
     const userPreferencesProps = {
         favePools: useFavePools(),
-        swapSlippage: useSlippage('swap', slippage.swap),
-        mintSlippage: useSlippage('mint', slippage.mint),
-        repoSlippage: useSlippage('repo', slippage.reposition),
+        swapSlippage: useSlippage('swap'),
+        mintSlippage: useSlippage('mint'),
+        repoSlippage: useSlippage('repo'),
         dexBalSwap: useExchangePrefs('swap'),
         dexBalLimit: useExchangePrefs('limit'),
         dexBalRange: useExchangePrefs('range'),


### PR DESCRIPTION
### Describe your changes 

Refactors to `slippage.ts` file:
* Reorganize structure of central data file
* Improve use of explicit typing and deriving types from data
* Add a new L2 default slippage value to every transaction type
* Add a new L2 slippage preset array to every transaction type

Refactors to `useSlippage.ts` file:
* Access slippage defaults via webpack import rather than function params
* Manage (persist to and consume from) slippage tolerance value for L2 in local storage separately from L1; values should not overwrite each other
* Centralize local storage keygen logic
* Improve use of explicit typing
* Update logic in return statement to preferentially return L1 vs L2 data and methods depending on the type of active network

General
* Update other files interacting with `slippage.ts` and `useSlippage.ts` to interact with new structure properly
* All changes are accomplished with No changes to the data layer 🎉

### Link the related issue
Closes #3462

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**
1. Initialize the app on an L2 and enter the transaction settings workflow.
7. Observe the slippage setting; should be `1` by default with new presets as specified in the `slippage.ts` file.
8. Change the slippage setting either with a preset or a custom value.
9. Change the app to another L2 network and repeat steps 1-3. The app should initialize on the value set in Step 3.
10. Change the app to Ethereum Mainnet and enter the transaction settings workflow.
11. Observe the slippage setting; the persisted value for an L2 network should not be consumed and the default value for an L1 as specified in `slippage.ts` should be consumed.
12. Open the `Applications` tab in Dev Tools; make sure that each of the three slippage k/v pairs have correctly persisted an `l2` value separately from the `stable` and `volatile` values.

**Environmental conditions that may result in expected but differential behavior.**
Be aware that the app will preferentially consume and update L1 and L2 values for slippage depending on the active network. This is handled in the hook and we do not need to change control flow in the display layer.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
@benwolski Please see comments in discussion