### PR TITLE
open /trade links in same tab when navigating from own portfolio

### DIFF
--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -14,6 +14,7 @@ import {
 } from '../../../../utils/hooks/useLinkGen';
 import { RowItem } from '../../../../styled/Components/TransactionTable';
 import { FlexContainer, Text } from '../../../../styled/Common';
+import { Link } from 'react-router-dom';
 
 interface propsIF {
     posHashTruncated: string;
@@ -253,24 +254,36 @@ export const orderRowConstants = (props: propsIF) => {
             className='base_color'
             onClick={(event) => event.stopPropagation()}
         >
-            <RowItem hover>
-                <a
-                    href={linkGenLimit.getFullURL(limitLinkParams)}
-                    target='_blank'
-                    rel='noreferrer'
-                >
-                    <div>
-                        <span>
-                            {baseTokenSymbol} / {quoteTokenSymbol}
-                        </span>
-                        <FiExternalLink
-                            size={10}
-                            color='white'
-                            style={{ marginLeft: '.5rem' }}
-                        />
-                    </div>
-                </a>
-            </RowItem>
+            {isOwnerActiveAccount ? (
+                <RowItem hover>
+                    <Link to={linkGenLimit.getFullURL(limitLinkParams)}>
+                        {
+                            <span>
+                                {baseTokenSymbol} / {quoteTokenSymbol}
+                            </span>
+                        }
+                    </Link>
+                </RowItem>
+            ) : (
+                <RowItem hover>
+                    <a
+                        href={linkGenLimit.getFullURL(limitLinkParams)}
+                        target='_blank'
+                        rel='noreferrer'
+                    >
+                        <div>
+                            <span>
+                                {baseTokenSymbol} / {quoteTokenSymbol}
+                            </span>
+                            <FiExternalLink
+                                size={10}
+                                color='white'
+                                style={{ marginLeft: '.5rem' }}
+                            />
+                        </div>
+                    </a>
+                </RowItem>
+            )}
         </div>
     );
 

--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -257,11 +257,14 @@ export const orderRowConstants = (props: propsIF) => {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={linkGenLimit.getFullURL(limitLinkParams)}>
-                        {
-                            <span>
-                                {baseTokenSymbol} / {quoteTokenSymbol}
-                            </span>
-                        }
+                        <span>
+                            {baseTokenSymbol} / {quoteTokenSymbol}
+                        </span>
+                        <FiExternalLink
+                            size={10}
+                            color='white'
+                            style={{ marginLeft: '.5rem' }}
+                        />
                     </Link>
                 </RowItem>
             ) : (

--- a/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
@@ -260,11 +260,14 @@ export default function rangeRowConstants(props: propsIF) {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={linkGenPool.getFullURL(poolLinkParams)}>
-                        {
-                            <span>
-                                {baseTokenSymbol} / {quoteTokenSymbol}
-                            </span>
-                        }
+                        <span>
+                            {baseTokenSymbol} / {quoteTokenSymbol}
+                        </span>
+                        <FiExternalLink
+                            size={10}
+                            color='white'
+                            style={{ marginLeft: '.5rem' }}
+                        />
                     </Link>
                 </RowItem>
             ) : (

--- a/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
@@ -16,6 +16,7 @@ import { TokenContext } from '../../../../contexts/TokenContext';
 import { RowItem } from '../../../../styled/Components/TransactionTable';
 import { FlexContainer, Text } from '../../../../styled/Common';
 import moment from 'moment';
+import { Link } from 'react-router-dom';
 
 interface propsIF {
     posHashTruncated: string;
@@ -256,24 +257,36 @@ export default function rangeRowConstants(props: propsIF) {
             className='base_color'
             onClick={(event) => event.stopPropagation()}
         >
-            <RowItem hover>
-                <a
-                    href={linkGenPool.getFullURL(poolLinkParams)}
-                    target='_blank'
-                    rel='noreferrer'
-                >
-                    <div>
-                        <span>
-                            {baseTokenSymbol} / {quoteTokenSymbol}
-                        </span>
-                        <FiExternalLink
-                            size={10}
-                            color='white'
-                            style={{ marginLeft: '.5rem' }}
-                        />
-                    </div>
-                </a>
-            </RowItem>
+            {isOwnerActiveAccount ? (
+                <RowItem hover>
+                    <Link to={linkGenPool.getFullURL(poolLinkParams)}>
+                        {
+                            <span>
+                                {baseTokenSymbol} / {quoteTokenSymbol}
+                            </span>
+                        }
+                    </Link>
+                </RowItem>
+            ) : (
+                <RowItem hover>
+                    <a
+                        href={linkGenPool.getFullURL(poolLinkParams)}
+                        target='_blank'
+                        rel='noreferrer'
+                    >
+                        <div>
+                            <span>
+                                {baseTokenSymbol} / {quoteTokenSymbol}
+                            </span>
+                            <FiExternalLink
+                                size={10}
+                                color='white'
+                                style={{ marginLeft: '.5rem' }}
+                            />
+                        </div>
+                    </a>
+                </RowItem>
+            )}
         </div>
     );
 

--- a/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
@@ -294,11 +294,14 @@ export const txRowConstants = (props: propsIF) => {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={tradeLinkPath}>
-                        {
-                            <span>
-                                {tx.baseSymbol} / {tx.quoteSymbol}
-                            </span>
-                        }
+                        <span>
+                            {tx.baseSymbol} / {tx.quoteSymbol}
+                        </span>
+                        <FiExternalLink
+                            size={10}
+                            color='white'
+                            style={{ marginLeft: '.5rem' }}
+                        />
                     </Link>
                 </RowItem>
             ) : (

--- a/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
@@ -14,6 +14,7 @@ import React, { useContext } from 'react';
 import { TokenContext } from '../../../../contexts/TokenContext';
 import { FlexContainer, Text } from '../../../../styled/Common';
 import { RowItem } from '../../../../styled/Components/TransactionTable';
+import { Link } from 'react-router-dom';
 
 interface propsIF {
     txHashTruncated: string;
@@ -290,20 +291,32 @@ export const txRowConstants = (props: propsIF) => {
             className='base_color'
             onClick={(event) => event.stopPropagation()}
         >
-            <RowItem hover>
-                <a href={tradeLinkPath} target='_blank' rel='noreferrer'>
-                    <div>
-                        <span>
-                            {tx.baseSymbol} / {tx.quoteSymbol}
-                        </span>
-                        <FiExternalLink
-                            size={10}
-                            color='white'
-                            style={{ marginLeft: '.5rem' }}
-                        />
-                    </div>
-                </a>
-            </RowItem>
+            {isOwnerActiveAccount ? (
+                <RowItem hover>
+                    <Link to={tradeLinkPath}>
+                        {
+                            <span>
+                                {tx.baseSymbol} / {tx.quoteSymbol}
+                            </span>
+                        }
+                    </Link>
+                </RowItem>
+            ) : (
+                <RowItem hover>
+                    <a href={tradeLinkPath} target='_blank' rel='noreferrer'>
+                        <div>
+                            <span>
+                                {tx.baseSymbol} / {tx.quoteSymbol}
+                            </span>
+                            <FiExternalLink
+                                size={10}
+                                color='white'
+                                style={{ marginLeft: '.5rem' }}
+                            />
+                        </div>
+                    </a>
+                </RowItem>
+            )}
         </div>
     );
 


### PR DESCRIPTION
### Describe your changes 
keep user in same app instance when navigating to a /trade route from their own portfolio, but still open new app instance when opening a pool from another user's account.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
