### PR TITLE
fix reposition copy button bug

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -140,20 +140,22 @@ function RangesMenu(props: propsIF) {
     const linkGenPool: linkGenMethodsIF = useLinkGen('pool');
     const linkGenRepo: linkGenMethodsIF = useLinkGen('reposition');
 
+    const shouldCopyQuoteToTokenA =
+        tokenAAddress.toLowerCase() === position.quote.toLowerCase() ||
+        tokenBAddress.toLowerCase() === position.base.toLowerCase();
+
     const repositionButton = (
         <Link
             id={`reposition_button_${position.positionId}`}
             className={styles.reposition_button}
             to={linkGenRepo.getFullURL({
                 chain: chainId,
-                tokenA:
-                    tokenAAddress.toLowerCase() === position.quote.toLowerCase()
-                        ? position.quote
-                        : position.base,
-                tokenB:
-                    tokenBAddress.toLowerCase() === position.base.toLowerCase()
-                        ? position.base
-                        : position.quote,
+                tokenA: shouldCopyQuoteToTokenA
+                    ? position.quote
+                    : position.base,
+                tokenB: shouldCopyQuoteToTokenA
+                    ? position.base
+                    : position.quote,
                 lowTick: position.bidTick.toString(),
                 highTick: position.askTick.toString(),
             })}


### PR DESCRIPTION
### Describe your changes 
fix logic to prevent same token from being copied as both TokenA and TokenB

### Link the related issue
From bus:

Repro steps on Scroll with benwolski.eth connected and local storage cleared:

1. Go to home page and click on the wrsETH/ETH pool button
2. Click on the arrow to switch the swap tokens so that wrsETH is the input
3. Go to your account page, open the liquidity tab
4. Find the out of range position and click on its link, it will take you to a pool where both tokens are zero addresses

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
