### PR TITLE
Fix usd diff warning flash on pair change

### DIFF
--- a/src/pages/Trade/Limit/Limit.tsx
+++ b/src/pages/Trade/Limit/Limit.tsx
@@ -165,6 +165,16 @@ export default function Limit() {
         activeTxHash.current = '';
     }, [tokenA.address + tokenB.address, primaryQuantity]);
 
+    useEffect(() => {
+        if (isTokenAPrimary) {
+            setLimitButtonErrorMessage('...');
+            setTokenBInputQty('');
+        } else {
+            setLimitButtonErrorMessage('...');
+            setTokenAInputQty('');
+        }
+    }, [tokenA.address + tokenB.address]);
+
     // TODO: is possible we can convert this to use the TradeTokenContext
     // However, unsure if the fact that baseToken comes from pool affects this
     const isSellTokenBase = pool?.baseToken.tokenAddr === tokenA.address;

--- a/src/pages/Trade/Swap/Swap.tsx
+++ b/src/pages/Trade/Swap/Swap.tsx
@@ -258,11 +258,15 @@ function Swap(props: propsIF) {
 
     useEffect(() => {
         if (
-            isNaN(parseFloat(sellQtyString)) ||
-            isNaN(parseFloat(buyQtyString)) ||
             (sellQtyString === '' && buyQtyString === '') ||
-            (isTokenAPrimary && parseFloat(sellQtyString) <= 0) ||
-            (!isTokenAPrimary && parseFloat(buyQtyString) <= 0)
+            (isTokenAPrimary &&
+                !isBuyLoading &&
+                (isNaN(parseFloat(sellQtyString)) ||
+                    parseFloat(sellQtyString) <= 0)) ||
+            (!isTokenAPrimary &&
+                !isSellLoading &&
+                (isNaN(parseFloat(buyQtyString)) ||
+                    parseFloat(buyQtyString) <= 0))
         ) {
             setSwapAllowed(false);
             setSwapButtonErrorMessage('Enter an Amount');
@@ -344,6 +348,18 @@ function Swap(props: propsIF) {
         activeTxHashInPendingTxs,
         isTokenAPrimary,
     ]);
+
+    useEffect(() => {
+        if (isTokenAPrimary) {
+            setIsBuyLoading(true);
+            setSwapButtonErrorMessage('...');
+            setBuyQtyString('');
+        } else {
+            setIsSellLoading(true);
+            setSwapButtonErrorMessage('...');
+            setSellQtyString('');
+        }
+    }, [tokenA.address + tokenB.address]);
 
     useEffect(() => {
         setNewSwapTransactionHash('');


### PR DESCRIPTION
### Describe your changes 
clear the secondary input quantity when token pair changes. This prevents the secondary input quantity from being used to calculate an incorrect USD value when the USD price changes before the input quantity is updated.
