### PR TITLE
add ETH price fallback for staked ETH tokens

### DIFF
--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -216,6 +216,11 @@ const useFetchPoolStats = (pool: PoolIF, isTradePair = false): PoolStatIF => {
                         ?.usdPrice || 0.0;
                 if (baseTokenPrice) {
                     setBasePrice(baseTokenPrice);
+                } else if (
+                    isETHorStakedEthToken(baseAddr) &&
+                    ethMainnetUsdPrice
+                ) {
+                    setBasePrice(ethMainnetUsdPrice);
                 } else if (poolPriceDisplayNum && quoteTokenPrice) {
                     // calculation of estimated base price below may be backwards;
                     // having a hard time finding an example of base missing a price

--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -9,6 +9,7 @@ import {
     getMoneynessRank,
     getFormattedNumber,
     expandPoolStats,
+    isETHorStakedEthToken,
 } from '../../ambient-utils/dataLayer';
 // import { estimateFrom24HrRangeApr } from '../../ambient-utils/api';
 import { sortBaseQuoteTokens, toDisplayPrice } from '@crocswap-libs/sdk';
@@ -37,6 +38,7 @@ const useFetchPoolStats = (pool: PoolIF, isTradePair = false): PoolStatIF => {
         activeNetwork,
         provider,
         chainData: { chainId },
+        ethMainnetUsdPrice,
     } = useContext(CrocEnvContext);
     const { lastBlockNumber } = useContext(ChainDataContext);
     const { tokens } = useContext(TokenContext);
@@ -225,6 +227,11 @@ const useFetchPoolStats = (pool: PoolIF, isTradePair = false): PoolStatIF => {
                 }
                 if (quoteTokenPrice) {
                     setQuotePrice(quoteTokenPrice);
+                } else if (
+                    isETHorStakedEthToken(quoteAddr) &&
+                    ethMainnetUsdPrice
+                ) {
+                    setQuotePrice(ethMainnetUsdPrice);
                 } else if (poolPriceDisplayNum && baseTokenPrice) {
                     const estimatedQuotePrice =
                         baseTokenPrice * poolPriceDisplayNum;

--- a/src/ambient-utils/constants/defaultTokens.ts
+++ b/src/ambient-utils/constants/defaultTokens.ts
@@ -499,6 +499,15 @@ export const scrollPxETH: TokenIF = {
     logoURI: '',
 };
 
+export const scrollPufETH: TokenIF = {
+    name: 'PufferVault',
+    address: '0xc4d46E8402F476F269c379677C99F18E22Ea030e',
+    symbol: 'PufETH',
+    decimals: 18,
+    chainId: 534352,
+    logoURI: '',
+};
+
 export const scrollWrappedETH: TokenIF = {
     name: 'Wrapped Ether',
     address: '0x5300000000000000000000000000000000000004',
@@ -650,6 +659,8 @@ export const defaultTokens: TokenIF[] = [
     scrollAxlUSDC,
     scrollWBTC,
     scrollRocketPoolETH,
+    scrollPxETH,
+    scrollPufETH,
     scrollWrappedETH,
     scrollWstETH,
     scrollWrsETH,

--- a/src/ambient-utils/dataLayer/functions/stablePairs.ts
+++ b/src/ambient-utils/dataLayer/functions/stablePairs.ts
@@ -30,6 +30,7 @@ import {
     scrollDAI,
     scrollPxETH,
     scrollRocketPoolETH,
+    scrollPufETH,
 } from '../../constants/defaultTokens';
 
 //       any sort of specific guaranteed relation between the tokens.
@@ -105,6 +106,7 @@ export const STAKED_ETH_TOKENS = [
     scrollSTONE.address,
     scrollUniETH.address,
     scrollPxETH.address,
+    scrollPufETH.address,
     scrollRocketPoolETH.address,
     blastWrsETH.address,
     blastEzETH.address,


### PR DESCRIPTION
### Describe your changes 
instead of immediately falling back on the pool price when the CoinGecko token price is missing, first check if the token is a staked ETH token and fallback on the mainnet price of ETH instead

### Link the related issue
![image](https://github.com/CrocSwap/ambient-ts-app/assets/570819/4dcfa502-077c-4593-98da-0e51c5f0c481)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
