### PR TITLE
fix token logo order based on denom in tx/order/range details cards

### DIFF
--- a/src/ambient-utils/api/fetchBatch.ts
+++ b/src/ambient-utils/api/fetchBatch.ts
@@ -93,7 +93,7 @@ class AnalyticsBatchRequestManager {
                     body: JSON.stringify(queryObject),
                 },
                 AnalyticsBatchRequestManager.sendFrequency +
-                    (isPriceQuery ? 1400 : 2700),
+                    (isPriceQuery ? 1400 : 2900),
             );
 
             if (!response.ok) {

--- a/src/ambient-utils/dataLayer/functions/getFormattedNumber.ts
+++ b/src/ambient-utils/dataLayer/functions/getFormattedNumber.ts
@@ -79,6 +79,9 @@ export function getFormattedNumber({
         } else {
             valueString = formatSubscript(value);
         }
+    } else if (Math.abs(value) < 0.1) {
+        // show 4 significant digits (after 0s) -- useful for ETH/WBTC
+        valueString = value.toPrecision(4);
     } else if (Math.abs(value) < 0.9) {
         // show 3 significant digits (after 0s)
         valueString = value.toPrecision(3);

--- a/src/components/Global/TransactionDetails/TransactionDetailsModal.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsModal.tsx
@@ -153,6 +153,7 @@ function TransactionDetailsModal(props: propsIF) {
                         tx={tx}
                         controlItems={controlItems}
                         positionApy={updatedPositionApy}
+                        isAccountView={isAccountView}
                     />
                 </div>
                 <div className={styles.right_container}>

--- a/src/components/Global/TransactionDetails/TransactionDetailsPriceInfo/TransactionDetailsPriceInfo.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsPriceInfo/TransactionDetailsPriceInfo.tsx
@@ -24,10 +24,11 @@ interface propsIF {
     tx: TransactionIF;
     controlItems: ItemIF[];
     positionApy: number | undefined;
+    isAccountView: boolean;
 }
 
 export default function TransactionDetailsPriceInfo(props: propsIF) {
-    const { tx, controlItems, positionApy } = props;
+    const { tx, controlItems, positionApy, isAccountView } = props;
     const { userAddress } = useContext(UserDataContext);
 
     const { tokens } = useContext(TokenContext);
@@ -67,25 +68,37 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
 
     const isBuy = tx.isBuy === true || tx.isBid === true;
 
+    const baseIcon = (
+        <TokenIcon
+            token={baseToken}
+            src={uriToHttp(baseTokenLogo)}
+            alt={baseTokenSymbol}
+            size='2xl'
+        />
+    );
+
+    const quoteIcon = (
+        <TokenIcon
+            token={quoteToken}
+            src={uriToHttp(quoteTokenLogo)}
+            alt={quoteTokenSymbol}
+            size='2xl'
+        />
+    );
+
+    const isDenomBaseLocal = isAccountView
+        ? !isBaseTokenMoneynessGreaterOrEqual
+        : isDenomBase;
+
     const tokenPairDetails = (
         <div className={styles.token_pair_details}>
             <div className={styles.token_pair_images}>
-                <TokenIcon
-                    token={baseToken}
-                    src={uriToHttp(baseTokenLogo)}
-                    alt={baseTokenSymbol}
-                    size='2xl'
-                />
-                <TokenIcon
-                    token={quoteToken}
-                    src={uriToHttp(quoteTokenLogo)}
-                    alt={quoteTokenSymbol}
-                    size='2xl'
-                />
+                {isDenomBaseLocal ? baseIcon : quoteIcon}
+                {isDenomBaseLocal ? quoteIcon : baseIcon}
             </div>
             <p>
-                {isDenomBase ? baseTokenSymbol : quoteTokenSymbol} /{' '}
-                {isDenomBase ? quoteTokenSymbol : baseTokenSymbol}
+                {isDenomBaseLocal ? baseTokenSymbol : quoteTokenSymbol} /{' '}
+                {isDenomBaseLocal ? quoteTokenSymbol : baseTokenSymbol}
             </p>
         </div>
     );
@@ -301,13 +314,13 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
             ) : isOnTradeRoute ? (
                 <span className={styles.min_price}>
                     {truncatedDisplayPrice
-                        ? isDenomBase
+                        ? isDenomBaseLocal
                             ? quoteTokenCharacter + truncatedDisplayPrice
                             : baseTokenCharacter + truncatedDisplayPrice
                         : null}
 
                     {truncatedLowDisplayPrice
-                        ? isDenomBase
+                        ? isDenomBaseLocal
                             ? quoteTokenCharacter + truncatedLowDisplayPrice
                             : baseTokenCharacter + truncatedLowDisplayPrice
                         : null}
@@ -315,7 +328,7 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
                         <AiOutlineLine style={{ paddingTop: '6px' }} />
                     ) : null}
                     {truncatedHighDisplayPrice
-                        ? isDenomBase
+                        ? isDenomBaseLocal
                             ? quoteTokenCharacter + truncatedHighDisplayPrice
                             : baseTokenCharacter + truncatedHighDisplayPrice
                         : null}
@@ -367,14 +380,14 @@ export default function TransactionDetailsPriceInfo(props: propsIF) {
             <div className={styles.price_info_container}>
                 {tokenPairDetails}
                 {txTypeContent}
-                {isDenomBase
+                {isDenomBaseLocal
                     ? isBuy
                         ? sellBaseRow
                         : buyBaseRow
                     : isBuy
                     ? buyQuoteRow
                     : sellQuoteRow}
-                {isDenomBase
+                {isDenomBaseLocal
                     ? isBuy
                         ? buyQuoteRow
                         : sellQuoteRow

--- a/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
+++ b/src/components/Global/TransactionDetails/TransactionDetailsSimplify/TransactionDetailsSimplify.tsx
@@ -312,12 +312,12 @@ function TransactionDetailsSimplify(props: TransactionDetailsSimplifyPropsIF) {
                             : isDenomBase
                             ? `1 ${baseTokenSymbol} = ${truncatedDisplayPrice} ${quoteTokenSymbol}`
                             : `1 ${quoteTokenSymbol} = ${truncatedDisplayPrice} ${baseTokenSymbol}`
+                        : isAmbient
+                        ? '0.00'
                         : isAccountView
                         ? isBaseTokenMoneynessGreaterOrEqual
                             ? `1 ${quoteTokenSymbol} = ${truncatedLowDisplayPriceDenomByMoneyness} ${baseTokenSymbol}`
                             : `1 ${baseTokenSymbol} = ${truncatedLowDisplayPriceDenomByMoneyness} ${quoteTokenSymbol}`
-                        : isAmbient
-                        ? '0.00'
                         : isDenomBase
                         ? `1 ${baseTokenSymbol} = ${truncatedLowDisplayPrice} ${quoteTokenSymbol}`
                         : `1 ${quoteTokenSymbol} = ${truncatedLowDisplayPrice} ${baseTokenSymbol}`}
@@ -344,12 +344,12 @@ function TransactionDetailsSimplify(props: TransactionDetailsSimplifyPropsIF) {
             : [
                   {
                       title: 'High Price Boundary',
-                      content: isAccountView
+                      content: isAmbient
+                          ? '∞'
+                          : isAccountView
                           ? isBaseTokenMoneynessGreaterOrEqual
                               ? `1 ${quoteTokenSymbol} = ${truncatedHighDisplayPriceDenomByMoneyness} ${baseTokenSymbol}`
                               : `1 ${baseTokenSymbol} = ${truncatedHighDisplayPriceDenomByMoneyness} ${quoteTokenSymbol}`
-                          : isAmbient
-                          ? '∞'
                           : isDenomBase
                           ? `1 ${baseTokenSymbol} = ${truncatedHighDisplayPrice} ${quoteTokenSymbol}`
                           : `1 ${quoteTokenSymbol} = ${truncatedHighDisplayPrice} ${baseTokenSymbol}`,

--- a/src/components/OrderDetails/OrderDetailsModal/OrderDetailsModal.tsx
+++ b/src/components/OrderDetails/OrderDetailsModal/OrderDetailsModal.tsx
@@ -260,6 +260,10 @@ export default function OrderDetailsModal(props: propsIF) {
                         baseTokenAddress={baseTokenAddress}
                         quoteTokenAddress={quoteTokenAddress}
                         fillPercentage={fillPercentage}
+                        isAccountView={isAccountView}
+                        isBaseTokenMoneynessGreaterOrEqual={
+                            isBaseTokenMoneynessGreaterOrEqual
+                        }
                     />
                 </div>
                 <div className={styles.right_container}>

--- a/src/components/OrderDetails/OrderDetailsSimplify/OrderDetailsSimplify.tsx
+++ b/src/components/OrderDetails/OrderDetailsSimplify/OrderDetailsSimplify.tsx
@@ -71,10 +71,10 @@ function OrderDetailsSimplify(props: OrderDetailsSimplifyPropsIF) {
         quoteTokenAddressLowerCase,
         startPriceDisplay,
         middlePriceDisplay,
-        truncatedDisplayPrice,
-        truncatedDisplayPriceDenomByMoneyness,
+        finishPriceDisplay,
         startPriceDisplayDenomByMoneyness,
         middlePriceDisplayDenomByMoneyness,
+        finishPriceDisplayDenomByMoneyness,
         isLimitOrderPartiallyFilled,
         fillPercentage,
         isBaseTokenMoneynessGreaterOrEqual,
@@ -326,11 +326,11 @@ function OrderDetailsSimplify(props: OrderDetailsSimplifyPropsIF) {
             title: 'Fill End ',
             content: isAccountView
                 ? isBaseTokenMoneynessGreaterOrEqual
-                    ? `1  ${quoteTokenSymbol} = ${truncatedDisplayPriceDenomByMoneyness}  ${baseTokenSymbol}`
-                    : `1  ${baseTokenSymbol} = ${truncatedDisplayPriceDenomByMoneyness}  ${quoteTokenSymbol}`
+                    ? `1  ${quoteTokenSymbol} = ${finishPriceDisplayDenomByMoneyness}  ${baseTokenSymbol}`
+                    : `1  ${baseTokenSymbol} = ${finishPriceDisplayDenomByMoneyness}  ${quoteTokenSymbol}`
                 : isDenomBase
-                ? `1  ${baseTokenSymbol} = ${truncatedDisplayPrice}  ${quoteTokenSymbol}`
-                : `1  ${quoteTokenSymbol} = ${truncatedDisplayPrice}  ${baseTokenSymbol}`,
+                ? `1  ${baseTokenSymbol} = ${finishPriceDisplay}  ${quoteTokenSymbol}`
+                : `1  ${quoteTokenSymbol} = ${finishPriceDisplay}  ${baseTokenSymbol}`,
 
             explanation:
                 'Price at which conversion ends and limit order can be claimed',

--- a/src/components/OrderDetails/PriceInfo/PriceInfo.tsx
+++ b/src/components/OrderDetails/PriceInfo/PriceInfo.tsx
@@ -37,6 +37,8 @@ interface propsIF {
     baseTokenAddress: string;
     quoteTokenAddress: string;
     fillPercentage: number;
+    isAccountView: boolean;
+    isBaseTokenMoneynessGreaterOrEqual: boolean;
 }
 
 export default function PriceInfo(props: propsIF) {
@@ -56,6 +58,8 @@ export default function PriceInfo(props: propsIF) {
         baseTokenAddress,
         quoteTokenAddress,
         fillPercentage,
+        isAccountView,
+        isBaseTokenMoneynessGreaterOrEqual,
     } = props;
 
     const { pathname } = useLocation();
@@ -65,6 +69,10 @@ export default function PriceInfo(props: propsIF) {
     const quoteToken: TokenIF | undefined =
         tokens.getTokenByAddress(quoteTokenAddress);
     const isOnTradeRoute = pathname.includes('trade');
+
+    const isDenomBaseLocal = isAccountView
+        ? !isBaseTokenMoneynessGreaterOrEqual
+        : isDenomBase;
 
     const isLimitOrderPartiallyFilled = isFillStarted && !isOrderFilled;
 
@@ -110,25 +118,37 @@ export default function PriceInfo(props: propsIF) {
         </div>
     );
 
+    const baseTokenLargeDisplay = (
+        <TokenIcon
+            token={baseToken}
+            src={baseTokenLogo}
+            alt={baseTokenSymbol}
+            size='2xl'
+        />
+    );
+
+    const quoteTokenLargeDisplay = (
+        <TokenIcon
+            token={quoteToken}
+            src={quoteTokenLogo}
+            alt={quoteTokenSymbol}
+            size='2xl'
+        />
+    );
+
     const tokenPairDetails = (
         <div className={styles.token_pair_details}>
             <div className={styles.token_pair_images}>
-                <TokenIcon
-                    token={baseToken}
-                    src={baseTokenLogo}
-                    alt={baseTokenSymbol}
-                    size='2xl'
-                />
-                <TokenIcon
-                    token={quoteToken}
-                    src={quoteTokenLogo}
-                    alt={quoteTokenSymbol}
-                    size='2xl'
-                />
+                {isDenomBaseLocal
+                    ? baseTokenLargeDisplay
+                    : quoteTokenLargeDisplay}
+                {isDenomBaseLocal
+                    ? quoteTokenLargeDisplay
+                    : baseTokenLargeDisplay}
             </div>
             <p>
-                {isDenomBase ? baseTokenSymbol : quoteTokenSymbol} /{' '}
-                {isDenomBase ? quoteTokenSymbol : baseTokenSymbol}
+                {isDenomBaseLocal ? baseTokenSymbol : quoteTokenSymbol} /{' '}
+                {isDenomBaseLocal ? quoteTokenSymbol : baseTokenSymbol}
             </p>
         </div>
     );
@@ -173,10 +193,10 @@ export default function PriceInfo(props: propsIF) {
             <div className={styles.price_info_container}>
                 {tokenPairDetails}
                 {orderType}
-                {(isDenomBase && isBid) || (!isDenomBase && !isBid)
+                {(isDenomBaseLocal && isBid) || (!isDenomBaseLocal && !isBid)
                     ? sellContent
                     : buyContent}
-                {(isDenomBase && isBid) || (!isDenomBase && !isBid)
+                {(isDenomBaseLocal && isBid) || (!isDenomBaseLocal && !isBid)
                     ? buyContent
                     : sellContent}
                 {totalValue}

--- a/src/components/RangeDetails/PriceInfo/PriceInfo.module.css
+++ b/src/components/RangeDetails/PriceInfo/PriceInfo.module.css
@@ -81,7 +81,7 @@
     flex-direction: row;
     align-items: center;
     justify-content: space-between;
-    padding: 0 1rem;
+    padding: 0 10px;
 }
 .price_status_content section {
     display: flex;
@@ -127,11 +127,11 @@
     line-height: var(--body-lh);
     color: var(--text2)
 } */
-.divider{
+.divider {
     width: 100%;
     height: 1px;
     background: var(--dark3);
-   margin: 4px 0;
+    margin: 4px 0;
 }
 @media only screen and (min-width: 768px) {
     .price_info_container,

--- a/src/components/RangeDetails/PriceInfo/PriceInfo.tsx
+++ b/src/components/RangeDetails/PriceInfo/PriceInfo.tsx
@@ -33,6 +33,8 @@ interface propsIF {
     baseTokenAddress: string;
     quoteTokenAddress: string;
     blastPointsData: BlastPointsDataIF;
+    isBaseTokenMoneynessGreaterOrEqual: boolean;
+    isAccountView: boolean;
 }
 
 export default function PriceInfo(props: propsIF) {
@@ -56,6 +58,8 @@ export default function PriceInfo(props: propsIF) {
         baseTokenAddress,
         quoteTokenAddress,
         blastPointsData,
+        isBaseTokenMoneynessGreaterOrEqual,
+        isAccountView,
     } = props;
 
     const { pathname } = useLocation();
@@ -64,6 +68,11 @@ export default function PriceInfo(props: propsIF) {
     const isOnTradeRoute = pathname.includes('trade');
     const { tokens } = useContext(TokenContext);
     const { isActiveNetworkBlast } = useContext(ChainDataContext);
+
+    const isDenomBaseLocal = isAccountView
+        ? !isBaseTokenMoneynessGreaterOrEqual
+        : isDenomBase;
+
     const baseToken: TokenIF | undefined =
         tokens.getTokenByAddress(baseTokenAddress);
     const quoteToken: TokenIF | undefined =
@@ -151,25 +160,37 @@ export default function PriceInfo(props: propsIF) {
         </div>
     );
 
+    const baseTokenLargeDisplay = (
+        <TokenIcon
+            token={baseToken}
+            src={baseTokenLogoURI}
+            alt={baseTokenSymbol}
+            size='2xl'
+        />
+    );
+
+    const quoteTokenLargeDisplay = (
+        <TokenIcon
+            token={quoteToken}
+            src={quoteTokenLogoURI}
+            alt={quoteTokenSymbol}
+            size='2xl'
+        />
+    );
+
     const tokenPairDetails = (
         <div className={styles.token_pair_details}>
             <div className={styles.token_pair_images}>
-                <TokenIcon
-                    token={baseToken}
-                    src={baseTokenLogoURI}
-                    alt={baseTokenSymbol}
-                    size='2xl'
-                />
-                <TokenIcon
-                    token={quoteToken}
-                    src={quoteTokenLogoURI}
-                    alt={quoteTokenSymbol}
-                    size='2xl'
-                />
+                {isDenomBaseLocal
+                    ? baseTokenLargeDisplay
+                    : quoteTokenLargeDisplay}
+                {isDenomBaseLocal
+                    ? quoteTokenLargeDisplay
+                    : baseTokenLargeDisplay}
             </div>
             <p>
-                {isDenomBase ? baseTokenSymbol : quoteTokenSymbol} /{' '}
-                {isDenomBase ? quoteTokenSymbol : baseTokenSymbol}
+                {isDenomBaseLocal ? baseTokenSymbol : quoteTokenSymbol} /{' '}
+                {isDenomBaseLocal ? quoteTokenSymbol : baseTokenSymbol}
             </p>
         </div>
     );

--- a/src/components/RangeDetails/PriceInfo/PriceInfo.tsx
+++ b/src/components/RangeDetails/PriceInfo/PriceInfo.tsx
@@ -35,6 +35,8 @@ interface propsIF {
     blastPointsData: BlastPointsDataIF;
     isBaseTokenMoneynessGreaterOrEqual: boolean;
     isAccountView: boolean;
+    baseTokenCharacter: string;
+    quoteTokenCharacter: string;
 }
 
 export default function PriceInfo(props: propsIF) {
@@ -60,6 +62,8 @@ export default function PriceInfo(props: propsIF) {
         blastPointsData,
         isBaseTokenMoneynessGreaterOrEqual,
         isAccountView,
+        baseTokenCharacter,
+        quoteTokenCharacter,
     } = props;
 
     const { pathname } = useLocation();
@@ -142,8 +146,12 @@ export default function PriceInfo(props: propsIF) {
                     {isAmbient
                         ? '0'
                         : isOnTradeRoute
-                        ? lowRangeDisplay
-                        : minRangeDenomByMoneyness}
+                        ? (isDenomBaseLocal
+                              ? quoteTokenCharacter
+                              : baseTokenCharacter) + lowRangeDisplay
+                        : (isDenomBaseLocal
+                              ? quoteTokenCharacter
+                              : baseTokenCharacter) + minRangeDenomByMoneyness}
                 </h2>
             </section>
 
@@ -153,8 +161,12 @@ export default function PriceInfo(props: propsIF) {
                     {isAmbient
                         ? '∞'
                         : isOnTradeRoute
-                        ? highRangeDisplay
-                        : maxRangeDenomByMoneyness}
+                        ? (isDenomBaseLocal
+                              ? quoteTokenCharacter
+                              : baseTokenCharacter) + highRangeDisplay
+                        : (isDenomBaseLocal
+                              ? quoteTokenCharacter
+                              : baseTokenCharacter) + maxRangeDenomByMoneyness}
                 </h2>
             </section>
         </div>

--- a/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
+++ b/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
@@ -71,6 +71,8 @@ function RangeDetailsModal(props: propsIF) {
         maxRangeDenomByMoneyness,
         ambientOrMin: lowRangeDisplay,
         ambientOrMax: highRangeDisplay,
+        baseTokenCharacter,
+        quoteTokenCharacter,
     } = useProcessRange(position, userAddress);
 
     const [serverPositionId, setServerPositionId] = useState<
@@ -456,6 +458,8 @@ function RangeDetailsModal(props: propsIF) {
                             isBaseTokenMoneynessGreaterOrEqual
                         }
                         isAccountView={isAccountView}
+                        baseTokenCharacter={baseTokenCharacter}
+                        quoteTokenCharacter={quoteTokenCharacter}
                     />
                 </div>
                 <div className={styles.right_container}>

--- a/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
+++ b/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
@@ -452,6 +452,10 @@ function RangeDetailsModal(props: propsIF) {
                         baseTokenAddress={baseTokenAddress}
                         quoteTokenAddress={quoteTokenAddress}
                         blastPointsData={blastPointsData}
+                        isBaseTokenMoneynessGreaterOrEqual={
+                            isBaseTokenMoneynessGreaterOrEqual
+                        }
+                        isAccountView={isAccountView}
                     />
                 </div>
                 <div className={styles.right_container}>

--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -382,7 +382,6 @@ export const orderRowConstants = (props: propsIF) => {
         >
             {(
                 <p>
-                    {/* <span>{priceCharacter}</span> */}
                     <span>
                         {isAccountView
                             ? truncatedDisplayPriceDenomByMoneyness

--- a/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
+++ b/src/components/Trade/TradeTabs/Orders/orderRowConstants.tsx
@@ -77,7 +77,6 @@ export const orderRowConstants = (props: propsIF) => {
         quoteTokenSymbol,
         elapsedTimeString,
         isAccountView,
-        priceCharacter,
         truncatedDisplayPrice,
         truncatedDisplayPriceDenomByMoneyness,
         sideType,
@@ -383,7 +382,7 @@ export const orderRowConstants = (props: propsIF) => {
         >
             {(
                 <p>
-                    <span>{priceCharacter}</span>
+                    {/* <span>{priceCharacter}</span> */}
                     <span>
                         {isAccountView
                             ? truncatedDisplayPriceDenomByMoneyness

--- a/src/utils/hooks/useProcessOrder.ts
+++ b/src/utils/hooks/useProcessOrder.ts
@@ -121,6 +121,10 @@ export const useProcessOrder = (
     const [finishPriceDisplay, setFinishPriceDisplay] = useState<
         string | undefined
     >();
+    const [
+        finishPriceDisplayDenomByMoneyness,
+        setFinishPriceDisplayDenomByMoneyness,
+    ] = useState<string | undefined>();
     const [initialTokenQty, setInitialTokenQty] = useState<string | undefined>(
         undefined,
     );
@@ -288,12 +292,12 @@ export const useProcessOrder = (
 
             const truncatedDisplayPriceDenomByMoneyness =
                 isBaseTokenMoneynessGreaterOrEqual
-                    ? nonInvertedPriceTruncated
-                    : invertedPriceTruncated;
+                    ? baseTokenCharacter + nonInvertedPriceTruncated
+                    : quoteTokenCharacter + invertedPriceTruncated;
 
             const truncatedDisplayPrice = isDenomBase
-                ? `${invertedPriceTruncated}`
-                : `${nonInvertedPriceTruncated}`;
+                ? `${quoteTokenCharacter}${invertedPriceTruncated}`
+                : `${baseTokenCharacter}${nonInvertedPriceTruncated}`;
 
             setTruncatedDisplayPrice(truncatedDisplayPrice);
             setTruncatedDisplayPriceDenomByMoneyness(
@@ -388,6 +392,19 @@ export const useProcessOrder = (
                 ? bidTickPrice
                 : askTickPrice;
 
+            const finishPriceDenomByMoneyness =
+                isBaseTokenMoneynessGreaterOrEqual
+                    ? isBid
+                        ? bidTickInvPrice
+                        : askTickInvPrice
+                    : isBid
+                    ? bidTickPrice
+                    : askTickPrice;
+
+            const finishPriceDisplayDenomByMoneyness = getFormattedNumber({
+                value: finishPriceDenomByMoneyness,
+            });
+
             const finishPriceDisplay = getFormattedNumber({
                 value: finishPriceDisplayNum,
             });
@@ -401,6 +418,9 @@ export const useProcessOrder = (
             );
             setMiddlePriceDisplay(middlePriceDisplay);
             setFinishPriceDisplay(finishPriceDisplay);
+            setFinishPriceDisplayDenomByMoneyness(
+                finishPriceDisplayDenomByMoneyness,
+            );
 
             const finalTokenQty = !isBid
                 ? limitOrder.claimableLiqBaseDecimalCorrected
@@ -484,6 +504,7 @@ export const useProcessOrder = (
         middlePriceDisplay,
         middlePriceDisplayDenomByMoneyness,
         finishPriceDisplay,
+        finishPriceDisplayDenomByMoneyness,
 
         // transaction matches selected token
         orderMatchesSelectedTokens,

--- a/src/utils/hooks/useProcessRange.ts
+++ b/src/utils/hooks/useProcessRange.ts
@@ -144,9 +144,6 @@ export const useProcessRange = (
     const minRange = isDenomBase
         ? position.lowRangeDisplayInBase
         : position.lowRangeDisplayInQuote;
-    // const minRange = isDenomBase
-    //     ? quoteTokenCharacter + position.lowRangeDisplayInBase
-    //     : baseTokenCharacter + position.lowRangeDisplayInQuote;
 
     const minRangeDenomByMoneyness = isBaseTokenMoneynessGreaterOrEqual
         ? position.lowRangeDisplayInQuote
@@ -159,9 +156,6 @@ export const useProcessRange = (
     const maxRange = isDenomBase
         ? position.highRangeDisplayInBase
         : position.highRangeDisplayInQuote;
-    // const maxRange = isDenomBase
-    //     ? quoteTokenCharacter + position.highRangeDisplayInBase
-    //     : baseTokenCharacter + position.highRangeDisplayInQuote;
 
     const ambientOrMin = position.positionType === 'ambient' ? '0' : minRange;
     const ambientOrMax = position.positionType === 'ambient' ? '∞' : maxRange;


### PR DESCRIPTION
### Describe your changes 


### Link the related issue
in some scenarios, the token logos appeared in reverse order of the active denomination: 
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/e58622b9-2a56-43f2-b004-c66888af7ce1)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
