### PR TITLE
Release 2.4.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.4.2",
+    "version": "2.4.3",
     "private": true,
     "dependencies": {
         "@crocswap-libs/sdk": "^0.3.9-1",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "version": "2.4.2",
     "private": true,
     "dependencies": {
-        "@crocswap-libs/sdk": "^0.3.9",
+        "@crocswap-libs/sdk": "^0.3.9-1",
         "@d3fc/d3fc-extent": "^4.0.2",
         "@emotion/is-prop-valid": "^1.2.1",
         "@emotion/react": "^11.10.5",

--- a/src/pages/Trade/Range/Range.tsx
+++ b/src/pages/Trade/Range/Range.tsx
@@ -1193,6 +1193,7 @@ function Range() {
                 !isTokenAAllowanceSufficient ? (
                     <Button
                         idForDOM='approve_token_for_range'
+                        style={{ textTransform: 'none' }}
                         title={
                             !isApprovalPending
                                 ? `Approve ${tokenA.symbol}`
@@ -1210,6 +1211,7 @@ function Range() {
                   !isTokenBAllowanceSufficient ? (
                     <Button
                         idForDOM='approve_token_for_range'
+                        style={{ textTransform: 'none' }}
                         title={
                             !isApprovalPending
                                 ? `Approve ${tokenB.symbol}`

--- a/yarn.lock
+++ b/yarn.lock
@@ -2143,10 +2143,10 @@
     stream-browserify "^3.0.0"
     util "^0.12.4"
 
-"@crocswap-libs/sdk@^0.3.9":
-  version "0.3.9"
-  resolved "https://registry.yarnpkg.com/@crocswap-libs/sdk/-/sdk-0.3.9.tgz#a5064a1c3507e90d76b073cb16a7696f946fd873"
-  integrity sha512-RRCmQOzrZLz64+L1r6Ewj65LzpUu6eTUg2dWv+xlEhnco3C0CYJ8cSE4duymPmpeXrljP4xx497/w+FUXUg8vw==
+"@crocswap-libs/sdk@^0.3.9-1":
+  version "0.3.9-1"
+  resolved "https://registry.yarnpkg.com/@crocswap-libs/sdk/-/sdk-0.3.9-1.tgz#bd4a53c05984f40d347878cf71016ceb91c1b4ed"
+  integrity sha512-cjtDPNXp8C5PhNGZ6H++duZgSfVsVocX0sh2aGQLkDZlRd5hA3ZLDhaub/T9NeMGojFNyIhxa7xoNkyZ9csOJQ==
   dependencies:
     ethers "^5.5.3"
 


### PR DESCRIPTION
- bump SDK version to 0.3.9-1 to fix ambient liquidity queries
- also adds extra padding to swap and approval gas limits