### PR TITLE
fix ETH persistence bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.4.6",
+    "version": "2.4.7",
     "private": true,
     "dependencies": {
         "@crocswap-libs/sdk": "^0.3.9-1",

--- a/src/contexts/CrocEnvContext.tsx
+++ b/src/contexts/CrocEnvContext.tsx
@@ -107,14 +107,14 @@ export const CrocEnvContextProvider = (props: { children: ReactNode }) => {
         const savedTokenASymbol = localStorage.getItem('tokenA');
         const savedTokenBSymbol = localStorage.getItem('tokenB');
 
-        const tokensMatchingA = tokens.getTokensByNameOrSymbol(
-            savedTokenASymbol || '',
-            true,
-        );
-        const tokensMatchingB = tokens.getTokensByNameOrSymbol(
-            savedTokenBSymbol || '',
-            true,
-        );
+        const tokensMatchingA =
+            savedTokenASymbol === 'ETH'
+                ? [dfltTokenA]
+                : tokens.getTokensByNameOrSymbol(savedTokenASymbol || '', true);
+        const tokensMatchingB =
+            savedTokenBSymbol === 'ETH'
+                ? [dfltTokenA]
+                : tokens.getTokensByNameOrSymbol(savedTokenBSymbol || '', true);
 
         const firstTokenMatchingA = tokensMatchingA[0] || undefined;
         const firstTokenMatchingB = tokensMatchingB[0] || undefined;

--- a/src/contexts/TradeDataContext.tsx
+++ b/src/contexts/TradeDataContext.tsx
@@ -78,13 +78,14 @@ export const TradeDataContextProvider = (props: {
 
     const tokens: tokenMethodsIF = useTokens(chainData.chainId, []);
 
-    const tokensMatchingA = savedTokenASymbol
-        ? tokens.getTokensByNameOrSymbol(savedTokenASymbol, true)
-        : [];
-
-    const tokensMatchingB = savedTokenBSymbol
-        ? tokens.getTokensByNameOrSymbol(savedTokenBSymbol, true)
-        : [];
+    const tokensMatchingA =
+        savedTokenASymbol === 'ETH'
+            ? [dfltTokenA]
+            : tokens.getTokensByNameOrSymbol(savedTokenASymbol || '', true);
+    const tokensMatchingB =
+        savedTokenBSymbol === 'ETH'
+            ? [dfltTokenA]
+            : tokens.getTokensByNameOrSymbol(savedTokenBSymbol || '', true);
 
     const firstTokenMatchingA = tokensMatchingA[0] || undefined;
     const firstTokenMatchingB = tokensMatchingB[0] || undefined;


### PR DESCRIPTION
### Describe your changes 
If "ETH" is saved in local storage, use the first default token instead of searching the token universe for a match.

### Link the related issue
Native Ether saved to local storage as "ETH" could be confused with a different "ETH" token on the CoinGecko list.

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/d5ca1dfb-4d46-492f-a923-b7ed03409390)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
