### PR TITLE
reset default range width to +/-10% for ETH/USDB

### DIFF
--- a/src/contexts/TradeDataContext.tsx
+++ b/src/contexts/TradeDataContext.tsx
@@ -148,7 +148,8 @@ export const TradeDataContextProvider = (props: {
             chainId === '0x13e31' &&
             baseAddress.toLowerCase() === blastETH.address.toLowerCase() &&
             quoteAddress.toLowerCase() === blastUSDB.address.toLowerCase();
-        const defaultWidth = isPoolBlastEthUSDB ? 5 : 10;
+        // temporarily reset to 10 for ETH/USDB until volatility reduces
+        const defaultWidth = isPoolBlastEthUSDB ? 10 : 10;
         return defaultWidth;
     };
 


### PR DESCRIPTION
### Describe your changes 
reset default range width to +/-10% for ETH/USDB

### Link the related issue
Doug
  [12:34 PM]
Probably should push default range in ETH/USDB back to 10% since volatility is high

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
