### PR TITLE
support only tokenB

### DIFF
--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -114,16 +114,21 @@ export const useUrlParams = (
         const areParamsMissing: boolean = requiredParams.some(
             (param: validParamsType) => !paramKeys.includes(param),
         );
-        const containsTokenParam: boolean =
-            paramKeys.includes('token') &&
-            !paramKeys.includes('tokenA') &&
-            !paramKeys.includes('tokenB');
+        const containsSingleTokenParam: boolean =
+            (paramKeys.includes('token') &&
+                !paramKeys.includes('tokenA') &&
+                !paramKeys.includes('tokenB')) ||
+            (!paramKeys.includes('token') &&
+                !paramKeys.includes('tokenA') &&
+                paramKeys.includes('tokenB'));
 
-        if (containsTokenParam) {
+        if (containsSingleTokenParam) {
+            const singleToken =
+                urlParamMap.get('token') || urlParamMap.get('tokenB');
             Promise.resolve(
                 getTopPairedTokenAddress(
                     urlParamMap.get('chain') || '',
-                    urlParamMap.get('token') || ZERO_ADDRESS,
+                    singleToken || ZERO_ADDRESS,
                     cachedFetchTopPairedToken,
                 ),
             )
@@ -131,13 +136,13 @@ export const useUrlParams = (
                     linkGenSwap.redirect({
                         chain: urlParamMap.get('chain') || '',
                         tokenA: result || ZERO_ADDRESS,
-                        tokenB: urlParamMap.get('token') || '',
+                        tokenB: singleToken || '',
                     });
                 })
                 .catch((err) => console.error(err));
         }
 
-        containsTokenParam &&
+        containsSingleTokenParam &&
             linkGenSwap.redirect({
                 chain: urlParamMap.get('chain') || '',
                 tokenA: ZERO_ADDRESS,

--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -142,13 +142,6 @@ export const useUrlParams = (
                 .catch((err) => console.error(err));
         }
 
-        containsSingleTokenParam &&
-            linkGenSwap.redirect({
-                chain: urlParamMap.get('chain') || '',
-                tokenA: ZERO_ADDRESS,
-                tokenB:
-                    urlParamMap.get('token') || urlParamMap.get('tokenB') || '',
-            });
         // redirect user if any required URL params are missing
         areParamsMissing && redirectUser();
         // array of parameter tuples from URL

--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -146,7 +146,8 @@ export const useUrlParams = (
             linkGenSwap.redirect({
                 chain: urlParamMap.get('chain') || '',
                 tokenA: ZERO_ADDRESS,
-                tokenB: urlParamMap.get('token') || '',
+                tokenB:
+                    urlParamMap.get('token') || urlParamMap.get('tokenB') || '',
             });
         // redirect user if any required URL params are missing
         areParamsMissing && redirectUser();


### PR DESCRIPTION
### Describe your changes 
If the swap page receives a single `tokenB` param instead of `token` or both `tokenA` and `tokenB`, the single token behavior will trigger.


### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?
