### PR TITLE
fix neverending input spinner when impact query fails

### DIFF
--- a/src/components/Form/TokenInputWithWalletBalance.tsx
+++ b/src/components/Form/TokenInputWithWalletBalance.tsx
@@ -147,7 +147,6 @@ function TokenInputWithWalletBalance(props: propsIF) {
                 onMaxButtonClick={
                     !hideWalletMaxButton ? handleMaxButtonClick : undefined
                 }
-                onRefresh={handleRefresh}
             />
         </>
     );

--- a/src/components/Form/WalletBalanceSubinfo.tsx
+++ b/src/components/Form/WalletBalanceSubinfo.tsx
@@ -20,7 +20,6 @@ interface PropsIF {
     onToggleDex: () => void;
     availableBalance?: number;
     onMaxButtonClick?: () => void;
-    onRefresh?: () => void;
 }
 export default function WalletBalanceSubinfo(props: PropsIF) {
     const {
@@ -243,12 +242,6 @@ export default function WalletBalanceSubinfo(props: PropsIF) {
                     {exchangeWithTooltip}
                 </FlexContainer>
             )}
-
-            {/* {onRefresh && (
-                <RefreshButton onClick={onRefresh} aria-label='Refresh data'>
-                    <FiRefreshCw size={18} />
-                </RefreshButton>
-            )} */}
         </FlexContainer>
     );
 }

--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -176,14 +176,17 @@ function SwapTokenInput(props: propsIF) {
             slippageTolerancePercentage / 100,
             input,
         );
-        if (impact === undefined) return;
-        setLastImpactQuery({
-            input,
-            isInputSell: sellToken,
-            impact,
-        });
+        if (impact === undefined) {
+            setLastImpactQuery(undefined);
+        } else {
+            setLastImpactQuery({
+                input,
+                isInputSell: sellToken,
+                impact,
+            });
+        }
         if (sellToken) {
-            const rawTokenBQty = parseFloat(impact.buyQty);
+            const rawTokenBQty = impact?.buyQty ? parseFloat(impact.buyQty) : 0;
             const truncatedTokenBQty = rawTokenBQty
                 ? rawTokenBQty < 2
                     ? rawTokenBQty.toPrecision(6)
@@ -196,7 +199,9 @@ function SwapTokenInput(props: propsIF) {
                 setIsBuyLoading(false);
             }
         } else {
-            const rawTokenAQty = parseFloat(impact.sellQty);
+            const rawTokenAQty = impact?.sellQty
+                ? parseFloat(impact.sellQty)
+                : 0;
             const truncatedTokenAQty = rawTokenAQty
                 ? rawTokenAQty < 2
                     ? rawTokenAQty.toPrecision(6)


### PR DESCRIPTION
### Describe your changes 
improve handling of scenario in which price impact query fails (Doug is looking into why it would fail) 

### Link the related issue
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/147cbccc-025c-4884-88c5-b9a67db515e0)
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/f5afe6ed-a497-4000-9075-a65df646b70c)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
