### PR TITLE
add percent diff in USD value

### DIFF
--- a/src/components/Form/TokenInputWithWalletBalance.tsx
+++ b/src/components/Form/TokenInputWithWalletBalance.tsx
@@ -31,6 +31,7 @@ interface propsIF {
     amountToReduceNativeTokenQty: number;
     isInitPage?: boolean | undefined;
     tokenDecimals?: number;
+    percentDiffUsdValue?: number;
 }
 
 function TokenInputWithWalletBalance(props: propsIF) {
@@ -58,6 +59,7 @@ function TokenInputWithWalletBalance(props: propsIF) {
         isInitPage,
         tokenDecimals,
         usdValue,
+        percentDiffUsdValue,
     } = props;
 
     const usdValueForDom =
@@ -133,6 +135,7 @@ function TokenInputWithWalletBalance(props: propsIF) {
                         ? ''
                         : usdValueForDom
                 }
+                percentDiffUsdValue={percentDiffUsdValue}
                 showWallet={showWallet}
                 isWithdraw={isWithdraw ?? tokenAorB === 'A'}
                 balance={balanceToDisplay}

--- a/src/components/Form/WalletBalanceSubinfo.tsx
+++ b/src/components/Form/WalletBalanceSubinfo.tsx
@@ -10,6 +10,7 @@ import WalletBalanceExplanation from '../Global/Informational/WalletBalanceExpla
 import { DefaultTooltip } from '../Global/StyledTooltip/StyledTooltip';
 import { FlexContainer } from '../../styled/Common';
 import { MaxButton } from '../../styled/Components/Portfolio';
+import { getFormattedNumber } from '../../ambient-utils/dataLayer';
 interface PropsIF {
     usdValueForDom: string;
     showWallet: boolean | undefined;
@@ -20,10 +21,12 @@ interface PropsIF {
     onToggleDex: () => void;
     availableBalance?: number;
     onMaxButtonClick?: () => void;
+    percentDiffUsdValue: number | undefined;
 }
 export default function WalletBalanceSubinfo(props: PropsIF) {
     const {
         usdValueForDom,
+        percentDiffUsdValue,
         showWallet,
         isWithdraw,
         balance,
@@ -214,6 +217,18 @@ export default function WalletBalanceSubinfo(props: PropsIF) {
             </MaxButton>
         </DefaultTooltip>
     );
+    const showWarning =
+        usdValueForDom &&
+        percentDiffUsdValue !== undefined &&
+        percentDiffUsdValue < -10;
+
+    const formattedUsdDifference =
+        percentDiffUsdValue !== undefined
+            ? getFormattedNumber({
+                  value: percentDiffUsdValue,
+                  isPercentage: true,
+              }) + '%'
+            : undefined;
 
     return (
         <FlexContainer
@@ -223,8 +238,13 @@ export default function WalletBalanceSubinfo(props: PropsIF) {
             gap={4}
             fontSize='body'
             color='text2'
+            cursor='default'
         >
-            <p>{usdValueForDom}</p>
+            <p style={showWarning ? { color: 'var(--other-red)' } : undefined}>
+                {showWarning
+                    ? `${usdValueForDom} ${' '}(${formattedUsdDifference})`
+                    : usdValueForDom}
+            </p>
             {showWallet && (
                 <FlexContainer
                     role='button'

--- a/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
+++ b/src/components/Swap/ConfirmSwapModal/ConfirmSwapModal.tsx
@@ -31,6 +31,7 @@ interface propsIF {
     isTokenAPrimary: boolean;
     priceImpactWarning: JSX.Element | undefined;
     isSaveAsDexSurplusChecked: boolean;
+    percentDiffUsdValue: number | undefined;
 }
 
 export default function ConfirmSwapModal(props: propsIF) {
@@ -55,6 +56,7 @@ export default function ConfirmSwapModal(props: propsIF) {
         isTokenAPrimary,
         priceImpactWarning,
         isSaveAsDexSurplusChecked,
+        percentDiffUsdValue,
     } = props;
 
     const { pool } = useContext(PoolContext);
@@ -269,6 +271,7 @@ export default function ConfirmSwapModal(props: propsIF) {
                 isWaitingForPriceChangeAckt && priceIncreaseComponent
             }
             priceImpactWarning={priceImpactWarning}
+            percentDiffUsdValue={percentDiffUsdValue}
         />
     );
 }

--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -47,6 +47,9 @@ interface propsIF {
     setIsLiquidityInsufficient: Dispatch<SetStateAction<boolean>>;
     toggleDexSelection: (tokenAorB: 'A' | 'B') => void;
     amountToReduceNativeTokenQty: number;
+    usdValueTokenA: number | undefined;
+    usdValueTokenB: number | undefined;
+    percentDiffUsdValue: number | undefined;
 }
 
 function SwapTokenInput(props: propsIF) {
@@ -64,6 +67,9 @@ function SwapTokenInput(props: propsIF) {
         toggleDexSelection,
         amountToReduceNativeTokenQty,
         setLastImpactQuery,
+        usdValueTokenA,
+        usdValueTokenB,
+        percentDiffUsdValue,
     } = props;
 
     const {
@@ -71,8 +77,7 @@ function SwapTokenInput(props: propsIF) {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
     const { lastBlockNumber } = useContext(ChainDataContext);
-    const { isPoolInitialized, poolData } = useContext(PoolContext);
-    const { isTokenABase } = useContext(TradeDataContext);
+    const { isPoolInitialized } = useContext(PoolContext);
     const {
         tokenABalance,
         tokenBBalance,
@@ -313,21 +318,6 @@ function SwapTokenInput(props: propsIF) {
             }
         }
     }, [isTokenAPrimary, sellQtyString, buyQtyString, primaryQuantity]);
-
-    const usdValueTokenA = isTokenABase
-        ? poolData.basePrice
-        : poolData.quotePrice;
-    const usdValueTokenB = isTokenABase
-        ? poolData.quotePrice
-        : poolData.basePrice;
-
-    const percentDiffUsdValue =
-        usdValueTokenA && usdValueTokenB
-            ? ((usdValueTokenB * parseFloat(buyQtyString) -
-                  usdValueTokenA * parseFloat(sellQtyString)) /
-                  (usdValueTokenA * parseFloat(sellQtyString))) *
-              100
-            : 0;
 
     return (
         <FlexContainer flexDirection='column' gap={8}>

--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -321,6 +321,14 @@ function SwapTokenInput(props: propsIF) {
         ? poolData.quotePrice
         : poolData.basePrice;
 
+    const percentDiffUsdValue =
+        usdValueTokenA && usdValueTokenB
+            ? ((usdValueTokenB * parseFloat(buyQtyString) -
+                  usdValueTokenA * parseFloat(sellQtyString)) /
+                  (usdValueTokenA * parseFloat(sellQtyString))) *
+              100
+            : 0;
+
     return (
         <FlexContainer flexDirection='column' gap={8}>
             <TokenInputWithWalletBalance
@@ -406,6 +414,7 @@ function SwapTokenInput(props: propsIF) {
                 }}
                 amountToReduceNativeTokenQty={0} // value not used for buy token
                 usdValue={usdValueTokenB}
+                percentDiffUsdValue={percentDiffUsdValue}
             />
         </FlexContainer>
     );

--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -22,6 +22,7 @@ interface propsIF {
     onClose: () => void;
     limitAllowed: boolean;
     limitButtonErrorMessage: string;
+    percentDiffUsdValue: number;
 }
 
 export default function ConfirmLimitModal(props: propsIF) {
@@ -41,6 +42,7 @@ export default function ConfirmLimitModal(props: propsIF) {
         onClose = () => null,
         limitAllowed,
         limitButtonErrorMessage,
+        percentDiffUsdValue,
     } = props;
 
     const { poolPriceDisplay } = useContext(PoolContext);
@@ -147,6 +149,7 @@ export default function ConfirmLimitModal(props: propsIF) {
             showConfirmation={showConfirmation}
             resetConfirmation={resetConfirmation}
             isAllowed={limitAllowed}
+            percentDiffUsdValue={percentDiffUsdValue}
         />
     );
 }

--- a/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
+++ b/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
@@ -27,6 +27,9 @@ interface propsIF {
     handleLimitButtonMessage: (val: number) => void;
     toggleDexSelection: (tokenAorB: 'A' | 'B') => void;
     amountToReduceNativeTokenQty: number;
+    usdValueTokenA: number | undefined;
+    usdValueTokenB: number | undefined;
+    percentDiffUsdValue: number | undefined;
 }
 
 function LimitTokenInput(props: propsIF) {
@@ -39,12 +42,15 @@ function LimitTokenInput(props: propsIF) {
         handleLimitButtonMessage,
         toggleDexSelection,
         amountToReduceNativeTokenQty,
+        usdValueTokenA,
+        usdValueTokenB,
+        percentDiffUsdValue,
     } = props;
 
     const {
         chainData: { chainId },
     } = useContext(CrocEnvContext);
-    const { pool, poolData } = useContext(PoolContext);
+    const { pool } = useContext(PoolContext);
     const {
         baseToken: {
             balance: baseTokenBalance,
@@ -70,7 +76,6 @@ function LimitTokenInput(props: propsIF) {
         setLimitTick,
         primaryQuantity,
         setPrimaryQuantity,
-        isTokenABase,
     } = useContext(TradeDataContext);
 
     const isSellTokenBase = pool?.baseToken.tokenAddr === tokenA.address;
@@ -195,21 +200,6 @@ function LimitTokenInput(props: propsIF) {
 
         limitTickDisplayPrice && setTokenAInputQty(truncatedTokenAQty);
     };
-
-    const usdValueTokenA = isTokenABase
-        ? poolData.basePrice
-        : poolData.quotePrice;
-    const usdValueTokenB = isTokenABase
-        ? poolData.quotePrice
-        : poolData.basePrice;
-
-    const percentDiffUsdValue =
-        usdValueTokenA && usdValueTokenB
-            ? ((usdValueTokenB * parseFloat(tokenBInputQty) -
-                  usdValueTokenA * parseFloat(tokenAInputQty)) /
-                  (usdValueTokenA * parseFloat(tokenAInputQty))) *
-              100
-            : 0;
 
     return (
         <FlexContainer flexDirection='column' gap={8}>

--- a/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
+++ b/src/components/Trade/Limit/LimitTokenInput/LimitTokenInput.tsx
@@ -203,6 +203,14 @@ function LimitTokenInput(props: propsIF) {
         ? poolData.quotePrice
         : poolData.basePrice;
 
+    const percentDiffUsdValue =
+        usdValueTokenA && usdValueTokenB
+            ? ((usdValueTokenB * parseFloat(tokenBInputQty) -
+                  usdValueTokenA * parseFloat(tokenAInputQty)) /
+                  (usdValueTokenA * parseFloat(tokenAInputQty))) *
+              100
+            : 0;
+
     return (
         <FlexContainer flexDirection='column' gap={8}>
             <TokenInputWithWalletBalance
@@ -254,6 +262,7 @@ function LimitTokenInput(props: propsIF) {
                 }}
                 amountToReduceNativeTokenQty={0} // value not used for buy token
                 usdValue={usdValueTokenB}
+                percentDiffUsdValue={percentDiffUsdValue}
             />
         </FlexContainer>
     );

--- a/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
@@ -7,7 +7,10 @@ import Button from '../../Form/Button';
 // START: Import Other Local Files
 import { TokenIF } from '../../../ambient-utils/types';
 import { UserPreferenceContext } from '../../../contexts/UserPreferenceContext';
-import { uriToHttp } from '../../../ambient-utils/dataLayer';
+import {
+    getFormattedNumber,
+    uriToHttp,
+} from '../../../ambient-utils/dataLayer';
 import ConfirmationModalControl from '../../Global/ConfirmationModalControl/ConfirmationModalControl';
 import TokensArrow from '../../Global/TokensArrow/TokensArrow';
 import TokenIcon from '../../Global/TokenIcon/TokenIcon';
@@ -39,6 +42,7 @@ interface propsIF {
     extraNotes?: React.ReactNode;
     priceImpactWarning?: JSX.Element | undefined;
     isAllowed?: boolean;
+    percentDiffUsdValue?: number | undefined;
 }
 
 export default function TradeConfirmationSkeleton(props: propsIF) {
@@ -61,6 +65,7 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
         extraNotes,
         priceImpactWarning,
         isAllowed,
+        percentDiffUsdValue,
     } = props;
 
     const {
@@ -72,6 +77,17 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
 
     const [skipFutureConfirmation, setSkipFutureConfirmation] =
         useState<boolean>(false);
+
+    const showWarning =
+        percentDiffUsdValue !== undefined && percentDiffUsdValue < -10;
+
+    const formattedUsdDifference =
+        percentDiffUsdValue !== undefined
+            ? getFormattedNumber({
+                  value: percentDiffUsdValue,
+                  isPercentage: true,
+              }) + '%'
+            : undefined;
 
     const tokenDisplay = (
         <>
@@ -104,7 +120,18 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
             </FlexContainer>
             <ConfirmationQuantityContainer>
                 <Text fontSize='header2' color='text1'>
-                    {tokenBQuantity}
+                    <span>{tokenBQuantity}</span>
+                    {showWarning && (
+                        <span
+                            style={
+                                showWarning
+                                    ? { color: 'var(--other-red)' }
+                                    : undefined
+                            }
+                        >
+                            {`${' '}(${formattedUsdDifference})`}
+                        </span>
+                    )}
                 </Text>
                 <FlexContainer
                     alignItems='center'

--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -109,6 +109,7 @@ export default function Limit() {
         poolPriceNonDisplay,
         primaryQuantity,
         setPrimaryQuantity,
+        isTokenABase,
     } = useContext(TradeDataContext);
     const { liquidityFee } = useContext(GraphDataContext);
     const { urlParamMap, updateURL } = useTradeData();
@@ -800,6 +801,21 @@ export default function Limit() {
         needConfirmTokenB && tokens.acknowledge(tokenB);
     };
 
+    const usdValueTokenA = isTokenABase
+        ? poolData.basePrice
+        : poolData.quotePrice;
+    const usdValueTokenB = isTokenABase
+        ? poolData.quotePrice
+        : poolData.basePrice;
+
+    const percentDiffUsdValue =
+        usdValueTokenA && usdValueTokenB
+            ? ((usdValueTokenB * parseFloat(tokenBInputQty) -
+                  usdValueTokenA * parseFloat(tokenAInputQty)) /
+                  (usdValueTokenA * parseFloat(tokenAInputQty))) *
+              100
+            : 0;
+
     return (
         <TradeModuleSkeleton
             chainId={chainId}
@@ -826,6 +842,9 @@ export default function Limit() {
                     handleLimitButtonMessage={handleLimitButtonMessage}
                     toggleDexSelection={toggleDexSelection}
                     amountToReduceNativeTokenQty={amountToReduceNativeTokenQty}
+                    usdValueTokenA={usdValueTokenA}
+                    usdValueTokenB={usdValueTokenB}
+                    percentDiffUsdValue={percentDiffUsdValue}
                 />
             }
             inputOptions={
@@ -873,6 +892,7 @@ export default function Limit() {
                         endDisplayPrice={endDisplayPrice}
                         limitAllowed={limitAllowed}
                         limitButtonErrorMessage={limitButtonErrorMessage}
+                        percentDiffUsdValue={percentDiffUsdValue}
                     />
                 ) : (
                     <></>

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -73,7 +73,7 @@ function Swap(props: propsIF) {
     const { userAddress } = useContext(UserDataContext);
     const { gasPriceInGwei, isActiveNetworkBlast, isActiveNetworkScroll } =
         useContext(ChainDataContext);
-    const { isPoolInitialized } = useContext(PoolContext);
+    const { isPoolInitialized, poolData } = useContext(PoolContext);
     const { tokens } = useContext(TokenContext);
 
     const {
@@ -112,6 +112,7 @@ function Swap(props: propsIF) {
         primaryQuantity,
         setPrimaryQuantity,
         areDefaultTokensUpdatedForChain,
+        isTokenABase,
     } = useContext(TradeDataContext);
 
     const [sellQtyString, setSellQtyString] = useState<string>(
@@ -657,6 +658,21 @@ function Swap(props: propsIF) {
         isTokenAWalletBalanceSufficient &&
         !isLiquidityInsufficient;
 
+    const usdValueTokenA = isTokenABase
+        ? poolData.basePrice
+        : poolData.quotePrice;
+    const usdValueTokenB = isTokenABase
+        ? poolData.quotePrice
+        : poolData.basePrice;
+
+    const percentDiffUsdValue =
+        usdValueTokenA && usdValueTokenB
+            ? ((usdValueTokenB * parseFloat(buyQtyString) -
+                  usdValueTokenA * parseFloat(sellQtyString)) /
+                  (usdValueTokenA * parseFloat(sellQtyString))) *
+              100
+            : 0;
+
     return (
         <TradeModuleSkeleton
             chainId={chainId}
@@ -697,6 +713,9 @@ function Swap(props: propsIF) {
                     setSwapAllowed={setSwapAllowed}
                     toggleDexSelection={toggleDexSelection}
                     amountToReduceNativeTokenQty={amountToReduceNativeTokenQty}
+                    usdValueTokenA={usdValueTokenA}
+                    usdValueTokenB={usdValueTokenB}
+                    percentDiffUsdValue={percentDiffUsdValue}
                 />
             }
             transactionDetails={
@@ -741,6 +760,7 @@ function Swap(props: propsIF) {
                         isTokenAPrimary={isTokenAPrimary}
                         priceImpactWarning={priceImpactWarning}
                         isSaveAsDexSurplusChecked={isSaveAsDexSurplusChecked}
+                        percentDiffUsdValue={percentDiffUsdValue}
                     />
                 ) : (
                     <></>

--- a/src/styled/Components/TradeModules.ts
+++ b/src/styled/Components/TradeModules.ts
@@ -353,7 +353,7 @@ export const ConfirmationQuantityContainer = styled.div`
     grid-template-columns: auto 140px;
     align-items: center;
     background: var(--dark2);
-    padding: 0 2rem;
+    padding: 0 1rem 0 1rem;
     border-radius: var(--border-radius);
 `;
 


### PR DESCRIPTION
### Describe your changes 
add usd value difference percentage in swap & limit modules and confirmation modals when loss in value > 10%

### Link the related issue
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/ef931803-650f-4f5e-a5f0-edd95727cb69)
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/7368bb9a-fafc-4adb-8381-31cf661e88f7)

bus
  [1:42 PM](https://crocodile-labs.slack.com/archives/D06BRRNK6RW/p1712770948552519)
People keep losing money by swapping in illiquid pools. I don't know if other warnings show up for them, but I think the thing that will help the most is making the output value red if it's significantly lower than the input value: https://crocodile-labs.slack.com/archives/C03D4TRT2UC/p1708755917499229
Previously the USD values weren't showing up sometimes, but I haven't seen that happen in a while. I also haven't seen the swap impact warning not be displayed when it ideally should be (like I saw it happen once https://crocodile-labs.slack.com/archives/D06BRRNK6RW/p1709417493711649) but still I think it would be better if the warning wasn't based on price impact percentage (which is how Uniswap UI does it) but by the difference between USD values. That would ensure no sneaky limit order nonsense would prevent the warning from being shown.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
