### PR TITLE
set default range width to 5% on ETH-USDB

### DIFF
--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -10,6 +10,7 @@ import {
 import {
     GCGO_OVERRIDE_URL,
     CACHE_UPDATE_FREQ_IN_MS,
+    getDefaultPairForChain,
 } from '../../ambient-utils/constants';
 import {
     LimitOrderIF,
@@ -129,13 +130,6 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
     // Token and range housekeeping when switching pairs
     useEffect(() => {
         if (contextMatchesParams && props.crocEnv) {
-            if (!ticksInParams) {
-                setAdvancedLowTick(0);
-                setAdvancedHighTick(0);
-                setAdvancedMode(false);
-                props.setSimpleRangeWidth(10);
-            }
-
             const tokenAAddress = tokenA.address;
             const tokenBAddress = tokenB.address;
 
@@ -144,6 +138,26 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                     tokenAAddress,
                     tokenBAddress,
                 );
+                if (!ticksInParams) {
+                    setAdvancedLowTick(0);
+                    setAdvancedHighTick(0);
+                    setAdvancedMode(false);
+                    const defaultPair = getDefaultPairForChain(
+                        props.chainData.chainId,
+                    );
+                    // set default range width to 5% for Blast ETH/USDB
+                    if (
+                        props.chainData.chainId === '0x13e31' &&
+                        sortedTokens[0].toLowerCase() ===
+                            defaultPair[0].address.toLowerCase() &&
+                        sortedTokens[1].toLowerCase() ===
+                            defaultPair[1].address.toLowerCase()
+                    ) {
+                        props.setSimpleRangeWidth(5);
+                    } else {
+                        props.setSimpleRangeWidth(10);
+                    }
+                }
 
                 setBaseTokenAddress(sortedTokens[0]);
                 setQuoteTokenAddress(sortedTokens[1]);

--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -10,7 +10,6 @@ import {
 import {
     GCGO_OVERRIDE_URL,
     CACHE_UPDATE_FREQ_IN_MS,
-    getDefaultPairForChain,
 } from '../../ambient-utils/constants';
 import {
     LimitOrderIF,
@@ -63,7 +62,7 @@ interface PoolParamsHookIF {
 
 // Hooks to update metadata and volume/TVL/liquidity curves on a per-pool basis
 export function usePoolMetadata(props: PoolParamsHookIF) {
-    const { tokenA, tokenB } = useContext(TradeDataContext);
+    const { tokenA, tokenB, defaultRangeWidth } = useContext(TradeDataContext);
     const { setDataLoadingStatus } = useContext(DataLoadingContext);
     const {
         setUserPositionsByPool,
@@ -142,21 +141,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                     setAdvancedLowTick(0);
                     setAdvancedHighTick(0);
                     setAdvancedMode(false);
-                    const defaultPair = getDefaultPairForChain(
-                        props.chainData.chainId,
-                    );
-                    // set default range width to 5% for Blast ETH/USDB
-                    if (
-                        props.chainData.chainId === '0x13e31' &&
-                        sortedTokens[0].toLowerCase() ===
-                            defaultPair[0].address.toLowerCase() &&
-                        sortedTokens[1].toLowerCase() ===
-                            defaultPair[1].address.toLowerCase()
-                    ) {
-                        props.setSimpleRangeWidth(5);
-                    } else {
-                        props.setSimpleRangeWidth(10);
-                    }
+                    props.setSimpleRangeWidth(defaultRangeWidth);
                 }
 
                 setBaseTokenAddress(sortedTokens[0]);

--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -62,7 +62,8 @@ interface PoolParamsHookIF {
 
 // Hooks to update metadata and volume/TVL/liquidity curves on a per-pool basis
 export function usePoolMetadata(props: PoolParamsHookIF) {
-    const { tokenA, tokenB, defaultRangeWidth } = useContext(TradeDataContext);
+    const { tokenA, tokenB, defaultRangeWidthForActivePool } =
+        useContext(TradeDataContext);
     const { setDataLoadingStatus } = useContext(DataLoadingContext);
     const {
         setUserPositionsByPool,
@@ -141,7 +142,7 @@ export function usePoolMetadata(props: PoolParamsHookIF) {
                     setAdvancedLowTick(0);
                     setAdvancedHighTick(0);
                     setAdvancedMode(false);
-                    props.setSimpleRangeWidth(defaultRangeWidth);
+                    props.setSimpleRangeWidth(defaultRangeWidthForActivePool);
                 }
 
                 setBaseTokenAddress(sortedTokens[0]);

--- a/src/App/hooks/useTokenPairAllowance.ts
+++ b/src/App/hooks/useTokenPairAllowance.ts
@@ -42,10 +42,8 @@ export function useTokenPairAllowance(props: PoolPricingPropsIF) {
         })();
     }, [
         crocEnv,
-        tokenA.address,
-        tokenA.chainId,
+        tokenA.address + tokenA.chainId + props.userAddress,
         props.lastBlockNumber,
-        props.userAddress,
         recheckTokenAApproval,
     ]);
 
@@ -72,10 +70,9 @@ export function useTokenPairAllowance(props: PoolPricingPropsIF) {
         })();
     }, [
         crocEnv,
-        tokenB.address,
-        tokenB.chainId,
+        tokenB.address + tokenB.chainId + props.userAddress,
         props.lastBlockNumber,
-        props.userAddress,
+
         recheckTokenBApproval,
     ]);
 

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -93,7 +93,7 @@ function RangesMenu(props: propsIF) {
 
     const { isUserConnected } = useContext(UserDataContext);
 
-    const { tokenA, tokenB } = useContext(TradeDataContext);
+    const { tokenA, tokenB, defaultRangeWidth } = useContext(TradeDataContext);
     const tokenAAddress = tokenA.address;
     const tokenBAddress = tokenB.address;
 
@@ -157,7 +157,7 @@ function RangesMenu(props: propsIF) {
             })}
             onClick={() => {
                 setActiveMobileComponent('trade');
-                setSimpleRangeWidth(10);
+                setSimpleRangeWidth(defaultRangeWidth);
                 setCurrentRangeInReposition(position.positionId);
                 setCurrentRangeInAdd('');
             }}

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -11,7 +11,6 @@ import {
 import UseOnClickOutside from '../../../../../utils/hooks/useOnClickOutside';
 import useMediaQuery from '../../../../../utils/hooks/useMediaQuery';
 
-import { IS_LOCAL_ENV } from '../../../../../ambient-utils/constants';
 import { RangeContext } from '../../../../../contexts/RangeContext';
 import {
     useLinkGen,
@@ -93,7 +92,8 @@ function RangesMenu(props: propsIF) {
 
     const { isUserConnected } = useContext(UserDataContext);
 
-    const { tokenA, tokenB } = useContext(TradeDataContext);
+    const { tokenA, tokenB, getDefaultRangeWidthForTokenPair } =
+        useContext(TradeDataContext);
     const tokenAAddress = tokenA.address;
     const tokenBAddress = tokenB.address;
 
@@ -126,7 +126,6 @@ function RangesMenu(props: propsIF) {
             setSimpleRangeWidth(100);
             setAdvancedMode(false);
         } else {
-            IS_LOCAL_ENV && console.debug({ position });
             setAdvancedLowTick(position.bidTick);
             setAdvancedHighTick(position.askTick);
             setAdvancedMode(true);
@@ -157,6 +156,13 @@ function RangesMenu(props: propsIF) {
             })}
             onClick={() => {
                 setActiveMobileComponent('trade');
+                setSimpleRangeWidth(
+                    getDefaultRangeWidthForTokenPair(
+                        position.chainId,
+                        position.base.toLowerCase(),
+                        position.quote.toLowerCase(),
+                    ),
+                );
                 setCurrentRangeInReposition(position.positionId);
                 setCurrentRangeInAdd('');
             }}

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -93,7 +93,7 @@ function RangesMenu(props: propsIF) {
 
     const { isUserConnected } = useContext(UserDataContext);
 
-    const { tokenA, tokenB, defaultRangeWidth } = useContext(TradeDataContext);
+    const { tokenA, tokenB } = useContext(TradeDataContext);
     const tokenAAddress = tokenA.address;
     const tokenBAddress = tokenB.address;
 
@@ -157,7 +157,6 @@ function RangesMenu(props: propsIF) {
             })}
             onClick={() => {
                 setActiveMobileComponent('trade');
-                setSimpleRangeWidth(defaultRangeWidth);
                 setCurrentRangeInReposition(position.positionId);
                 setCurrentRangeInAdd('');
             }}

--- a/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
+++ b/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
@@ -33,7 +33,7 @@ function RepositionHeader(props: propsIF) {
     const { bypassConfirmRepo, repoSlippage } = useContext(
         UserPreferenceContext,
     );
-    const { defaultRangeWidth } = useContext(TradeDataContext);
+    const { defaultRangeWidthForActivePool } = useContext(TradeDataContext);
 
     const [isOpen, openModal, closeModal] = useModal();
 
@@ -63,8 +63,8 @@ function RepositionHeader(props: propsIF) {
                     className={styles.close_icon}
                     onClick={() => {
                         setAdvancedMode(false);
-                        setRangeWidthPercentage(defaultRangeWidth);
-                        setSimpleRangeWidth(defaultRangeWidth);
+                        setRangeWidthPercentage(defaultRangeWidthForActivePool);
+                        setSimpleRangeWidth(defaultRangeWidthForActivePool);
                         navigate(exitPath, { replace: true });
                         resetTxHash();
                         setCurrentRangeInReposition('');

--- a/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
+++ b/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
@@ -14,6 +14,7 @@ import { UserPreferenceContext } from '../../../../contexts/UserPreferenceContex
 import { RangeContext } from '../../../../contexts/RangeContext';
 import { useModal } from '../../../Global/Modal/useModal';
 import { TradeModuleHeaderContainer } from '../../../../styled/Components/TradeModules';
+import { TradeDataContext } from '../../../../contexts/TradeDataContext';
 
 interface propsIF {
     positionHash: string;
@@ -32,6 +33,7 @@ function RepositionHeader(props: propsIF) {
     const { bypassConfirmRepo, repoSlippage } = useContext(
         UserPreferenceContext,
     );
+    const { defaultRangeWidth } = useContext(TradeDataContext);
 
     const [isOpen, openModal, closeModal] = useModal();
 
@@ -61,8 +63,8 @@ function RepositionHeader(props: propsIF) {
                     className={styles.close_icon}
                     onClick={() => {
                         setAdvancedMode(false);
-                        setRangeWidthPercentage(10);
-                        setSimpleRangeWidth(10);
+                        setRangeWidthPercentage(defaultRangeWidth);
+                        setSimpleRangeWidth(defaultRangeWidth);
                         navigate(exitPath, { replace: true });
                         resetTxHash();
                         setCurrentRangeInReposition('');

--- a/src/contexts/TradeDataContext.tsx
+++ b/src/contexts/TradeDataContext.tsx
@@ -1,7 +1,6 @@
 import React, { createContext, useEffect, useMemo } from 'react';
 import { NetworkIF, TokenIF } from '../ambient-utils/types';
 import { ChainSpec, sortBaseQuoteTokens } from '@crocswap-libs/sdk';
-import { getDefaultChainId } from '../ambient-utils/dataLayer';
 import { getDefaultPairForChain, goerliETH } from '../ambient-utils/constants';
 import { useAppChain } from '../App/hooks/useAppChain';
 
@@ -43,6 +42,7 @@ export interface TradeDataContextIF {
     isWalletChainSupported: boolean;
     activeNetwork: NetworkIF;
     chooseNetwork: (network: NetworkIF) => void;
+    defaultRangeWidth: number;
 }
 
 export const TradeDataContext = createContext<TradeDataContextIF>(
@@ -52,13 +52,15 @@ export const TradeDataContext = createContext<TradeDataContextIF>(
 // for default chain. Don't worry if user is coming in to another chain,
 // since these will get updated by useUrlParams() in any context where a
 // pair is necessary at load time
-const dfltChainId = getDefaultChainId();
-const dfltTokenA = getDefaultPairForChain(dfltChainId)[0];
-const dfltTokenB = getDefaultPairForChain(dfltChainId)[1];
 
 export const TradeDataContextProvider = (props: {
     children: React.ReactNode;
 }) => {
+    const { chainData, isWalletChainSupported, activeNetwork, chooseNetwork } =
+        useAppChain();
+    // const dfltChainId = getDefaultChainId();
+    const dfltTokenA = getDefaultPairForChain(chainData.chainId)[0];
+    const dfltTokenB = getDefaultPairForChain(chainData.chainId)[1];
     const [tokenA, setTokenA] = React.useState<TokenIF>(dfltTokenA);
     const [tokenB, setTokenB] = React.useState<TokenIF>(dfltTokenB);
     const [
@@ -104,8 +106,7 @@ export const TradeDataContextProvider = (props: {
     // TODO: this part feels suspicious
     // Why should we be handling the app chain in a hook
     // rather than a context?
-    const { chainData, isWalletChainSupported, activeNetwork, chooseNetwork } =
-        useAppChain();
+
     useEffect(() => {
         if (tokenA.chainId !== parseInt(chainData.chainId)) {
             const [_tokenA, _tokenB] = getDefaultPairForChain(
@@ -127,6 +128,27 @@ export const TradeDataContextProvider = (props: {
     );
     const [poolPriceNonDisplay, setPoolPriceNonDisplay] = React.useState(0);
     const [slippageTolerance, setSlippageTolerance] = React.useState(0.5);
+
+    const isPoolBlastEthUSDB = useMemo(() => {
+        return (
+            chainData.chainId === '0x13e31' &&
+            baseToken.address.toLowerCase() ===
+                dfltTokenA.address.toLowerCase() &&
+            quoteToken.address.toLowerCase() ===
+                dfltTokenB.address.toLowerCase()
+        );
+    }, [
+        baseToken.address +
+            quoteToken.address +
+            chainData.chainId +
+            dfltTokenA +
+            dfltTokenB,
+    ]);
+
+    const defaultRangeWidth = useMemo(() => {
+        const defaultWidth = isPoolBlastEthUSDB ? 5 : 10;
+        return defaultWidth;
+    }, [isPoolBlastEthUSDB]);
 
     const tradeDataContext = {
         tokenA,
@@ -162,6 +184,7 @@ export const TradeDataContextProvider = (props: {
         isWalletChainSupported,
         activeNetwork,
         chooseNetwork,
+        defaultRangeWidth,
     };
 
     return (

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -173,7 +173,7 @@ function Reposition() {
         tokenB,
         isTokenABase,
         poolPriceNonDisplay: currentPoolPriceNonDisplay,
-        defaultRangeWidth,
+        getDefaultRangeWidthForTokenPair,
     } = useContext(TradeDataContext);
 
     const currentPoolPriceTick =
@@ -224,8 +224,13 @@ function Reposition() {
         closeModal();
     };
 
-    const [rangeWidthPercentage, setRangeWidthPercentage] =
-        useState(defaultRangeWidth);
+    const [rangeWidthPercentage, setRangeWidthPercentage] = useState(
+        getDefaultRangeWidthForTokenPair(
+            position.chainId,
+            position.base.toLowerCase(),
+            position.quote.toLowerCase(),
+        ),
+    );
 
     const [pinnedLowTick, setPinnedLowTick] = useState(0);
     const [pinnedHighTick, setPinnedHighTick] = useState(0);
@@ -237,7 +242,13 @@ function Reposition() {
     }, []);
 
     useEffect(() => {
-        setSimpleRangeWidth(defaultRangeWidth);
+        setSimpleRangeWidth(
+            getDefaultRangeWidthForTokenPair(
+                position.chainId,
+                position.base.toLowerCase(),
+                position.quote.toLowerCase(),
+            ),
+        );
         setNewRepositionTransactionHash('');
     }, [position]);
 
@@ -250,10 +261,6 @@ function Reposition() {
             if (sliderInput) sliderInput.value = simpleRangeWidth.toString();
         }
     }, [simpleRangeWidth]);
-
-    useEffect(() => {
-        setSimpleRangeWidth(defaultRangeWidth);
-    }, [defaultRangeWidth]);
 
     useEffect(() => {
         if (!position) {

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -173,6 +173,7 @@ function Reposition() {
         tokenB,
         isTokenABase,
         poolPriceNonDisplay: currentPoolPriceNonDisplay,
+        defaultRangeWidth,
     } = useContext(TradeDataContext);
 
     const currentPoolPriceTick =
@@ -223,7 +224,8 @@ function Reposition() {
         closeModal();
     };
 
-    const [rangeWidthPercentage, setRangeWidthPercentage] = useState(10);
+    const [rangeWidthPercentage, setRangeWidthPercentage] =
+        useState(defaultRangeWidth);
 
     const [pinnedLowTick, setPinnedLowTick] = useState(0);
     const [pinnedHighTick, setPinnedHighTick] = useState(0);
@@ -235,7 +237,7 @@ function Reposition() {
     }, []);
 
     useEffect(() => {
-        setSimpleRangeWidth(10);
+        setSimpleRangeWidth(defaultRangeWidth);
         setNewRepositionTransactionHash('');
     }, [position]);
 

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -252,10 +252,8 @@ function Reposition() {
     }, [simpleRangeWidth]);
 
     useEffect(() => {
-        if (simpleRangeWidth !== rangeWidthPercentage) {
-            setSimpleRangeWidth(rangeWidthPercentage);
-        }
-    }, [rangeWidthPercentage]);
+        setSimpleRangeWidth(defaultRangeWidth);
+    }, [defaultRangeWidth]);
 
     useEffect(() => {
         if (!position) {

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -65,11 +65,16 @@ function Reposition() {
         crocEnv,
         activeNetwork,
         provider,
-        chainData: { blockExplorer, chainId },
         ethMainnetUsdPrice,
+        chainData: { blockExplorer },
     } = useContext(CrocEnvContext);
     const { tokens } = useContext(TokenContext);
-    const { gasPriceInGwei, lastBlockNumber } = useContext(ChainDataContext);
+    const {
+        gasPriceInGwei,
+        lastBlockNumber,
+        isActiveNetworkBlast,
+        isActiveNetworkScroll,
+    } = useContext(ChainDataContext);
     const { bypassConfirmRepo, repoSlippage } = useContext(
         UserPreferenceContext,
     );
@@ -627,11 +632,12 @@ function Reposition() {
         string | undefined
     >();
 
-    const isScroll = chainId === '0x82750' || chainId === '0x8274f';
     // const [l1GasFeePoolInGwei] = useState<number>(
     //     isScroll ? 0.0009 * 1e9 : 0,
     // );
-    const [extraL1GasFeePool] = useState(isScroll ? 2.75 : 0);
+    const [extraL1GasFeePool] = useState(
+        isActiveNetworkScroll ? 2.75 : isActiveNetworkBlast ? 2.5 : 0,
+    );
 
     useEffect(() => {
         if (gasPriceInGwei && ethMainnetUsdPrice) {


### PR DESCRIPTION
### Describe your changes 
create a method by which a custom default range width can be set for a specific pool

set default range/reposition width to +/-5% for ETH/USDB on Blast network.
