### PR TITLE
add extra warning when price impact greater than 10%

### DIFF
--- a/src/components/Form/Button.tsx
+++ b/src/components/Form/Button.tsx
@@ -3,6 +3,7 @@ import { ButtonBase } from './Form.styles';
 interface propsIF {
     idForDOM: string;
     disabled?: boolean;
+    warning?: boolean;
     title: string;
     action: () => void;
     flat?: boolean;
@@ -17,6 +18,7 @@ export default function Button(props: propsIF) {
     const {
         idForDOM,
         disabled,
+        warning,
         action,
         title,
         flat,
@@ -45,6 +47,7 @@ export default function Button(props: propsIF) {
             flat={!!flat}
             width={width ? width : thin ? '156px' : '100%'}
             height={thin ? '28px' : 'auto'}
+            warning={warning}
         >
             {title}
         </ButtonBase>

--- a/src/components/Form/Form.styles.ts
+++ b/src/components/Form/Form.styles.ts
@@ -2,6 +2,7 @@ import styled, { css } from 'styled-components/macro';
 
 export const ButtonBase = styled.button<{
     flat: boolean;
+    warning?: boolean;
     width?: string;
     height?: string;
     style?: React.CSSProperties;
@@ -61,6 +62,12 @@ export const ButtonBase = styled.button<{
             border-radius: var(--border-radius);
             background-color: var(--dark2);
             pointer-events: none;
+        `}
+    ${({ warning }) =>
+        warning &&
+        css`
+            background: var(--dark2);
+            color: var(--accent1);
         `}
 `;
 

--- a/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
+++ b/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
@@ -16,6 +16,7 @@ interface propsIF {
     isOnTradeRoute?: boolean;
     effectivePriceWithDenom: number | undefined;
     showExtraInfoDropdown: boolean;
+    showWarning: boolean;
 }
 
 function SwapExtraInfo(props: propsIF) {
@@ -26,6 +27,7 @@ function SwapExtraInfo(props: propsIF) {
         liquidityProviderFeeString,
         swapGasPriceinDollars,
         showExtraInfoDropdown,
+        showWarning,
     } = props;
 
     const { poolPriceDisplay, isTradeDollarizationEnabled, usdPrice } =
@@ -133,6 +135,7 @@ function SwapExtraInfo(props: propsIF) {
             conversionRate={conversionRate}
             gasPrice={swapGasPriceinDollars}
             showDropdown={showExtraInfoDropdown}
+            showWarning={showWarning}
         />
     );
 }

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useContext, useState } from 'react';
+import { MouseEvent, useContext, useEffect, useState } from 'react';
 import { FaGasPump } from 'react-icons/fa';
 import { RiArrowDownSLine, RiArrowUpSLine } from 'react-icons/ri';
 import { FlexContainer } from '../../../../styled/Common';
@@ -19,14 +19,22 @@ interface PropsIF {
     conversionRate: string;
     gasPrice: string | undefined;
     showDropdown: boolean;
+    showWarning?: boolean;
 }
 
 export const ExtraInfo = (props: PropsIF) => {
-    const { extraInfo, showDropdown, conversionRate, gasPrice } = props;
+    const { extraInfo, showDropdown, conversionRate, gasPrice, showWarning } =
+        props;
 
     const { toggleDidUserFlipDenom } = useContext(TradeDataContext);
 
     const [showExtraInfo, setShowExtraInfo] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (showWarning) {
+            setShowExtraInfo(true);
+        }
+    }, [showWarning]);
 
     const arrowToRender = showDropdown ? (
         showExtraInfo ? (

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -751,12 +751,12 @@ function Swap(props: propsIF) {
                             ? bypassConfirmSwap.isEnabled
                                 ? swapAllowed
                                     ? showWarning
-                                        ? 'I understand the price impact of this swap. Submit Anyway!'
+                                        ? 'I understand the price impact of this swap. Submit anyway!'
                                         : 'Submit Swap'
                                     : swapButtonErrorMessage
                                 : swapAllowed
                                 ? showWarning
-                                    ? 'I understand the price impact of this swap. Confirm Anyway!'
+                                    ? 'I understand the price impact of this swap. Confirm anyway!'
                                     : 'Confirm'
                                 : swapButtonErrorMessage
                             : 'Acknowledge'

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -649,6 +649,11 @@ function Swap(props: propsIF) {
             </WarningContainer>
         ) : undefined;
 
+    const showWarning =
+        (priceImpactNumMemo || 0) > 10 &&
+        isTokenAWalletBalanceSufficient &&
+        !isLiquidityInsufficient;
+
     return (
         <TradeModuleSkeleton
             chainId={chainId}
@@ -702,6 +707,7 @@ function Swap(props: propsIF) {
                         primaryQuantity !== '' &&
                         parseFloat(primaryQuantity) > 0
                     }
+                    showWarning={showWarning}
                 />
             }
             modal={
@@ -744,11 +750,13 @@ function Swap(props: propsIF) {
                         areBothAckd
                             ? bypassConfirmSwap.isEnabled
                                 ? swapAllowed
-                                    ? 'Submit Swap'
+                                    ? showWarning
+                                        ? 'I understand the price impact of this swap. Submit Anyway!'
+                                        : 'Submit Swap'
                                     : swapButtonErrorMessage
                                 : swapAllowed
-                                ? bypassConfirmSwap.isEnabled
-                                    ? 'Submit Swap'
+                                ? showWarning
+                                    ? 'I understand the price impact of this swap. Confirm Anyway!'
                                     : 'Confirm'
                                 : swapButtonErrorMessage
                             : 'Acknowledge'
@@ -766,6 +774,7 @@ function Swap(props: propsIF) {
                             buyQtyString === '') &&
                         areBothAckd
                     }
+                    warning={showWarning}
                     flat
                 />
             }


### PR DESCRIPTION
### Describe your changes 
add different button styling when price impact exceeds 10% for the swap

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/ae8fa8f4-ac2f-4074-8a44-e1660c0d8b14)
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/44826f29-db87-42aa-b994-d5385267f75e)



### Link the related issue
previously, there was only a small warning when price impact was very large and the confirm/submit buttons looked the same

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/cf11e190-3126-4b09-87a7-9fcba3bdef96)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
