### PR TITLE
remap WETH to native ETH while fetching top paired token

### DIFF
--- a/src/App/functions/checkPoolForWETH.ts
+++ b/src/App/functions/checkPoolForWETH.ts
@@ -1,9 +1,12 @@
 import { PoolDataIF } from '../../contexts/ExploreContext';
-import { isWethToken } from '../../ambient-utils/dataLayer';
+import { isWrappedNativeToken } from '../../ambient-utils/dataLayer';
 import { PoolIF } from '../../ambient-utils/types';
 
 // fn to determine if the pool in question has WETH
 export default function checkPoolForWETH(pool: PoolIF | PoolDataIF): boolean {
     // check for a canonical WETH address on the current chain
-    return isWethToken(pool.base.address) || isWethToken(pool.quote.address);
+    return (
+        isWrappedNativeToken(pool.base.address) ||
+        isWrappedNativeToken(pool.quote.address)
+    );
 }

--- a/src/ambient-utils/api/fetchTopPairedToken.ts
+++ b/src/ambient-utils/api/fetchTopPairedToken.ts
@@ -1,21 +1,17 @@
 /* eslint-disable camelcase */
-import {
-    PAIR_LOOKUP_URL,
-    WRAPPED_NATIVE_TOKENS,
-    ZERO_ADDRESS,
-} from '../constants';
+import { PAIR_LOOKUP_URL, ZERO_ADDRESS } from '../constants';
+import { isWrappedNativeToken } from '../dataLayer';
 import { memoizePromiseFn } from '../dataLayer/functions/memoizePromiseFn';
 
 export const fetchTopPairedToken = async (address: string, chainId: string) => {
-    const isWrappedNativeToken = WRAPPED_NATIVE_TOKENS.includes(
-        address.toLowerCase(),
-    );
     try {
         const response = await fetch(
             PAIR_LOOKUP_URL +
                 new URLSearchParams({
                     chain: chainId,
-                    token: isWrappedNativeToken ? ZERO_ADDRESS : address,
+                    token: isWrappedNativeToken(address)
+                        ? ZERO_ADDRESS
+                        : address,
                 }),
         );
         const result = await response.json();

--- a/src/ambient-utils/api/fetchTopPairedToken.ts
+++ b/src/ambient-utils/api/fetchTopPairedToken.ts
@@ -1,14 +1,21 @@
 /* eslint-disable camelcase */
-import { PAIR_LOOKUP_URL } from '../constants';
+import {
+    PAIR_LOOKUP_URL,
+    WRAPPED_NATIVE_TOKENS,
+    ZERO_ADDRESS,
+} from '../constants';
 import { memoizePromiseFn } from '../dataLayer/functions/memoizePromiseFn';
 
 export const fetchTopPairedToken = async (address: string, chainId: string) => {
+    const isWrappedNativeToken = WRAPPED_NATIVE_TOKENS.includes(
+        address.toLowerCase(),
+    );
     try {
         const response = await fetch(
             PAIR_LOOKUP_URL +
                 new URLSearchParams({
                     chain: chainId,
-                    token: address,
+                    token: isWrappedNativeToken ? ZERO_ADDRESS : address,
                 }),
         );
         const result = await response.json();

--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -29,6 +29,12 @@ export const PAIR_LOOKUP_URL =
     import.meta.env.VITE_PAIR_LOOKUP_URL ||
     'https://croc-smart.liquidity.tools/pair-lookup?';
 
+export const WRAPPED_NATIVE_TOKENS = [
+    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH on mainnet
+    '0x5300000000000000000000000000000000000004', // WETH on scroll
+    '0x4300000000000000000000000000000000000004', // WETH on blast
+];
+
 export const HISTORICAL_CANDLES_URL =
     import.meta.env.VITE_HISTORICAL_CANDLES_URL || 'https://ambindexer.net';
 

--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -29,12 +29,6 @@ export const PAIR_LOOKUP_URL =
     import.meta.env.VITE_PAIR_LOOKUP_URL ||
     'https://croc-smart.liquidity.tools/pair-lookup?';
 
-export const WRAPPED_NATIVE_TOKENS = [
-    '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // WETH on mainnet
-    '0x5300000000000000000000000000000000000004', // WETH on scroll
-    '0x4300000000000000000000000000000000000004', // WETH on blast
-];
-
 export const HISTORICAL_CANDLES_URL =
     import.meta.env.VITE_HISTORICAL_CANDLES_URL || 'https://ambindexer.net';
 

--- a/src/ambient-utils/dataLayer/functions/removeWrappedNative.ts
+++ b/src/ambient-utils/dataLayer/functions/removeWrappedNative.ts
@@ -1,4 +1,4 @@
-import { isWethToken } from './stablePairs';
+import { isWrappedNativeToken } from './stablePairs';
 import { TokenIF } from '../../types';
 
 // fn to remove the wrapped native token of the current chain from a token array
@@ -8,5 +8,5 @@ export function removeWrappedNative(
 ): TokenIF[] {
     // return the token array with the wrapped native removed, or the original
     // ... token array if the current chain has no wrapped native token specified
-    return tokens.filter((tkn: TokenIF) => !isWethToken(tkn.address));
+    return tokens.filter((tkn: TokenIF) => !isWrappedNativeToken(tkn.address));
 }

--- a/src/ambient-utils/dataLayer/functions/stablePairs.ts
+++ b/src/ambient-utils/dataLayer/functions/stablePairs.ts
@@ -68,6 +68,13 @@ export function isWrappedNativeToken(addr: string): boolean {
     return WRAPPED_NATIVE_TOKENS.includes(addr.toLowerCase());
 }
 
+export function remapTokenIfWrappedNative(addr: string): string {
+    if (isWrappedNativeToken(addr)) {
+        return ZERO_ADDRESS;
+    }
+    return addr;
+}
+
 // No need to specify chain ID because token address is unique even across chains
 export const STABLE_USD_TOKENS = [
     mainnetDAI.address,

--- a/src/ambient-utils/dataLayer/functions/stablePairs.ts
+++ b/src/ambient-utils/dataLayer/functions/stablePairs.ts
@@ -64,8 +64,8 @@ export function isWbtcToken(addr: string): boolean {
 }
 
 // @return true if the token is a WETH or wrapped native token asset
-export function isWethToken(addr: string): boolean {
-    return WETH_TOKENS.includes(addr.toLowerCase());
+export function isWrappedNativeToken(addr: string): boolean {
+    return WRAPPED_NATIVE_TOKENS.includes(addr.toLowerCase());
 }
 
 // No need to specify chain ID because token address is unique even across chains
@@ -112,7 +112,7 @@ export const STAKED_ETH_TOKENS = [
     blastEzETH.address,
 ].map((x) => x.toLowerCase());
 
-export const WETH_TOKENS = [
+export const WRAPPED_NATIVE_TOKENS = [
     '0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2', // Mainnet
     '0x5300000000000000000000000000000000000004', // Scroll (test and main)
     '0x863d7abb9c62d8bc69ea9ebc3e3583057d533e6f', // Scroll Sepolia

--- a/src/components/Global/Explore/DexTokens.tsx
+++ b/src/components/Global/Explore/DexTokens.tsx
@@ -18,7 +18,7 @@ import { PoolContext } from '../../../contexts/PoolContext';
 import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 import { usePoolList2 } from '../../../App/hooks/usePoolList2';
 import { CrocEnvContext } from '../../../contexts/CrocEnvContext';
-import { isWethToken } from '../../../ambient-utils/dataLayer';
+import { isWrappedNativeToken } from '../../../ambient-utils/dataLayer';
 
 export type columnSlugs =
     | 'token'
@@ -156,10 +156,12 @@ function DexTokens(props: propsIF) {
                                         (p: GCServerPoolIF) =>
                                             (p.base.toLowerCase() ===
                                                 token.tokenAddr.toLowerCase() &&
-                                                !isWethToken(p.quote)) ||
+                                                !isWrappedNativeToken(
+                                                    p.quote,
+                                                )) ||
                                             (p.quote.toLowerCase() ===
                                                 token.tokenAddr.toLowerCase() &&
-                                                !isWethToken(p.base)),
+                                                !isWrappedNativeToken(p.base)),
                                     );
                                     if (
                                         !token.tokenMeta ||

--- a/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelect.tsx
@@ -18,7 +18,7 @@ import { CachedDataContext } from '../../../contexts/CachedDataContext';
 import { IS_LOCAL_ENV, ZERO_ADDRESS } from '../../../ambient-utils/constants';
 import {
     removeWrappedNative,
-    isWethToken,
+    isWrappedNativeToken,
 } from '../../../ambient-utils/dataLayer';
 import { WarningBox } from '../../RangeActionModal/WarningBox/WarningBox';
 import { IoIosArrowBack } from 'react-icons/io';
@@ -282,7 +282,7 @@ export const SoloTokenSelect = (props: propsIF) => {
                 )}
             </div>
             <div style={{ padding: '1rem' }}>
-                {isWethToken(validatedInput) && (
+                {isWrappedNativeToken(validatedInput) && (
                     <WarningBox
                         title=''
                         details={WETH_WARNING}
@@ -310,7 +310,7 @@ export const SoloTokenSelect = (props: propsIF) => {
                     />
                 )}
             </div>
-            {isWethToken(validatedInput) &&
+            {isWrappedNativeToken(validatedInput) &&
                 [tokens.getTokenByAddress(ZERO_ADDRESS) as TokenIF].map(
                     (token: TokenIF) => (
                         <TokenSelect

--- a/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
+++ b/src/components/Global/TokenSelectContainer/SoloTokenSelectModal.tsx
@@ -19,7 +19,7 @@ import { IS_LOCAL_ENV, ZERO_ADDRESS } from '../../../ambient-utils/constants';
 import Modal from '../Modal/Modal';
 import {
     removeWrappedNative,
-    isWethToken,
+    isWrappedNativeToken,
 } from '../../../ambient-utils/dataLayer';
 import { WarningBox } from '../../RangeActionModal/WarningBox/WarningBox';
 import { TradeDataContext } from '../../../contexts/TradeDataContext';
@@ -274,7 +274,7 @@ export const SoloTokenSelectModal = (props: propsIF) => {
                     )}
                 </div>
                 <div style={{ padding: '1rem' }}>
-                    {isWethToken(validatedInput) && (
+                    {isWrappedNativeToken(validatedInput) && (
                         <WarningBox
                             title=''
                             details={WETH_WARNING}
@@ -302,7 +302,7 @@ export const SoloTokenSelectModal = (props: propsIF) => {
                         />
                     )}
                 </div>
-                {isWethToken(validatedInput) &&
+                {isWrappedNativeToken(validatedInput) &&
                     [tokens.getTokenByAddress(ZERO_ADDRESS) as TokenIF].map(
                         (token: TokenIF) => (
                             <TokenSelect

--- a/src/contexts/PoolContext.tsx
+++ b/src/contexts/PoolContext.tsx
@@ -14,7 +14,10 @@ import { usePoolList } from '../App/hooks/usePoolList';
 import { PoolIF, PoolStatIF, TokenIF } from '../ambient-utils/types';
 import useFetchPoolStats from '../App/hooks/useFetchPoolStats';
 import { TradeDataContext } from './TradeDataContext';
-import { getFormattedNumber, isWethToken } from '../ambient-utils/dataLayer';
+import {
+    getFormattedNumber,
+    isWrappedNativeToken,
+} from '../ambient-utils/dataLayer';
 
 interface PoolContextIF {
     poolList: PoolIF[];
@@ -108,8 +111,9 @@ export const PoolContextProvider = (props: { children: React.ReactNode }) => {
                 const baseAddr: string = p.base.address.toLowerCase();
                 const quoteAddr: string = p.quote.address.toLowerCase();
                 const isMatch: boolean =
-                    (baseAddr === tkn1Addr && !isWethToken(quoteAddr)) ||
-                    (quoteAddr === tkn1Addr && !isWethToken(baseAddr));
+                    (baseAddr === tkn1Addr &&
+                        !isWrappedNativeToken(quoteAddr)) ||
+                    (quoteAddr === tkn1Addr && !isWrappedNativeToken(baseAddr));
                 return isMatch;
             });
         }

--- a/src/pages/Explore/useTokenStats.ts
+++ b/src/pages/Explore/useTokenStats.ts
@@ -9,7 +9,7 @@ import {
     DexTokenAggServerIF,
     getChainStats,
     getFormattedNumber,
-    isWethToken,
+    isWrappedNativeToken,
 } from '../../ambient-utils/dataLayer';
 import { TokenIF } from '../../ambient-utils/types';
 import { tokenMethodsIF } from '../../App/hooks/useTokens';
@@ -90,7 +90,7 @@ export const useTokenStats = (
                             (result) =>
                                 (result as { value: dexTokenData }).value,
                         )
-                        .filter((t) => !isWethToken(t.tokenAddr));
+                        .filter((t) => !isWrappedNativeToken(t.tokenAddr));
                     setDexTokens(fulfilledResults);
                 }
             } catch (error) {

--- a/src/utils/hooks/useUrlParams.ts
+++ b/src/utils/hooks/useUrlParams.ts
@@ -6,7 +6,11 @@ import { tokenMethodsIF } from '../../App/hooks/useTokens';
 import { pageNames, linkGenMethodsIF, useLinkGen } from './useLinkGen';
 import { TokenIF } from '../../ambient-utils/types';
 // import { getDefaultPairForChain } from '../../ambient-utils/constants';
-import { validateAddress, validateChain } from '../../ambient-utils/dataLayer';
+import {
+    remapTokenIfWrappedNative,
+    validateAddress,
+    validateChain,
+} from '../../ambient-utils/dataLayer';
 import { TradeDataContext } from '../../contexts/TradeDataContext';
 import { ZERO_ADDRESS } from '../../ambient-utils/constants';
 import { getTopPairedTokenAddress } from '../../ambient-utils/dataLayer/functions/getTopPairedTokenAddress';
@@ -27,7 +31,7 @@ const validParams = [
 ] as const;
 
 // type generated as a union of all string literals in `validParams`
-export type validParamsType = (typeof validParams)[number];
+export type validParamsType = typeof validParams[number];
 
 export interface updatesIF {
     update?: Array<[validParamsType, string | number]>;
@@ -123,8 +127,9 @@ export const useUrlParams = (
                 paramKeys.includes('tokenB'));
 
         if (containsSingleTokenParam) {
-            const singleToken =
-                urlParamMap.get('token') || urlParamMap.get('tokenB');
+            const singleToken = remapTokenIfWrappedNative(
+                urlParamMap.get('token') || urlParamMap.get('tokenB') || '',
+            );
 
             const chainToUse = urlParamMap.get('chain') || dfltChainId;
 


### PR DESCRIPTION
### Describe your changes 
Dexscreener doesn't support native ETH and currently we need to remap it so the largest ETH/X pairs can get properly routed automatically.

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

Visiting `/swap/tokenB=0x5300000000000000000000000000000000000004&chain=0x82750` will now resolve to `USDC/ETH` pair on Scroll instead of `USDC/wETH` or `ETH/wETH` pair.