### PR TITLE
Add batched RPC proxy

### DIFF
--- a/src/contexts/CrocEnvContext.tsx
+++ b/src/contexts/CrocEnvContext.tsx
@@ -12,6 +12,7 @@ import { useBlacklist } from '../App/hooks/useBlacklist';
 import { useTopPools } from '../App/hooks/useTopPools';
 import { CachedDataContext } from './CachedDataContext';
 import { Provider } from '@ethersproject/providers';
+import { BatchedJsonRpcProvider } from '../utils/batchedProvider';
 import {
     limitParamsIF,
     linkGenMethodsIF,
@@ -60,13 +61,19 @@ interface CrocEnvContextIF {
 export const CrocEnvContext = createContext<CrocEnvContextIF>(
     {} as CrocEnvContextIF,
 );
-const mainnetProvider = new ethers.providers.InfuraProvider(
-    'mainnet',
-    process.env.REACT_APP_INFURA_KEY || '360ea5fda45b4a22883de8522ebd639e',
-);
+const mainnetProvider = new BatchedJsonRpcProvider(
+    new ethers.providers.InfuraProvider(
+        'mainnet',
+        process.env.REACT_APP_INFURA_KEY || '360ea5fda45b4a22883de8522ebd639e',
+    ),
+).proxy;
 
-const scrollProvider = new ethers.providers.JsonRpcProvider(SCROLL_RPC_URL);
-const blastProvider = new ethers.providers.JsonRpcProvider(BLAST_RPC_URL);
+const scrollProvider = new BatchedJsonRpcProvider(
+    new ethers.providers.JsonRpcProvider(SCROLL_RPC_URL),
+).proxy;
+const blastProvider = new BatchedJsonRpcProvider(
+    new ethers.providers.JsonRpcProvider(BLAST_RPC_URL),
+).proxy;
 
 export const CrocEnvContextProvider = (props: { children: ReactNode }) => {
     const { cachedFetchTokenPrice } = useContext(CachedDataContext);

--- a/src/utils/batchedProvider.ts
+++ b/src/utils/batchedProvider.ts
@@ -1,0 +1,354 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+import { JsonRpcProvider } from '@ethersproject/providers';
+import { Contract } from 'ethers';
+
+export const MULTICALL_ABI = [
+    {
+        name: 'aggregate3',
+        inputs: [
+            {
+                components: [
+                    {
+                        internalType: 'address',
+                        name: 'target',
+                        type: 'address',
+                    },
+                    {
+                        internalType: 'bool',
+                        name: 'allowFailure',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bytes',
+                        name: 'callData',
+                        type: 'bytes',
+                    },
+                ],
+                internalType: 'struct Multicall3.Call3[]',
+                name: 'calls',
+                type: 'tuple[]',
+            },
+        ],
+        outputs: [
+            {
+                components: [
+                    {
+                        internalType: 'bool',
+                        name: 'success',
+                        type: 'bool',
+                    },
+                    {
+                        internalType: 'bytes',
+                        name: 'returnData',
+                        type: 'bytes',
+                    },
+                ],
+                internalType: 'struct Multicall3.Result[]',
+                name: 'returnData',
+                type: 'tuple[]',
+            },
+        ],
+        stateMutability: 'payable',
+        type: 'function',
+    },
+];
+
+const MULTICALL_ADDRESSES: Map<number, string> = new Map([
+    [1, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [5, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [7700, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [7701, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [81457, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [534351, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [534352, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [11155111, '0xca11bde05977b3631167028862be2a173976ca11'],
+    [168587773, '0xca11bde05977b3631167028862be2a173976ca11'],
+]);
+
+export type JsonRpcPayload = {
+    id: number;
+    method: string;
+    params: EthCallWithBlockTag;
+    jsonrpc: '2.0';
+};
+
+type EthCallParams = {
+    to: string;
+    data: string;
+};
+
+type EthCallWithBlockTag = [EthCallParams, string];
+
+export type JsonRpcResult = {
+    id: number;
+    result: any;
+};
+type ResolveFunc = (result: JsonRpcResult) => void;
+type RejectFunc = (error: Error) => void;
+type Payload = {
+    payload: JsonRpcPayload;
+    resolve: ResolveFunc;
+    reject: RejectFunc;
+};
+type Timer = ReturnType<typeof setTimeout>;
+
+type CachedResponse = {
+    response: any;
+    validUntil: Date;
+};
+
+export class BatchedJsonRpcProvider {
+    provider: JsonRpcProvider;
+    multicall: Multicall;
+    payloads: Array<Payload>;
+    drainTimer: null | Timer;
+    nextId: number;
+    batchOptions: {
+        batchMaxCount: number;
+        batchMaxSizeBytes: number;
+        batchStallTimeMs: number;
+    };
+    cachedCalls: Map<string, CachedResponse>;
+    proxy: JsonRpcProvider;
+    constructor(provider: JsonRpcProvider) {
+        this.multicall = new Multicall(provider);
+        this.payloads = [];
+        this.drainTimer = null;
+        this.nextId = 0;
+        this.batchOptions = {
+            batchMaxCount: 20,
+            batchMaxSizeBytes: 1000000,
+            batchStallTimeMs: 20,
+        };
+        this.cachedCalls = new Map();
+        this.provider = provider;
+        this.proxy = new Proxy(provider, {
+            get: (target, prop, receiver) => {
+                // override only the send method
+                if (prop === 'send') {
+                    return (...args: any[]) => {
+                        try {
+                            return this.send(args[0], args[1]);
+                        } catch (e) {
+                            console.error(
+                                'multicall failed, calling directly',
+                                e,
+                            );
+                            return this.provider.send(args[0], args[1]);
+                        }
+                    };
+                }
+                return Reflect.get(target, prop, receiver);
+            },
+        });
+    }
+
+    async send(method: string, params: any[]): Promise<any> {
+        // console.log(method, params, params[0]?.['data']);
+        if (!this.multicall.initialized) {
+            this.multicall.initialize();
+        }
+        if (method == 'eth_chainId' || method == 'eth_accounts') {
+            return this.sendCached(method, params);
+        } else if (method != 'eth_call' || !this.multicall.ready) {
+            return this.provider.send(method, params);
+        } else {
+            const callParams = params as EthCallWithBlockTag;
+            if (callParams[1] != 'latest') {
+                return this.provider.send(method, params);
+            }
+            return this.scheduleForBatch(callParams);
+        }
+    }
+
+    scheduleForBatch(call: EthCallWithBlockTag): Promise<any> {
+        return new Promise((resolve, reject) => {
+            const payload: JsonRpcPayload = {
+                id: this.nextId++,
+                method: 'eth_call',
+                params: call,
+                jsonrpc: '2.0',
+            };
+            this.payloads.push({
+                payload,
+                resolve,
+                reject: (_) => {
+                    // attempt to call directly if multicall fails
+                    this.provider
+                        .send(payload.method, payload.params)
+                        .then(resolve)
+                        .catch(reject);
+                },
+            });
+            this.scheduleDrain();
+        });
+    }
+
+    async sendCached(method: string, params: any[]): Promise<any> {
+        const cacheKey = JSON.stringify({ method, params });
+        const cachedResponse = this.cachedCalls.get(cacheKey);
+        if (cachedResponse && cachedResponse.validUntil > new Date()) {
+            return cachedResponse.response;
+        }
+        const response = this.provider.send(method, params);
+        // I don't think there's a reason to not cache these forever, but it might break some obscure use case.
+        this.cachedCalls.set(cacheKey, {
+            response,
+            validUntil: new Date(Date.now() + 9999999999),
+        });
+        return response;
+    }
+
+    scheduleDrain() {
+        if (this.drainTimer) {
+            return;
+        }
+        const stallTime =
+            this.batchOptions.batchMaxCount === 1
+                ? 0
+                : this.batchOptions.batchStallTimeMs;
+
+        this.drainTimer = setTimeout(async () => {
+            this.drainTimer = null;
+
+            const payloads = this.payloads;
+            this.payloads = [];
+
+            while (payloads.length) {
+                const batch = [payloads.shift() as Payload];
+                while (payloads.length) {
+                    if (batch.length === this.batchOptions.batchMaxCount) {
+                        break;
+                    }
+                    batch.push(payloads.shift() as Payload);
+                    const bytes = JSON.stringify(batch.map((p) => p.payload));
+                    if (bytes.length > this.batchOptions.batchMaxSizeBytes) {
+                        payloads.unshift(batch.pop() as Payload);
+                        break;
+                    }
+                }
+                await (async () => {
+                    if (batch.length === 1) {
+                        this.provider
+                            .send(
+                                batch[0].payload.method,
+                                batch[0].payload.params,
+                            )
+                            .then(batch[0].resolve)
+                            .catch(batch[0].reject);
+                        return;
+                    }
+
+                    const payload = batch.map((p) => p.payload);
+
+                    try {
+                        const results = await this.multicall.sendMulticall(
+                            payload,
+                        );
+                        for (const { resolve, reject, payload } of batch) {
+                            const resp = results.filter(
+                                (r: any) => r.id === payload.id,
+                            )[0];
+
+                            if (resp == null || resp == undefined) {
+                                console.error('missing batched resp');
+                                reject(
+                                    new Error('missing response for request'),
+                                );
+                                continue;
+                            }
+
+                            if ('error' in resp) {
+                                console.error(
+                                    'error in batched response',
+                                    resp.error,
+                                );
+                                reject(new Error(resp.error));
+                                continue;
+                            }
+
+                            resolve(resp.result);
+                        }
+                    } catch (error) {
+                        for (const { reject } of batch) {
+                            console.error('error in batched catch', error);
+                            reject(error);
+                        }
+                    }
+                })();
+            }
+        }, stallTime);
+    }
+}
+
+class Multicall {
+    provider: JsonRpcProvider;
+    contract: Contract | null | undefined;
+    constructor(provider: JsonRpcProvider) {
+        this.provider = provider;
+        this.contract = undefined;
+    }
+
+    async initialize() {
+        if (this.contract === undefined) {
+            try {
+                const chainId = this.provider.network.chainId;
+                if (this.contract === undefined && chainId) {
+                    const multicallAddress = MULTICALL_ADDRESSES.get(chainId);
+                    if (multicallAddress) {
+                        this.contract = new Contract(
+                            multicallAddress,
+                            MULTICALL_ABI,
+                            this.provider,
+                        );
+                    } else {
+                        this.contract = null;
+                        console.warn(
+                            'No multicall address found for chainId:',
+                            chainId,
+                        );
+                    }
+                }
+            } catch (e) {
+                this.contract = null;
+                console.error('Error initializing multicall contract:', e);
+            }
+        }
+    }
+
+    async sendMulticall(payload: Array<JsonRpcPayload>): Promise<any[]> {
+        if (!this.contract) {
+            throw new Error('Multicall contract not ready');
+        }
+
+        const calls = payload.map((p) => {
+            return {
+                target: p.params[0].to,
+                callData: p.params[0].data,
+            };
+        });
+
+        const preparedCalls = calls.map((c) => {
+            return [c.target, true, c.callData];
+        });
+        const rawResults = await this.contract.callStatic.aggregate3(
+            preparedCalls,
+        );
+        const results = rawResults.map((r: any, i: number) => {
+            return {
+                id: payload[i].id,
+                result: r.success ? r.returnData : undefined,
+            };
+        });
+
+        return results;
+    }
+
+    get initialized(): boolean {
+        return this.contract !== undefined;
+    }
+
+    get ready(): boolean {
+        return this.contract !== undefined && this.contract !== null;
+    }
+}


### PR DESCRIPTION
### Describe your changes 
Added a proxy RPC provider that batches `eth_call` requests and sends them to the [multicall](https://github.com/mds1/multicall) contract. Currently it's configured to send batches of either 20 requests or as many as have been collected within a 20ms stall window. If there's any kind of error during a multicall then a direct call will be attempted, so there should be no downside compared to the current code.

The proxy also caches forever responses to `eth_chainId` and `eth_accounts` requests. I don't think this will break anything, but usually these aren't supposed to be cached for very long. I don't think this applies to our use case though.

Most of the code here is adapted from [ethers v6](https://github.com/ethers-io/ethers.js/blob/main/src.ts/providers/provider-jsonrpc.ts#L504), so this is a stopgap solution until we upgrade from v5.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [X] I have performed a self-review of my code.
- [X] Did I request feedback from a team member prior to the merge? 
- [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1. Click on stuff, look at the RPC calls in the network tab.

**Environmental conditions that may result in expected but differential behavior.**

1. Some RPC providers don't like large payloads. Since the frontend specifies its own RPC URL, this can be checked ahead of time (and there's a fallback to direct calls anyway, so any failure shouldn't be catastrophic).

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
