### PR TITLE
fix trade now button on homepage reverting to previous token pair

### DIFF
--- a/src/ambient-utils/constants/networks/ethereumMainnet.ts
+++ b/src/ambient-utils/constants/networks/ethereumMainnet.ts
@@ -5,8 +5,8 @@ import {
     mainnetUSDC,
     mainnetWBTC,
     mainnetSYN,
-    mainnetRPL,
     mainnetSWETH,
+    mainnetMKR,
 } from '../defaultTokens';
 import { NetworkIF } from '../../types/NetworkIF';
 import { TopPool } from './TopPool';
@@ -29,10 +29,10 @@ export const ethereumMainnet: NetworkIF = {
     defaultPair: [mainnetETH, mainnetUSDC],
     topPools: [
         new TopPool(mainnetETH, mainnetWBTC, lookupChain('0x1').poolIndex),
-        new TopPool(mainnetSYN, mainnetETH, lookupChain('0x1').poolIndex),
         new TopPool(mainnetETH, mainnetUSDC, lookupChain('0x1').poolIndex),
+        new TopPool(mainnetSYN, mainnetETH, lookupChain('0x1').poolIndex),
+        new TopPool(mainnetMKR, mainnetETH, lookupChain('0x1').poolIndex),
         new TopPool(mainnetETH, mainnetSWETH, lookupChain('0x1').poolIndex),
-        new TopPool(mainnetRPL, mainnetETH, lookupChain('0x1').poolIndex),
     ],
     getGasPriceInGwei: async (provider?: Provider) => {
         if (!provider) return 0;

--- a/src/components/Home/Landing/TradeNowButton/TradeNowButton.tsx
+++ b/src/components/Home/Landing/TradeNowButton/TradeNowButton.tsx
@@ -1,10 +1,16 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { FlexContainer } from '../../../../styled/Common';
-import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import {
     StyledLink,
     TradeNowButtonText,
 } from '../../../../styled/Components/Home';
+import { chainNumToString } from '../../../../ambient-utils/dataLayer';
+import {
+    linkGenMethodsIF,
+    marketParamsIF,
+    useLinkGen,
+} from '../../../../utils/hooks/useLinkGen';
+import { TradeDataContext } from '../../../../contexts/TradeDataContext';
 
 interface propsIF {
     fieldId: string;
@@ -13,12 +19,19 @@ interface propsIF {
 
 export default function TradeNowButton(props: propsIF) {
     const { fieldId, inNav } = props;
-    const showMobileVersion = useMediaQuery('(max-width: 600px)');
+    const linkGenMarket: linkGenMethodsIF = useLinkGen('market');
 
+    const { tokenA, tokenB } = useContext(TradeDataContext);
+
+    const tradeButtonParams: marketParamsIF = {
+        chain: chainNumToString(tokenA.chainId),
+        tokenA: tokenA.address,
+        tokenB: tokenB.address,
+    };
     return (
         <StyledLink
             id={fieldId}
-            to={showMobileVersion ? '/trade' : '/trade/market'}
+            to={linkGenMarket.getFullURL(tradeButtonParams)}
             tabIndex={0}
             aria-label='Go to trade page button'
             inNav={inNav}

--- a/src/contexts/TradeDataContext.tsx
+++ b/src/contexts/TradeDataContext.tsx
@@ -78,15 +78,13 @@ export const TradeDataContextProvider = (props: {
 
     const tokens: tokenMethodsIF = useTokens(chainData.chainId, []);
 
-    const tokensMatchingA = tokens.getTokensByNameOrSymbol(
-        savedTokenASymbol || '',
-        true,
-    );
+    const tokensMatchingA = savedTokenASymbol
+        ? tokens.getTokensByNameOrSymbol(savedTokenASymbol, true)
+        : [];
 
-    const tokensMatchingB = tokens.getTokensByNameOrSymbol(
-        savedTokenBSymbol || '',
-        true,
-    );
+    const tokensMatchingB = savedTokenBSymbol
+        ? tokens.getTokensByNameOrSymbol(savedTokenBSymbol, true)
+        : [];
 
     const firstTokenMatchingA = tokensMatchingA[0] || undefined;
     const firstTokenMatchingB = tokensMatchingB[0] || undefined;


### PR DESCRIPTION
### Describe your changes 
update homepage Trade Now link to use same link generation logic as the Trade button in the page header
also fix an issue where empty strings for the token symbols of the user's last selected pool were being interpreted as the token symbol of the Lenny Face token on the CoinGecko list, which has an empty string for a token symbol.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
