### PR TITLE
bug fix: liq. chart highlighting not full width for ambient repos.

### DIFF
--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -258,6 +258,11 @@ function Reposition() {
     }, [position]);
 
     useEffect(() => {
+        if (rangeWidthPercentage !== undefined)
+            setSimpleRangeWidth(rangeWidthPercentage);
+    }, [rangeWidthPercentage]);
+
+    useEffect(() => {
         if (simpleRangeWidth !== rangeWidthPercentage) {
             setRangeWidthPercentage(simpleRangeWidth);
             const sliderInput = document.getElementById(


### PR DESCRIPTION
### Describe your changes 
Cengiz re-added a useEffect (with an added if statement) to sync the chart and the slider that had been removed to fix an issue where clicking Reposition from /account for a pool other than the one active resulted in an unpredictable range width.

### Link the related issue

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/c4808109-386b-4f78-b050-44c6407576d9)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
