### PR TITLE
Fix link to Canto

### DIFF
--- a/src/App/components/PageHeader/NetworkSelector/NetworkSelector.tsx
+++ b/src/App/components/PageHeader/NetworkSelector/NetworkSelector.tsx
@@ -156,7 +156,7 @@ export default function NetworkSelector(props: propsIF) {
     const cantoNetwork: JSX.Element = (
         <NetworkItem
             id='canto_network_selector'
-            onClick={() => window.open('http://canto.io/lp', '_blank')}
+            onClick={() => window.open('https://app.canto.io/lp', '_blank')}
             key='canto'
             custom={chains.length + 1}
             variants={ItemEnterAnimation}
@@ -292,10 +292,10 @@ export default function NetworkSelector(props: propsIF) {
                             .includes('scroll')
                             ? scrollLogo
                             : lookupChain(chainId)
-                                  .displayName.toLowerCase()
-                                  .includes('blast')
-                            ? blastLogo
-                            : ETH
+                                    .displayName.toLowerCase()
+                                    .includes('blast')
+                              ? blastLogo
+                              : ETH
                     }
                 >
                     <MenuContent


### PR DESCRIPTION
### Describe your changes 
Just a simple URL change in NetworkSelector.tsx. The current link to the Canto LP page is broken (gives a 404).

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

n/a

**Environmental conditions that may result in expected but differential behavior.**

n/a

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
