### PR TITLE
Refactor imported token provenance

### DIFF
--- a/docs/CODING-STYLE.md
+++ b/docs/CODING-STYLE.md
@@ -31,6 +31,7 @@ Please follow these items as close to as possible for your PR. Please add a desc
 - [ ] Are React functional components declared as a default export?
 
 #### Data Management
+- [ ] Are data fetches described with an interface for the incoming data shape and an extended interface for the internal post-decorating specification?
 - [ ] Are data and relevant methods packaged together in objects?
 - [ ] Are objects instantiated through a centralized process when made in parallel? (factory function, class constructor, etc)
 - [ ] Are classes checked against an interface via the `implements` keyword?

--- a/src/ambient-utils/api/fetchContractDetails.ts
+++ b/src/ambient-utils/api/fetchContractDetails.ts
@@ -1,7 +1,7 @@
 import { ERC20_ABI } from '@crocswap-libs/sdk';
 import { Contract, ethers } from 'ethers';
 import { memoizeProviderFn } from '../dataLayer/functions/memoizePromiseFn';
-import { TokenIF } from '../types/token/TokenIF';
+import { TokenIF, otherTokenSources } from '../types/token/TokenIF';
 import { ZERO_ADDRESS } from '../constants';
 
 export interface ContractDetails {
@@ -19,7 +19,7 @@ export const fetchContractDetails = async (
     provider: ethers.providers.Provider,
     address: string,
     _chainId: string,
-    provenance: string,
+    provenance: otherTokenSources,
 ): Promise<TokenIF> => {
     // TODO:    update this logic to work on chains where the native token is not ETH
     if (address === ZERO_ADDRESS) {

--- a/src/ambient-utils/api/fetchContractDetails.ts
+++ b/src/ambient-utils/api/fetchContractDetails.ts
@@ -12,11 +12,16 @@ export interface ContractDetails {
     name: string | undefined;
 }
 
+// !important:  the `provenance` argument should be used to label what part of the app
+// !important:  ... as the point of entry for a token fetched from on-chain data
+
 export const fetchContractDetails = async (
     provider: ethers.providers.Provider,
     address: string,
     _chainId: string,
+    provenance: string,
 ): Promise<TokenIF> => {
+    // TODO:    update this logic to work on chains where the native token is not ETH
     if (address === ZERO_ADDRESS) {
         return {
             address: address,
@@ -71,7 +76,7 @@ export const fetchContractDetails = async (
         decimals: decimals,
         symbol: symbol,
         name: name,
-        fromList: 'custom_token',
+        fromList: provenance,
         logoURI: '',
     };
 };

--- a/src/ambient-utils/types/token/TokenIF.ts
+++ b/src/ambient-utils/types/token/TokenIF.ts
@@ -2,7 +2,7 @@ import { tokenListURIs } from '../../constants';
 
 // string-union type of all acceptable values for `fromList` property
 type uris = typeof tokenListURIs[keyof typeof tokenListURIs];
-type otherTokenSources = 'on_chain_by_URL_param';
+export type otherTokenSources = 'on_chain_by_URL_param';
 type tokenProvenances = uris | otherTokenSources;
 
 // interface conforming to Uniswap standard, this is the format we expect

--- a/src/ambient-utils/types/token/TokenIF.ts
+++ b/src/ambient-utils/types/token/TokenIF.ts
@@ -5,13 +5,20 @@ type uris = typeof tokenListURIs[keyof typeof tokenListURIs];
 type otherTokenSources = 'on_chain_by_URL_param';
 type tokenProvenances = uris | otherTokenSources;
 
-export interface TokenIF {
+// interface conforming to Uniswap standard, this is the format we expect
+// ... of any token retrieved from an external URI
+export interface ServerTokenIF {
     name: string;
     address: string;
     symbol: string;
     decimals: number;
     chainId: number;
     logoURI: string;
+}
+
+// interface describing our internal standard we use for token data after
+// ... being decorated by in-app middleware
+export interface TokenIF extends ServerTokenIF {
     fromList?: tokenProvenances;
     listedBy?: string[];
     walletBalance?: string;

--- a/src/ambient-utils/types/token/TokenIF.ts
+++ b/src/ambient-utils/types/token/TokenIF.ts
@@ -1,3 +1,10 @@
+import { tokenListURIs } from '../../constants';
+
+// string-union type of all acceptable values for `fromList` property
+type uris = typeof tokenListURIs[keyof typeof tokenListURIs];
+type otherTokenSources = 'on_chain_by_URL_param';
+type tokenProvenances = uris | otherTokenSources;
+
 export interface TokenIF {
     name: string;
     address: string;
@@ -5,7 +12,7 @@ export interface TokenIF {
     decimals: number;
     chainId: number;
     logoURI: string;
-    fromList?: string;
+    fromList?: tokenProvenances;
     listedBy?: string[];
     walletBalance?: string;
     dexBalance?: string;

--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -184,7 +184,12 @@ export const useUrlParams = (
         } else {
             // const provider = inflateProvider(chainId);
             if (provider) {
-                return fetchContractDetails(provider, addr, chainId);
+                return fetchContractDetails(
+                    provider,
+                    addr,
+                    chainId,
+                    'fetched_per_url_param',
+                );
             }
         }
     }

--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -188,7 +188,7 @@ export const useUrlParams = (
                     provider,
                     addr,
                     chainId,
-                    'fetched_per_url_param',
+                    'on_chain_by_URL_param',
                 );
             }
         }


### PR DESCRIPTION
### Describe your changes 
* Refactor `fetchContractDetails.ts` such that the `fromList` property of the token data object can be populated a custom value for its provenance.
* Refactor `TokenIF` such that `fromList` is typed as a string-union to force tokens to be labeled with a recognized provenance.
* Refactor `TokenIF` into `ServerTokenIF` (conforms to Uniswap standard) and an extended `TokenIF` (describes our internal specification).

### Link the related issue
Closes #3515

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**
Import a custom token by its hex address through the token selector.

**Environmental conditions that may result in expected but differential behavior.**
None.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
none, ready for merge!