### PR TITLE
prevent auto re-fetch of Top Pools for Explore

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.3.7",
+    "version": "2.3.8",
     "private": true,
     "dependencies": {
         "@covalenthq/client-sdk": "^0.2.6",

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -36,7 +36,7 @@ export default function Explore() {
         }
     };
 
-    // get expanded pool metadata
+    // get expanded pool metadata, if not already fetched
     useEffect(() => {
         if (
             crocEnv !== undefined &&

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -1,4 +1,5 @@
 import { useContext, useEffect } from 'react';
+import { FiRefreshCw } from 'react-icons/fi';
 import TopPools from '../../components/Global/Analytics/TopPools';
 import { ExploreContext } from '../../contexts/ExploreContext';
 import styled from 'styled-components/macro';
@@ -37,10 +38,14 @@ export default function Explore() {
 
     // get expanded pool metadata
     useEffect(() => {
-        if (crocEnv !== undefined && poolList.length > 0) {
+        if (
+            crocEnv !== undefined &&
+            poolList.length > 0 &&
+            pools.all.length === 0
+        ) {
             getAllPools();
         }
-    }, [crocEnv, poolList.length]);
+    }, [crocEnv, poolList.length, pools.all.length]);
 
     const titleText = isActiveNetworkMainnet
         ? 'Top Ambient Pools on Ethereum'
@@ -54,6 +59,15 @@ export default function Explore() {
         <Section>
             <MainWrapper>
                 <TitleText>{titleText}</TitleText>
+                <Refresh>
+                    <RefreshButton
+                        onClick={() => {
+                            getAllPools();
+                        }}
+                    >
+                        <RefreshIcon />
+                    </RefreshButton>
+                </Refresh>
             </MainWrapper>
             <TopPools allPools={pools.all} chainId={chainData.chainId} />
         </Section>
@@ -94,4 +108,36 @@ const TitleText = styled.h2`
     @media (max-width: 480px) {
         font-size: 20px;
     }
+`;
+
+const Refresh = styled.div`
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    font-size: var(--body-size);
+    font-style: italic;
+    color: var(--text1);
+    gap: 8px;
+`;
+const RefreshButton = styled.button`
+    width: 30px;
+    height: 30px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    background-color: var(--dark3);
+    border-radius: var(--border-radius);
+    border: none;
+    outline: none;
+`;
+
+// const RefreshText = styled.p`
+//     /* Hide the RefreshText on screens smaller than 600px */
+//     @media (max-width: 600px) {
+//         display: none;
+//     }
+// `;
+const RefreshIcon = styled(FiRefreshCw)`
+    font-size: var(--header2-size);
+    cursor: pointer;
 `;


### PR DESCRIPTION
### Describe your changes 
only fetch fresh Top Pools data if user loads /explore before the pre-fetch is complete, or if they click the refresh button.

### Link the related issue
Top Pools on /explore was re-fetching when data was already available

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
