### PR TITLE
fix token symbol casing for token pair on /account

### DIFF
--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -257,7 +257,7 @@ export const orderRowConstants = (props: propsIF) => {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={linkGenLimit.getFullURL(limitLinkParams)}>
-                        <span>
+                        <span style={{ textTransform: 'none' }}>
                             {baseTokenSymbol} / {quoteTokenSymbol}
                         </span>
                         <FiExternalLink
@@ -275,7 +275,7 @@ export const orderRowConstants = (props: propsIF) => {
                         rel='noreferrer'
                     >
                         <div>
-                            <span>
+                            <span style={{ textTransform: 'none' }}>
                                 {baseTokenSymbol} / {quoteTokenSymbol}
                             </span>
                             <FiExternalLink

--- a/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/rangeRowConstants.tsx
@@ -260,7 +260,7 @@ export default function rangeRowConstants(props: propsIF) {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={linkGenPool.getFullURL(poolLinkParams)}>
-                        <span>
+                        <span style={{ textTransform: 'none' }}>
                             {baseTokenSymbol} / {quoteTokenSymbol}
                         </span>
                         <FiExternalLink
@@ -278,7 +278,7 @@ export default function rangeRowConstants(props: propsIF) {
                         rel='noreferrer'
                     >
                         <div>
-                            <span>
+                            <span style={{ textTransform: 'none' }}>
                                 {baseTokenSymbol} / {quoteTokenSymbol}
                             </span>
                             <FiExternalLink

--- a/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/txRowConstants.tsx
@@ -294,7 +294,7 @@ export const txRowConstants = (props: propsIF) => {
             {isOwnerActiveAccount ? (
                 <RowItem hover>
                     <Link to={tradeLinkPath}>
-                        <span>
+                        <span style={{ textTransform: 'none' }}>
                             {tx.baseSymbol} / {tx.quoteSymbol}
                         </span>
                         <FiExternalLink
@@ -308,7 +308,7 @@ export const txRowConstants = (props: propsIF) => {
                 <RowItem hover>
                     <a href={tradeLinkPath} target='_blank' rel='noreferrer'>
                         <div>
-                            <span>
+                            <span style={{ textTransform: 'none' }}>
                                 {tx.baseSymbol} / {tx.quoteSymbol}
                             </span>
                             <FiExternalLink


### PR DESCRIPTION
### Describe your changes 
prevent automatic uppercasing of token symbols in token pair displays on /account

### Link the related issue

these token symbols should start with a lowercase letter:

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/3e57cc91-3d86-4452-9036-7bb4d8432a25)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
