### PR TITLE
add ETH pool fallback for Active Token USD values

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.4.4",
+    "version": "2.4.5",
     "private": true,
     "dependencies": {
         "@crocswap-libs/sdk": "^0.3.9-1",

--- a/src/pages/Explore/useTokenStats.ts
+++ b/src/pages/Explore/useTokenStats.ts
@@ -1,5 +1,5 @@
 import { CrocEnv } from '@crocswap-libs/sdk';
-import { useState } from 'react';
+import { useContext, useState } from 'react';
 import {
     FetchContractDetailsFn,
     TokenPriceFn,
@@ -14,6 +14,11 @@ import {
 import { TokenIF } from '../../ambient-utils/types';
 import { tokenMethodsIF } from '../../App/hooks/useTokens';
 import { ethers } from 'ethers';
+import {
+    CACHE_UPDATE_FREQ_IN_MS,
+    getDefaultPairForChain,
+} from '../../ambient-utils/constants';
+import { CachedDataContext } from '../../contexts/CachedDataContext';
 
 interface dexDataGeneric {
     raw: number;
@@ -46,6 +51,10 @@ export const useTokenStats = (
     provider: ethers.providers.Provider,
 ): useTokenStatsIF => {
     const [dexTokens, setDexTokens] = useState<dexTokenData[]>([]);
+
+    const { cachedQuerySpotPrice } = useContext(CachedDataContext);
+    const defaultTokensForChain: [TokenIF, TokenIF] =
+        getDefaultPairForChain(chainId);
 
     async function fetchData(): Promise<void> {
         dexTokens.length && setDexTokens([]);
@@ -101,8 +110,28 @@ export const useTokenStats = (
             if (!crocEnv || !tokenMeta) return;
             const tokenPricePromise: Promise<TokenPriceFnReturn> =
                 cachedFetchTokenPrice(token.tokenAddr, chainId, crocEnv);
+            const ethPricePromise: Promise<TokenPriceFnReturn> =
+                cachedFetchTokenPrice(
+                    defaultTokensForChain[0].address,
+                    chainId,
+                    crocEnv,
+                );
+            const poolWithETHPricePromise: Promise<number> =
+                tokenMeta.address === defaultTokensForChain[0].address
+                    ? Promise.resolve(1)
+                    : cachedQuerySpotPrice(
+                          crocEnv,
+                          defaultTokensForChain[0].address,
+                          tokenMeta.address,
+                          chainId,
+                          Math.floor(Date.now() / CACHE_UPDATE_FREQ_IN_MS),
+                      );
 
-            const price: number = (await tokenPricePromise)?.usdPrice || 0;
+            const price: number =
+                (await tokenPricePromise)?.usdPrice ||
+                (await poolWithETHPricePromise) *
+                    ((await ethPricePromise)?.usdPrice || 0) ||
+                0;
 
             const tvlUSD: number = normalizeToUSD(
                 token.dexTvl,


### PR DESCRIPTION
### Describe your changes 
Added a fallback on the price of the pool for that token with ETH when the CoinGecko price was missing.
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/fd72bdec-c57c-4bb9-86ff-f53149a417fb)

### Link the related issue
previously, tokens for which the CoinGecko Price API  did not have a USD value available showed $0 for volume, TVL and fees on the Active Tokens table.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/5a71c400-71b3-451c-907e-c2c87d88d015)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
