### PR TITLE
update parseErrorMessage logic

### DIFF
--- a/src/App/hooks/useCreateRangePosition.ts
+++ b/src/App/hooks/useCreateRangePosition.ts
@@ -57,6 +57,7 @@ export function useCreateRangePosition() {
         setNewRangeTransactionHash: (s: string) => void;
         setTxErrorCode: (s: string) => void;
         setTxErrorMessage: (s: string) => void;
+        setTxErrorJSON: (s: string) => void;
         resetConfirmation: () => void;
         setIsTxCompletedRange?: React.Dispatch<React.SetStateAction<boolean>>;
         activeRangeTxHash: MutableRefObject<string>;
@@ -74,6 +75,7 @@ export function useCreateRangePosition() {
             setNewRangeTransactionHash,
             setTxErrorCode,
             setTxErrorMessage,
+            setTxErrorJSON,
             setIsTxCompletedRange,
             activeRangeTxHash,
         } = params;
@@ -152,6 +154,7 @@ export function useCreateRangePosition() {
             console.error({ error });
             setTxErrorCode(error?.code);
             setTxErrorMessage(parseErrorMessage(error));
+            setTxErrorJSON(JSON.stringify(error));
         }
 
         let receipt;

--- a/src/App/hooks/useSendInit.ts
+++ b/src/App/hooks/useSendInit.ts
@@ -19,6 +19,7 @@ export function useSendInit(
     setIsTxCompletedInit: React.Dispatch<React.SetStateAction<boolean>>,
     setTxErrorCode: React.Dispatch<React.SetStateAction<string>>,
     setTxErrorMessage: React.Dispatch<React.SetStateAction<string>>,
+    setTxErrorJSON: React.Dispatch<React.SetStateAction<string>>,
     resetConfirmation: () => void, // Include resetConfirmation as an argument
 ) {
     const { crocEnv } = useContext(CrocEnvContext);
@@ -95,6 +96,7 @@ export function useSendInit(
                 console.error({ error });
                 setTxErrorCode(error?.code);
                 setTxErrorMessage(parseErrorMessage(error));
+                setTxErrorJSON(JSON.stringify(error));
             } finally {
                 setIsInitPending(false);
             }

--- a/src/components/LimitActionModal/LimitActionModal.tsx
+++ b/src/components/LimitActionModal/LimitActionModal.tsx
@@ -82,6 +82,7 @@ export default function LimitActionModal(props: propsIF) {
     const [newTxHash, setNewTxHash] = useState('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
     const [showSettings, setShowSettings] = useState(false);
     const [networkFee, setNetworkFee] = useState<string | undefined>(undefined);
 
@@ -93,6 +94,7 @@ export default function LimitActionModal(props: propsIF) {
         setShowConfirmation(false);
         setNewTxHash('');
         setTxErrorCode('');
+        setTxErrorJSON('');
         setTxErrorMessage('');
     };
 
@@ -250,6 +252,7 @@ export default function LimitActionModal(props: propsIF) {
                 console.error({ error });
                 setTxErrorCode(error?.code);
                 setTxErrorMessage(parseErrorMessage(error));
+                setTxErrorJSON(JSON.stringify(error));
                 if (
                     error.reason === 'sending a transaction requires a signer'
                 ) {
@@ -391,6 +394,7 @@ export default function LimitActionModal(props: propsIF) {
                 console.error({ error });
                 setTxErrorCode(error?.code);
                 setTxErrorMessage(parseErrorMessage(error));
+                setTxErrorJSON(JSON.stringify(error));
                 if (
                     error.reason === 'sending a transaction requires a signer'
                 ) {
@@ -533,6 +537,7 @@ export default function LimitActionModal(props: propsIF) {
                             newTransactionHash={newTxHash}
                             txErrorCode={txErrorCode}
                             txErrorMessage={txErrorMessage}
+                            txErrorJSON={txErrorJSON}
                             resetConfirmation={resetConfirmation}
                             sendTransaction={
                                 type === 'Remove' ? removeFn : claimFn

--- a/src/components/RangeActionModal/RangeActionModal.tsx
+++ b/src/components/RangeActionModal/RangeActionModal.tsx
@@ -266,12 +266,14 @@ function RangeActionModal(props: propsIF) {
     const [newTransactionHash, setNewTransactionHash] = useState('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
 
     const resetConfirmation = () => {
         setShowConfirmation(false);
         setNewTransactionHash('');
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
     };
 
     useEffect(() => {
@@ -327,6 +329,7 @@ function RangeActionModal(props: propsIF) {
                     console.error({ error });
                     setTxErrorCode(error?.code);
                     setTxErrorMessage(parseErrorMessage(error));
+                    setTxErrorJSON(JSON.stringify(error));
                 }
             } else {
                 try {
@@ -347,6 +350,7 @@ function RangeActionModal(props: propsIF) {
                     IS_LOCAL_ENV && console.debug({ error });
                     setTxErrorCode(error?.code);
                     setTxErrorMessage(parseErrorMessage(error));
+                    setTxErrorJSON(JSON.stringify(error));
                 }
             }
         } else if (position.positionType === 'concentrated') {
@@ -369,6 +373,7 @@ function RangeActionModal(props: propsIF) {
                 console.error({ error });
                 setTxErrorCode(error?.code);
                 setTxErrorMessage(parseErrorMessage(error));
+                setTxErrorJSON(JSON.stringify(error));
             }
         } else {
             IS_LOCAL_ENV &&
@@ -497,6 +502,7 @@ function RangeActionModal(props: propsIF) {
                 console.error({ error });
                 setTxErrorCode(error?.code);
                 setTxErrorMessage(parseErrorMessage(error));
+                setTxErrorJSON(JSON.stringify(error));
                 if (
                     error.reason === 'sending a transaction requires a signer'
                 ) {
@@ -627,6 +633,7 @@ function RangeActionModal(props: propsIF) {
                     newTransactionHash={newTransactionHash}
                     txErrorCode={txErrorCode}
                     txErrorMessage={txErrorMessage}
+                    txErrorJSON={txErrorJSON}
                     resetConfirmation={resetConfirmation}
                     sendTransaction={type === 'Remove' ? removeFn : harvestFn}
                     transactionPendingDisplayString={

--- a/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
+++ b/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
@@ -19,6 +19,7 @@ interface propsIF {
     tokenPair: TokenPairIF;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     showConfirmation: boolean;
     resetConfirmation: () => void;
     slippageTolerancePercentage: number;
@@ -42,6 +43,7 @@ export default function ConfirmSwapModal(props: propsIF) {
         tokenPair,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         resetConfirmation,
         showConfirmation,
         slippageTolerancePercentage,
@@ -254,6 +256,7 @@ export default function ConfirmSwapModal(props: propsIF) {
             transactionHash={newSwapTransactionHash}
             txErrorCode={txErrorCode}
             txErrorMessage={txErrorMessage}
+            txErrorJSON={txErrorJSON}
             showConfirmation={showConfirmation}
             statusText={
                 !showConfirmation

--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -13,6 +13,7 @@ interface propsIF {
     newLimitOrderTransactionHash: string;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     showConfirmation: boolean;
     resetConfirmation: () => void;
     startDisplayPrice: number;
@@ -29,6 +30,7 @@ export default function ConfirmLimitModal(props: propsIF) {
         newLimitOrderTransactionHash,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         resetConfirmation,
         showConfirmation,
         startDisplayPrice,
@@ -134,6 +136,7 @@ export default function ConfirmLimitModal(props: propsIF) {
             transactionHash={newLimitOrderTransactionHash}
             txErrorCode={txErrorCode}
             txErrorMessage={txErrorMessage}
+            txErrorJSON={txErrorJSON}
             statusText={
                 !showConfirmation
                     ? limitAllowed

--- a/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
+++ b/src/components/Trade/Range/ConfirmRangeModal/ConfirmRangeModal.tsx
@@ -32,6 +32,7 @@ interface propsIF {
     showConfirmation: boolean;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     resetConfirmation: () => void;
     isAdd: boolean;
     tokenAQty: string;
@@ -53,6 +54,7 @@ function ConfirmRangeModal(props: propsIF) {
         pinnedMaxPriceDisplayTruncatedInQuote,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         showConfirmation,
         resetConfirmation,
         isAdd,
@@ -201,6 +203,7 @@ function ConfirmRangeModal(props: propsIF) {
             transactionHash={newRangeTransactionHash}
             txErrorCode={txErrorCode}
             txErrorMessage={txErrorMessage}
+            txErrorJSON={txErrorJSON}
             showConfirmation={showConfirmation}
             poolTokenDisplay={poolTokenDisplay}
             statusText={

--- a/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
+++ b/src/components/Trade/Reposition/ConfirmRepositionModal/ConfirmRepositionModal.tsx
@@ -16,6 +16,7 @@ interface propsIF {
     resetConfirmation: () => void;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     minPriceDisplay: string;
     maxPriceDisplay: string;
     currentBaseQtyDisplayTruncated: string;
@@ -46,6 +47,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
         resetConfirmation,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         currentBaseQtyDisplayTruncated,
         currentQuoteQtyDisplayTruncated,
         newBaseQtyDisplay,
@@ -183,6 +185,7 @@ export default function ConfirmRepositionModal(props: propsIF) {
             transactionHash={newRepositionTransactionHash}
             txErrorCode={txErrorCode}
             txErrorMessage={txErrorMessage}
+            txErrorJSON={txErrorJSON}
             showConfirmation={showConfirmation}
             statusText={
                 !showConfirmation

--- a/src/components/Trade/TradeModules/SubmitTransaction/SubmitTransaction.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/SubmitTransaction.tsx
@@ -32,6 +32,7 @@ interface propsIF {
     newTransactionHash: string;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     resetConfirmation: () => void;
     sendTransaction: () => Promise<void>;
     transactionPendingDisplayString: string;
@@ -43,6 +44,7 @@ export default function SubmitTransaction(props: propsIF) {
         newTransactionHash,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         resetConfirmation,
         sendTransaction,
         transactionPendingDisplayString,
@@ -86,7 +88,10 @@ export default function SubmitTransaction(props: propsIF) {
         />
     );
     const transactionException = (
-        <TransactionException txErrorMessage={txErrorMessage} />
+        <TransactionException
+            txErrorMessage={txErrorMessage}
+            txErrorJSON={txErrorJSON}
+        />
     );
 
     const [isTransactionFailed, setIsTransactionFailed] =

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.module.css
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.module.css
@@ -13,3 +13,40 @@
     line-height: var(--body-lh);
     color: var(--text2);
 }
+
+.formatted_error{
+    word-break: break-all;
+    height: 50px;
+    overflow-y: scroll;
+}
+
+.formatted_error_container{
+
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+
+}
+
+.copy_error{
+    width: 80%;
+    background: none;
+    margin: 0 auto;
+    cursor: pointer;
+    outline: none;
+    display: flex;
+padding: 4px 8px;
+justify-content: space-between;
+align-items: center;
+border-radius: 4px;
+border: 1px solid var(--text2);
+align-self: stretch;
+color: var(--text2);
+
+}
+.copy_error:hover{
+    border: 1px solid var(--accent4);
+    color: var(--accent4);
+
+
+}

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.tsx
@@ -3,15 +3,23 @@ import { ZERO_ADDRESS } from '../../../../../ambient-utils/constants';
 import DividerDark from '../../../../Global/DividerDark/DividerDark';
 import { useContext } from 'react';
 import { TradeDataContext } from '../../../../../contexts/TradeDataContext';
+import TooltipComponent from '../../../../Global/TooltipComponent/TooltipComponent';
+import useCopyToClipboard from '../../../../../utils/hooks/useCopyToClipboard';
+import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     txErrorMessage: string;
 }
 
 export default function TransactionException(props: propsIF) {
+    const {
+        snackbar: { open: openSnackbar },
+    } = useContext(AppStateContext);
     const { txErrorMessage } = props;
     const rangeModuleActive = location.pathname.includes('/trade/pool');
     const { tokenA, tokenB, isTokenAPrimary } = useContext(TradeDataContext);
+
+    const [_, copy] = useCopyToClipboard();
 
     const isNativeTokenSecondary =
         (isTokenAPrimary && tokenB.address === ZERO_ADDRESS) ||
@@ -22,6 +30,10 @@ export default function TransactionException(props: propsIF) {
     const formattedErrorMessage =
         'Error Message: ' + txErrorMessage?.replace('err: ', '');
 
+    function handleCopyErrorMessage() {
+        copy(formattedErrorMessage);
+        openSnackbar('error message copied', 'info');
+    }
     const suggestionToCheckWalletETHBalance = (
         <p>
             Please verify that the native token (e.g. ETH) balance in your
@@ -60,7 +72,22 @@ export default function TransactionException(props: propsIF) {
                         We apologize for this inconvenience.
                     </p>
                     <DividerDark />
-                    <p>{formattedErrorMessage}</p>
+                    <div className={styles.formatted_error_container}>
+                        <p className={styles.formatted_error}>
+                            {formattedErrorMessage}
+                        </p>
+
+                        <button
+                            className={styles.copy_error}
+                            onClick={handleCopyErrorMessage}
+                        >
+                            Copy Error Message
+                            <TooltipComponent
+                                title='If you have any questions or need further assistance, feel free to copy your error message and paste it in Discord. Our team is here to help!'
+                                placement='bottom'
+                            />
+                        </button>
+                    </div>
                     <DividerDark />
 
                     {!txErrorMessage ? (

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionException/TransactionException.tsx
@@ -9,13 +9,14 @@ import { AppStateContext } from '../../../../../contexts/AppStateContext';
 
 interface propsIF {
     txErrorMessage: string;
+    txErrorJSON: string;
 }
 
 export default function TransactionException(props: propsIF) {
     const {
         snackbar: { open: openSnackbar },
     } = useContext(AppStateContext);
-    const { txErrorMessage } = props;
+    const { txErrorMessage, txErrorJSON } = props;
     const rangeModuleActive = location.pathname.includes('/trade/pool');
     const { tokenA, tokenB, isTokenAPrimary } = useContext(TradeDataContext);
 
@@ -31,8 +32,8 @@ export default function TransactionException(props: propsIF) {
         'Error Message: ' + txErrorMessage?.replace('err: ', '');
 
     function handleCopyErrorMessage() {
-        copy(formattedErrorMessage);
-        openSnackbar('error message copied', 'info');
+        copy(txErrorJSON);
+        openSnackbar('Error message copied to clipboard', 'info');
     }
     const suggestionToCheckWalletETHBalance = (
         <p>
@@ -81,9 +82,9 @@ export default function TransactionException(props: propsIF) {
                             className={styles.copy_error}
                             onClick={handleCopyErrorMessage}
                         >
-                            Copy Error Message
+                            Copy Error Message to Clipboard
                             <TooltipComponent
-                                title='If you have any questions or need further assistance, feel free to copy your error message and paste it in Discord. Our team is here to help!'
+                                title='If you have any questions or need further assistance, please open a ticket on Discord (#open-a-ticket) and paste this error message. https://discord.gg/ambient-finance'
                                 placement='bottom'
                             />
                         </button>

--- a/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
@@ -27,6 +27,7 @@ interface propsIF {
     transactionHash: string;
     txErrorCode: string;
     txErrorMessage: string;
+    txErrorJSON: string;
     showConfirmation: boolean;
     statusText: string;
     onClose?: () => void;
@@ -51,6 +52,7 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
         transactionHash,
         txErrorCode,
         txErrorMessage,
+        txErrorJSON,
         statusText,
         showConfirmation,
         resetConfirmation,
@@ -189,6 +191,7 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
                             newTransactionHash={transactionHash}
                             txErrorCode={txErrorCode}
                             txErrorMessage={txErrorMessage}
+                            txErrorJSON={txErrorJSON}
                             resetConfirmation={resetConfirmation}
                             sendTransaction={initiate}
                             transactionPendingDisplayString={statusText}

--- a/src/pages/InitPool/InitConfirmation.tsx
+++ b/src/pages/InitPool/InitConfirmation.tsx
@@ -36,6 +36,7 @@ interface InitConfirmationProps {
     isTxCompletedRange: boolean;
     errorCode?: string;
     txErrorMessage?: string;
+    txErrorJSON?: string;
     handleNavigation: () => void;
     pinnedMinPriceDisplayTruncatedInBase: string;
     pinnedMinPriceDisplayTruncatedInQuote: string;

--- a/src/pages/InitPool/InitPool.tsx
+++ b/src/pages/InitPool/InitPool.tsx
@@ -970,6 +970,8 @@ export default function InitPool() {
     >('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
+
     const [isInitPending, setIsInitPending] = useState(false);
     const [isTxCompletedInit, setIsTxCompletedInit] = useState(false);
     const [isTxCompletedRange, setIsTxCompletedRange] = useState(false);
@@ -984,6 +986,7 @@ export default function InitPool() {
     const resetConfirmation = () => {
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
         setNewRangeTransactionHash('');
         setNewInitTransactionHash('');
         setIsTxCompletedInit(false);
@@ -1009,6 +1012,7 @@ export default function InitPool() {
         setIsTxCompletedInit,
         setTxErrorCode,
         setTxErrorMessage,
+        setTxErrorJSON,
         resetConfirmation,
     );
 
@@ -1092,6 +1096,7 @@ export default function InitPool() {
             setNewRangeTransactionHash,
             setTxErrorCode,
             setTxErrorMessage,
+            setTxErrorJSON,
             resetConfirmation,
             poolPrice: selectedPoolNonDisplayPrice,
             setIsTxCompletedRange: setIsTxCompletedRange,
@@ -1774,6 +1779,7 @@ export default function InitPool() {
         isTokenABase,
         errorCode: txErrorCode,
         txErrorMessage: txErrorMessage,
+        txErrorJSON: txErrorJSON,
         isTxCompletedInit,
         isTxCompletedRange,
         handleNavigation,

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -132,6 +132,7 @@ export default function Limit() {
         useState('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
     const [showConfirmation, setShowConfirmation] = useState<boolean>(false);
     const [endDisplayPrice, setEndDisplayPrice] = useState<number>(0);
     const [startDisplayPrice, setStartDisplayPrice] = useState<number>(0);
@@ -554,6 +555,7 @@ export default function Limit() {
         setShowConfirmation(false);
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
         setNewLimitOrderTransactionHash('');
     };
 
@@ -649,6 +651,7 @@ export default function Limit() {
             console.error({ error });
             setTxErrorCode(error?.code);
             setTxErrorMessage(parseErrorMessage(error));
+            setTxErrorJSON(JSON.stringify(error));
             if (error.reason === 'sending a transaction requires a signer') {
                 location.reload();
             }
@@ -862,6 +865,7 @@ export default function Limit() {
                         }
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         showConfirmation={showConfirmation}
                         resetConfirmation={resetConfirmation}
                         startDisplayPrice={startDisplayPrice}
@@ -910,6 +914,7 @@ export default function Limit() {
                         newTransactionHash={newLimitOrderTransactionHash}
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         resetConfirmation={resetConfirmation}
                         sendTransaction={sendLimitOrder}
                         transactionPendingDisplayString={`Submitting Limit Order to Swap ${tokenAInputQty} ${tokenA.symbol} for ${tokenBInputQty} ${tokenB.symbol}`}

--- a/src/pages/Trade/Range/Range.tsx
+++ b/src/pages/Trade/Range/Range.tsx
@@ -173,6 +173,7 @@ function Range() {
     const [newRangeTransactionHash, setNewRangeTransactionHash] = useState('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
 
     const [rangeGasPriceinDollars, setRangeGasPriceinDollars] = useState<
         string | undefined
@@ -884,6 +885,7 @@ function Range() {
         setShowConfirmation(false);
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
         setNewRangeTransactionHash('');
     };
     const { createRangePosition } = useCreateRangePosition();
@@ -908,6 +910,7 @@ function Range() {
             setNewRangeTransactionHash,
             setTxErrorCode,
             setTxErrorMessage,
+            setTxErrorJSON,
             resetConfirmation,
             activeRangeTxHash,
         });
@@ -1099,6 +1102,7 @@ function Range() {
                         showConfirmation={showConfirmation}
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         isInRange={!isOutOfRange}
                         pinnedMinPriceDisplayTruncatedInBase={
                             pinnedMinPriceDisplayTruncatedInBase
@@ -1162,6 +1166,7 @@ function Range() {
                         newTransactionHash={newRangeTransactionHash}
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         resetConfirmation={resetConfirmation}
                         sendTransaction={sendTransaction}
                         transactionPendingDisplayString={

--- a/src/pages/Trade/Reposition/Reposition.tsx
+++ b/src/pages/Trade/Reposition/Reposition.tsx
@@ -104,11 +104,13 @@ function Reposition() {
     const [showConfirmation, setShowConfirmation] = useState(false);
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
 
     const resetConfirmation = () => {
         setShowConfirmation(false);
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
         setNewRepositionTransactionHash('');
     };
 
@@ -333,6 +335,7 @@ function Reposition() {
         let tx;
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
 
         resetConfirmation();
         setShowConfirmation(true);
@@ -392,6 +395,7 @@ function Reposition() {
             console.error({ error });
             setTxErrorCode(error?.code);
             setTxErrorMessage(parseErrorMessage(error));
+            setTxErrorJSON(JSON.stringify(error));
         }
 
         let receipt;
@@ -863,6 +867,7 @@ function Reposition() {
                                 }
                                 txErrorCode={txErrorCode}
                                 txErrorMessage={txErrorMessage}
+                                txErrorJSON={txErrorJSON}
                                 sendTransaction={sendRepositionTransaction}
                                 resetConfirmation={resetConfirmation}
                                 transactionPendingDisplayString={`Repositioning ${tokenA.symbol} and ${tokenB.symbol}`}
@@ -909,6 +914,7 @@ function Reposition() {
                     resetConfirmation={resetConfirmation}
                     txErrorCode={txErrorCode}
                     txErrorMessage={txErrorMessage}
+                    txErrorJSON={txErrorJSON}
                     minPriceDisplay={minPriceDisplay}
                     maxPriceDisplay={maxPriceDisplay}
                     currentBaseQtyDisplayTruncated={

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -486,7 +486,7 @@ function Swap(props: propsIF) {
 
         let tx;
         try {
-            const sellTokenAddress = tokenA.address;
+            const sellTokenAddress = tokenB.address;
             const buyTokenAddress = tokenB.address;
 
             tx = await performSwap({

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -142,6 +142,7 @@ function Swap(props: propsIF) {
     const [newSwapTransactionHash, setNewSwapTransactionHash] = useState('');
     const [txErrorCode, setTxErrorCode] = useState('');
     const [txErrorMessage, setTxErrorMessage] = useState('');
+    const [txErrorJSON, setTxErrorJSON] = useState('');
     const [swapButtonErrorMessage, setSwapButtonErrorMessage] =
         useState<string>('');
 
@@ -469,6 +470,7 @@ function Swap(props: propsIF) {
         setShowConfirmation(false);
         setTxErrorCode('');
         setTxErrorMessage('');
+        setTxErrorJSON('');
         setNewSwapTransactionHash('');
     };
 
@@ -486,7 +488,7 @@ function Swap(props: propsIF) {
 
         let tx;
         try {
-            const sellTokenAddress = tokenB.address;
+            const sellTokenAddress = tokenA.address;
             const buyTokenAddress = tokenB.address;
 
             tx = await performSwap({
@@ -531,6 +533,7 @@ function Swap(props: propsIF) {
             console.error({ error });
             setTxErrorCode(error?.code);
             setTxErrorMessage(parseErrorMessage(error));
+            setTxErrorJSON(JSON.stringify(error));
         }
 
         if (tx) {
@@ -725,6 +728,7 @@ function Swap(props: propsIF) {
                         newSwapTransactionHash={newSwapTransactionHash}
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         showConfirmation={showConfirmation}
                         resetConfirmation={resetConfirmation}
                         slippageTolerancePercentage={
@@ -785,6 +789,7 @@ function Swap(props: propsIF) {
                         newTransactionHash={newSwapTransactionHash}
                         txErrorCode={txErrorCode}
                         txErrorMessage={txErrorMessage}
+                        txErrorJSON={txErrorJSON}
                         resetConfirmation={resetConfirmation}
                         sendTransaction={initiateSwap}
                         transactionPendingDisplayString={`Swapping ${sellQtyString} ${tokenA.symbol} for ${buyQtyString} ${tokenB.symbol}`}

--- a/src/utils/TransactionError.ts
+++ b/src/utils/TransactionError.ts
@@ -59,6 +59,7 @@ export function isTransactionFailedError(
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function parseErrorMessage(error: any): string {
     const errorMessage =
+        error?.error?.data?.message ||
         error?.error?.message ||
         error?.data?.message ||
         error?.response?.data?.message ||


### PR DESCRIPTION
### Describe your changes 

- update parseErrorMessage logic
- added button to copy entire error object as a string to clipboard

![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/52c9b8ba-f738-4cd4-b714-d4b0a51b08dd)


### Link the related issue
from bus: 

And one more thing, can you add error?.error?.data?.message || as the first selector to [parseErrorMessage](https://github.com/CrocSwap/ambient-ts-app/blob/develop/src/utils/TransactionError.ts#L61)? I noticed MetaMask returns the most useful error message in that field, otherwise "Internal JSON-RPC Error" gets selected and it's like the good old days of error messages being useless. Also would be nice if we had a button to copy the whole error object.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
