### PR TITLE
Bring back Metamask Chrome preloading fix

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,6 +17,22 @@ import {
 import scrollLogo from './assets/images/networks/scroll.png';
 import blastLogo from './assets/images/networks/blast_logo.png';
 
+/* Perform a single forcible reload when the page first loads. Without this, there
+ * are issues with Metamask and Chrome preloading. This shortcircuits preloading, at the
+ * cost of higher load times, especially when pre-loading isn't happening. See:
+ * https://community.metamask.io/t/google-chrome-page-preload-causes-weirdness-with-metamask/24042
+ *
+ * Still happening as of May 2024 using Metamask v11.15.4 on Chrome 124. */
+const doReload =
+    JSON.parse(localStorage.getItem('ambiAppReloadTrigger') || 'true') &&
+    navigator.userAgent.includes('Chrome');
+if (doReload) {
+    localStorage.setItem('ambiAppReloadTrigger', 'false');
+    location.reload();
+} else {
+    localStorage.setItem('ambiAppReloadTrigger', 'true');
+}
+
 const metadata = {
     name: 'Ambient Finance',
     description:


### PR DESCRIPTION
### Describe your changes 
A year later, Metamask and Chrome still haven't fixed the issue where the wallet connection would fail if preloading is enabled. This PR brings back our old page reloading hack but now only applying it to Chrome (and its forks).