### PR TITLE
Release 2.5.9

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.5.8",
+    "version": "2.5.9",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.5.6",
+    "version": "2.5.7",
     "private": true,
     "type": "module",
     "dependencies": {


### PR DESCRIPTION
add support for links to swap page containing only a tokenB without a tokenA parameter, e.g. https://ambient.finance/swap/chain=0x13e31&tokenB=0x4fee793d435c6d2c10c135983bb9d6d4fc7b9bbds