### PR TITLE
fix bignumber parsing for some rewards displays

### DIFF
--- a/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
+++ b/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
@@ -140,8 +140,8 @@ function RangeDetailsModal(props: propsIF) {
                     position.askTick,
                 );
 
-                const baseRewards = positionRewards.baseRewards.toNumber();
-                const quoteRewards = positionRewards.quoteRewards.toNumber();
+                const baseRewards = parseFloat(positionRewards.baseRewards);
+                const quoteRewards = parseFloat(positionRewards.quoteRewards);
 
                 const feesLiqBaseDecimalCorrected =
                     baseRewards / Math.pow(10, position.baseDecimals);


### PR DESCRIPTION
### Describe your changes 
for some reason the .toNumber() function from the ethers bignumber library was failing, but switching to parseFloat seems to work.

### Link the related issue
rewards obtained from an SDK call were not appearing for some positions.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/c9945102-8536-44ca-8553-dc8bf25a4a13)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
