### PR TITLE
Fixed the fact that shareable charts open with the previous data when…

### DIFF
--- a/src/components/Trade/TradeTabs/TableRows.tsx
+++ b/src/components/Trade/TradeTabs/TableRows.tsx
@@ -113,24 +113,26 @@ function TableRows({
     const [activeRecord, setActiveRecord] = useState<ActiveRecord>(undefined);
 
     useEffect(() => {
-        if (type === 'Range') {
-            setActiveRecord(
-                (fullData as PositionIF[]).find((position) => {
-                    return position.positionId === currentPositionActive;
-                }),
-            );
-        } else if (type === 'Order') {
-            setActiveRecord(
-                (fullData as LimitOrderIF[]).find((order) => {
-                    return order.limitOrderId === currentLimitOrderActive;
-                }),
-            );
-        } else {
-            setActiveRecord(
-                (fullData as TransactionIF[]).find((tx) => {
-                    return tx.txId === currentTxActiveInTransactions;
-                }),
-            );
+        if (isDetailsModalOpen) {
+            if (type === 'Range') {
+                setActiveRecord(
+                    (fullData as PositionIF[]).find((position) => {
+                        return position.positionId === currentPositionActive;
+                    }),
+                );
+            } else if (type === 'Order') {
+                setActiveRecord(
+                    (fullData as LimitOrderIF[]).find((order) => {
+                        return order.limitOrderId === currentLimitOrderActive;
+                    }),
+                );
+            } else {
+                setActiveRecord(
+                    (fullData as TransactionIF[]).find((tx) => {
+                        return tx.txId === currentTxActiveInTransactions;
+                    }),
+                );
+            }
         }
     }, [
         type,


### PR DESCRIPTION
… opening

### Describe your changes 

- When shareable charts are first opened, they open with the previous transaction data

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
