### PR TITLE
remove auto network switching on mismatch

### DIFF
--- a/src/contexts/CrocEnvContext.tsx
+++ b/src/contexts/CrocEnvContext.tsx
@@ -7,10 +7,7 @@ import {
     useMemo,
     useState,
 } from 'react';
-import {
-    useSwitchNetwork,
-    useWeb3ModalProvider,
-} from '@web3modal/ethers/react';
+import { useWeb3ModalProvider } from '@web3modal/ethers/react';
 import { useBlacklist } from '../App/hooks/useBlacklist';
 import { useTopPools } from '../App/hooks/useTopPools';
 import { CachedDataContext } from './CachedDataContext';
@@ -237,9 +234,9 @@ export const CrocEnvContextProvider = (props: { children: ReactNode }) => {
                 // Since this is a weird case, it's best not to rush things - maybe this happens
                 // during the short moment while the network is switching already, idk.
                 await new Promise((resolve) => setTimeout(resolve, 1000));
-                await useSwitchNetwork().switchNetwork(
-                    Number(chainData.chainId),
-                );
+                // await useSwitchNetwork().switchNetwork(
+                //     Number(chainData.chainId),
+                // );
             }
         }
     };


### PR DESCRIPTION
### Describe your changes 
this new change (now commented out) was causing metamask to automatically prompt the user to switch back to a network they just left if the new network was not supported by an Ambient app currently running in the same or different tab.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
