### PR TITLE
add ellipsis for buy side of limit mint txs and view status button for limit and range transactions

### DIFF
--- a/src/components/Global/TabComponent/TabComponent.tsx
+++ b/src/components/Global/TabComponent/TabComponent.tsx
@@ -52,24 +52,24 @@ export default function TabComponent(props: TabPropsIF) {
         setOutsideControl,
         selectedOutsideTab,
         toggleTradeTable,
-        setCurrentTxActiveInTransactions,
-        setCurrentLimitOrderActive,
-        setCurrentPositionActive,
+        // setCurrentTxActiveInTransactions,
+        // setCurrentLimitOrderActive,
+        // setCurrentPositionActive,
     } = useContext(TradeTableContext);
 
     const { tradeTableState } = useContext(ChartContext);
 
     const [selectedTab, setSelectedTab] = useState(data[0]);
 
-    const resetActiveRow = () => {
-        setCurrentTxActiveInTransactions('');
-        setCurrentLimitOrderActive('');
-        setCurrentPositionActive('');
-    };
+    // const resetActiveRow = () => {
+    //     setCurrentTxActiveInTransactions('');
+    //     setCurrentLimitOrderActive('');
+    //     setCurrentPositionActive('');
+    // };
 
-    useEffect(() => {
-        resetActiveRow();
-    }, [selectedTab.label]);
+    // useEffect(() => {
+    //     resetActiveRow();
+    // }, [selectedTab.label]);
 
     function handleSelectedTab(item: tabData) {
         setOutsideControl(false);

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
@@ -28,11 +28,12 @@ interface propsIF {
     isAccountView: boolean;
     handleWalletClick: () => void;
     openDetailsModal: () => void;
+    isOwnerActiveAccount: boolean;
 }
 
 // React functional component
 export default function TransactionsMenu(props: propsIF) {
-    const { tx, isAccountView, openDetailsModal } = props;
+    const { tx, isAccountView, openDetailsModal, isOwnerActiveAccount } = props;
     const {
         chainData: { blockExplorer, chainId },
     } = useContext(CrocEnvContext);
@@ -47,16 +48,21 @@ export default function TransactionsMenu(props: propsIF) {
     const {
         sidebar: { isOpen: isSidebarOpen },
     } = useContext(SidebarContext);
-    const { handlePulseAnimation, setActiveMobileComponent } =
-        useContext(TradeTableContext);
+    const {
+        handlePulseAnimation,
+        setActiveMobileComponent,
+        setOutsideControl,
+        setSelectedOutsideTab,
+        setShowAllData,
+    } = useContext(TradeTableContext);
 
     const showAbbreviatedCopyTradeButton = isAccountView
         ? isSidebarOpen
             ? useMediaQuery('(max-width: 1700px)')
             : useMediaQuery('(max-width: 1400px)')
         : isSidebarOpen
-        ? useMediaQuery('(max-width: 1500px)')
-        : useMediaQuery('(max-width: 1250px)');
+          ? useMediaQuery('(max-width: 1500px)')
+          : useMediaQuery('(max-width: 1250px)');
 
     const {
         tokenA,
@@ -124,8 +130,6 @@ export default function TransactionsMenu(props: propsIF) {
         }
     }
 
-    const isTxCopiable = true;
-
     const walletButton = (
         <Chip ariaLabel='View wallet.' onClick={props.handleWalletClick}>
             Wallet
@@ -191,9 +195,35 @@ export default function TransactionsMenu(props: propsIF) {
         handleCopyClick();
     };
 
+    const viewButtonFunction = (entityType: string) => {
+        switch (entityType) {
+            case 'limitOrder':
+                setOutsideControl(true);
+                setSelectedOutsideTab(1);
+                setShowAllData(true);
+                break;
+            case 'liqchange':
+                setOutsideControl(true);
+                setSelectedOutsideTab(2);
+                setShowAllData(true);
+                break;
+            default:
+                setOutsideControl(true);
+                setSelectedOutsideTab(0);
+                setShowAllData(true);
+                break;
+        }
+    };
+
     const copyButton = (
         <Chip onClick={() => copyButtonFunction(tx.entityType)}>
             {showAbbreviatedCopyTradeButton ? 'Copy' : 'Copy Trade'}
+        </Chip>
+    );
+
+    const viewButton = (
+        <Chip onClick={() => viewButtonFunction(tx.entityType)}>
+            {showAbbreviatedCopyTradeButton ? 'View' : 'View Status'}
         </Chip>
     );
 
@@ -216,8 +246,15 @@ export default function TransactionsMenu(props: propsIF) {
     const showCopyButtonOutsideDropdownMenu =
         useMediaQuery('(min-width: 650px)');
     // --------------------------------
+
+    const showViewButton =
+        isOwnerActiveAccount &&
+        ['limitOrder', 'liqchange'].includes(tx.entityType);
+
     const transactionsMenu = (
-        <div className={styles.actions_menu}>{isTxCopiable && copyButton}</div>
+        <div className={styles.actions_menu}>
+            {showViewButton ? viewButton : copyButton}
+        </div>
     );
 
     const menuContent = (

--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/TransactionsMenu.tsx
@@ -29,11 +29,18 @@ interface propsIF {
     handleWalletClick: () => void;
     openDetailsModal: () => void;
     isOwnerActiveAccount: boolean;
+    positionHash: string;
 }
 
 // React functional component
 export default function TransactionsMenu(props: propsIF) {
-    const { tx, isAccountView, openDetailsModal, isOwnerActiveAccount } = props;
+    const {
+        tx,
+        isAccountView,
+        openDetailsModal,
+        isOwnerActiveAccount,
+        positionHash,
+    } = props;
     const {
         chainData: { blockExplorer, chainId },
     } = useContext(CrocEnvContext);
@@ -54,6 +61,8 @@ export default function TransactionsMenu(props: propsIF) {
         setOutsideControl,
         setSelectedOutsideTab,
         setShowAllData,
+        setCurrentLimitOrderActive,
+        setCurrentPositionActive,
     } = useContext(TradeTableContext);
 
     const showAbbreviatedCopyTradeButton = isAccountView
@@ -200,17 +209,19 @@ export default function TransactionsMenu(props: propsIF) {
             case 'limitOrder':
                 setOutsideControl(true);
                 setSelectedOutsideTab(1);
-                setShowAllData(true);
+                setShowAllData(false);
+                setCurrentLimitOrderActive(positionHash);
                 break;
             case 'liqchange':
                 setOutsideControl(true);
                 setSelectedOutsideTab(2);
-                setShowAllData(true);
+                setShowAllData(false);
+                setCurrentPositionActive(positionHash);
                 break;
             default:
                 setOutsideControl(true);
                 setSelectedOutsideTab(0);
-                setShowAllData(true);
+                setShowAllData(false);
                 break;
         }
     };

--- a/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
+++ b/src/components/Trade/TradeTabs/Orders/OrderTable/OrderRow.tsx
@@ -94,16 +94,16 @@ function OrderRow(props: propsIF) {
             ? baseTokenCharacter
             : quoteTokenCharacter
         : !isDenomBase
-        ? baseTokenCharacter
-        : quoteTokenCharacter;
+          ? baseTokenCharacter
+          : quoteTokenCharacter;
 
     const sideCharacter = isAccountView
         ? isBaseTokenMoneynessGreaterOrEqual
             ? quoteTokenCharacter
             : baseTokenCharacter
         : isDenomBase
-        ? baseTokenCharacter
-        : quoteTokenCharacter;
+          ? baseTokenCharacter
+          : quoteTokenCharacter;
 
     const priceStyle = 'base_color';
 
@@ -111,11 +111,12 @@ function OrderRow(props: propsIF) {
         isOwnerActiveAccount && showAllData
             ? 'accent2'
             : ensName || userNameToDisplay === 'You'
-            ? 'accent1'
-            : 'text1';
+              ? 'accent1'
+              : 'text1';
 
     const orderDomId =
-        limitOrder.limitOrderId === currentLimitOrderActive
+        limitOrder.limitOrderId === currentLimitOrderActive ||
+        posHash === currentLimitOrderActive
             ? `order-${limitOrder.limitOrderId}`
             : '';
 
@@ -131,7 +132,8 @@ function OrderRow(props: propsIF) {
     }
 
     useEffect(() => {
-        limitOrder.limitOrderId === currentLimitOrderActive
+        limitOrder.limitOrderId === currentLimitOrderActive ||
+        posHash === currentLimitOrderActive
             ? scrollToDiv()
             : null;
     }, [currentLimitOrderActive]);
@@ -155,8 +157,8 @@ function OrderRow(props: propsIF) {
                     isOwnerActiveAccount
                         ? 'account'
                         : ensName
-                        ? ensName
-                        : ownerId
+                          ? ensName
+                          : ownerId
                 }`,
             );
     }
@@ -244,7 +246,10 @@ function OrderRow(props: propsIF) {
             <OrderRowStyled
                 size={tableView}
                 account={isAccountView}
-                active={limitOrder.limitOrderId === currentLimitOrderActive}
+                active={
+                    limitOrder.limitOrderId === currentLimitOrderActive ||
+                    posHash === currentLimitOrderActive
+                }
                 user={userNameToDisplay === 'You' && showAllData}
                 id={orderDomId}
                 onClick={openDetailsModal}

--- a/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
@@ -77,8 +77,8 @@ function TransactionRow(props: propsIF) {
         isOwnerActiveAccount && showAllData
             ? 'accent2'
             : ensName || userNameToDisplay === 'You'
-            ? 'accent1'
-            : 'text1';
+              ? 'accent1'
+              : 'text1';
 
     function scrollToDiv() {
         const element = document.getElementById(idForDOM);
@@ -233,6 +233,7 @@ function TransactionRow(props: propsIF) {
                         isAccountView={props.isAccountView}
                         handleWalletClick={handleWalletClick}
                         openDetailsModal={openDetailsModal}
+                        isOwnerActiveAccount={isOwnerActiveAccount}
                     />
                 </div>
             </TransactionRowStyled>

--- a/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/TransactionsTable/TransactionRow.tsx
@@ -56,6 +56,7 @@ function TransactionRow(props: propsIF) {
         isBuy,
         elapsedTimeString,
         isBaseTokenMoneynessGreaterOrEqual,
+        positionHash,
     } = useProcessTransaction(tx, userAddress, crocEnv, isAccountView);
 
     const {
@@ -234,6 +235,7 @@ function TransactionRow(props: propsIF) {
                         handleWalletClick={handleWalletClick}
                         openDetailsModal={openDetailsModal}
                         isOwnerActiveAccount={isOwnerActiveAccount}
+                        positionHash={positionHash}
                     />
                 </div>
             </TransactionRowStyled>

--- a/src/utils/hooks/useProcessTransaction.ts
+++ b/src/utils/hooks/useProcessTransaction.ts
@@ -21,6 +21,7 @@ import { TradeDataContext } from '../../contexts/TradeDataContext';
 import { useFetchBatch } from '../../App/hooks/useFetchBatch';
 import { UserDataContext } from '../../contexts/UserDataContext';
 import { CachedDataContext } from '../../contexts/CachedDataContext';
+import { getPositionHash } from '../../ambient-utils/dataLayer/functions/getPositionHash';
 
 export const useProcessTransaction = (
     tx: TransactionIF,
@@ -143,6 +144,8 @@ export const useProcessTransaction = (
     let isBaseFlowPositive = false;
     let isQuoteFlowPositive = false;
 
+    let positionHash = '';
+
     const baseTokenCharacter = tx.baseSymbol
         ? getUnicodeCharacter(tx.baseSymbol)
         : '';
@@ -212,6 +215,15 @@ export const useProcessTransaction = (
         } else {
             truncatedDisplayPrice = undefined;
         }
+        positionHash = getPositionHash(undefined, {
+            isPositionTypeAmbient: false,
+            user: tx.user ?? '',
+            baseAddress: tx.base ?? '',
+            quoteAddress: tx.quote ?? '',
+            poolIdx: tx.poolIdx ?? 0,
+            bidTick: tx.bidTick ?? 0,
+            askTick: tx.askTick ?? 0,
+        });
     } else if (tx.entityType === 'liqchange') {
         if (
             tx.bidTickPriceDecimalCorrected &&
@@ -291,6 +303,15 @@ export const useProcessTransaction = (
             truncatedLowDisplayPrice = undefined;
             truncatedHighDisplayPrice = undefined;
         }
+        positionHash = getPositionHash(undefined, {
+            isPositionTypeAmbient: tx.positionType == 'ambient',
+            user: tx.user ?? '',
+            baseAddress: tx.base ?? '',
+            quoteAddress: tx.quote ?? '',
+            poolIdx: tx.poolIdx ?? 0,
+            bidTick: tx.bidTick ?? 0,
+            askTick: tx.askTick ?? 0,
+        });
     } else {
         const priceDecimalCorrected = tx.swapPriceDecimalCorrected;
         const invPriceDecimalCorrected = tx.swapInvPriceDecimalCorrected;
@@ -595,5 +616,7 @@ export const useProcessTransaction = (
 
         //
         elapsedTimeString,
+
+        positionHash,
     } as const;
 };

--- a/src/utils/hooks/useProcessTransaction.ts
+++ b/src/utils/hooks/useProcessTransaction.ts
@@ -170,8 +170,8 @@ export const useProcessTransaction = (
             ? 1 / priceHalfBelow
             : 1 / priceHalfAbove
         : tx.isBid
-        ? priceHalfBelow
-        : priceHalfAbove;
+          ? priceHalfBelow
+          : priceHalfAbove;
 
     if (tx.entityType === 'limitOrder') {
         if (tx.limitPriceDecimalCorrected && tx.invLimitPriceDecimalCorrected) {
@@ -200,15 +200,15 @@ export const useProcessTransaction = (
                         ? priceDecimalCorrected * basePrice
                         : undefined
                     : quotePrice
-                    ? invPriceDecimalCorrected * quotePrice
-                    : undefined
+                      ? invPriceDecimalCorrected * quotePrice
+                      : undefined
                 : isDenomBase
-                ? quotePrice
-                    ? invPriceDecimalCorrected * quotePrice
-                    : undefined
-                : basePrice
-                ? priceDecimalCorrected * basePrice
-                : undefined;
+                  ? quotePrice
+                      ? invPriceDecimalCorrected * quotePrice
+                      : undefined
+                  : basePrice
+                    ? priceDecimalCorrected * basePrice
+                    : undefined;
         } else {
             truncatedDisplayPrice = undefined;
         }
@@ -262,15 +262,15 @@ export const useProcessTransaction = (
                         ? bidTickPriceDecimalCorrected * basePrice
                         : undefined
                     : quotePrice
-                    ? bidTickInvPriceDecimalCorrected * quotePrice
-                    : undefined
+                      ? bidTickInvPriceDecimalCorrected * quotePrice
+                      : undefined
                 : isDenomBase
-                ? quotePrice
-                    ? bidTickInvPriceDecimalCorrected * quotePrice
-                    : undefined
-                : basePrice
-                ? bidTickPriceDecimalCorrected * basePrice
-                : undefined;
+                  ? quotePrice
+                      ? bidTickInvPriceDecimalCorrected * quotePrice
+                      : undefined
+                  : basePrice
+                    ? bidTickPriceDecimalCorrected * basePrice
+                    : undefined;
 
             highDisplayPriceInUsd = isAccountView
                 ? isBaseTokenMoneynessGreaterOrEqual
@@ -278,15 +278,15 @@ export const useProcessTransaction = (
                         ? askTickPriceDecimalCorrected * basePrice
                         : undefined
                     : quotePrice
-                    ? askTickInvPriceDecimalCorrected * quotePrice
-                    : undefined
+                      ? askTickInvPriceDecimalCorrected * quotePrice
+                      : undefined
                 : isDenomBase
-                ? quotePrice
-                    ? askTickInvPriceDecimalCorrected * quotePrice
-                    : undefined
-                : basePrice
-                ? askTickPriceDecimalCorrected * basePrice
-                : undefined;
+                  ? quotePrice
+                      ? askTickInvPriceDecimalCorrected * quotePrice
+                      : undefined
+                  : basePrice
+                    ? askTickPriceDecimalCorrected * basePrice
+                    : undefined;
         } else {
             truncatedLowDisplayPrice = undefined;
             truncatedHighDisplayPrice = undefined;
@@ -317,15 +317,15 @@ export const useProcessTransaction = (
                     ? priceDecimalCorrected * basePrice
                     : undefined
                 : quotePrice
-                ? invPriceDecimalCorrected * quotePrice
-                : undefined
+                  ? invPriceDecimalCorrected * quotePrice
+                  : undefined
             : isDenomBase
-            ? quotePrice
-                ? invPriceDecimalCorrected * quotePrice
-                : undefined
-            : basePrice
-            ? priceDecimalCorrected * basePrice
-            : undefined;
+              ? quotePrice
+                  ? invPriceDecimalCorrected * quotePrice
+                  : undefined
+              : basePrice
+                ? priceDecimalCorrected * basePrice
+                : undefined;
     }
 
     if (
@@ -380,35 +380,35 @@ export const useProcessTransaction = (
             ? tx.changeType === 'burn'
                 ? 'remove'
                 : tx.changeType === 'harvest'
-                ? 'harvest'
-                : 'add'
+                  ? 'harvest'
+                  : 'add'
             : tx.entityType === 'limitOrder'
-            ? tx.changeType === 'mint'
-                ? isAccountView
-                    ? isBaseTokenMoneynessGreaterOrEqual
-                        ? isBuy
-                            ? 'buy'
-                            : 'sell'
-                        : isBuy
+              ? tx.changeType === 'mint'
+                  ? isAccountView
+                      ? isBaseTokenMoneynessGreaterOrEqual
+                          ? isBuy
+                              ? 'buy'
+                              : 'sell'
+                          : isBuy
+                            ? 'sell'
+                            : 'buy'
+                      : (isDenomBase && tx.isBuy) || (!isDenomBase && !tx.isBuy)
                         ? 'sell'
                         : 'buy'
-                    : (isDenomBase && tx.isBuy) || (!isDenomBase && !tx.isBuy)
-                    ? 'sell'
-                    : 'buy'
-                : tx.changeType === 'recover'
-                ? 'claim'
-                : 'remove'
-            : isAccountView
-            ? isBaseTokenMoneynessGreaterOrEqual
-                ? isBuy
-                    ? 'buy'
-                    : 'sell'
-                : isBuy
-                ? 'sell'
-                : 'buy'
-            : (isDenomBase && tx.isBuy) || (!isDenomBase && !tx.isBuy)
-            ? 'sell'
-            : 'buy';
+                  : tx.changeType === 'recover'
+                    ? 'claim'
+                    : 'remove'
+              : isAccountView
+                ? isBaseTokenMoneynessGreaterOrEqual
+                    ? isBuy
+                        ? 'buy'
+                        : 'sell'
+                    : isBuy
+                      ? 'sell'
+                      : 'buy'
+                : (isDenomBase && tx.isBuy) || (!isDenomBase && !tx.isBuy)
+                  ? 'sell'
+                  : 'buy';
 
     const transactionTypeSide =
         tx.entityType === 'liqchange'
@@ -416,8 +416,8 @@ export const useProcessTransaction = (
                 ? 'rangeAdd'
                 : 'rangeRemove'
             : tx.entityType === 'limitOrder'
-            ? 'limit'
-            : 'market';
+              ? 'limit'
+              : 'market';
 
     const type =
         tx.entityType === 'liqchange'
@@ -425,8 +425,8 @@ export const useProcessTransaction = (
                 ? 'range'
                 : 'range'
             : tx.entityType === 'limitOrder'
-            ? 'limit'
-            : 'market';
+              ? 'limit'
+              : 'market';
 
     const usdValueNum = tx.totalValueUSD;
     const totalFlowUSDNum = tx.totalValueUSD;
@@ -443,15 +443,26 @@ export const useProcessTransaction = (
         prefix: '$',
     });
 
+    const isLimitRemove =
+        tx.entityType === 'limitOrder' && sideType === 'remove';
+
+    const isLimitAdd =
+        tx.entityType === 'limitOrder' &&
+        (sideType === 'buy' || sideType === 'sell');
+
     // --------------------------------------------------------
 
     const usdValue = totalFlowUSD ?? usdValueString;
 
     const baseQuantityDisplay =
-        baseFlowDisplay !== undefined ? `${baseFlowDisplay || '0'}` : '…';
+        baseFlowDisplay !== undefined
+            ? `${baseFlowDisplay && parseFloat(baseFlowDisplay) !== 0 ? baseFlowDisplay : isLimitAdd ? '...' : '0'}`
+            : '…';
 
     const quoteQuantityDisplay =
-        quoteFlowDisplay !== undefined ? `${quoteFlowDisplay || '0'}` : '…';
+        quoteFlowDisplay !== undefined
+            ? `${quoteFlowDisplay && parseFloat(quoteFlowDisplay) !== 0 ? quoteFlowDisplay : isLimitAdd ? '...' : '0'}`
+            : '…';
 
     // --------------------------------------------------------
 
@@ -480,24 +491,21 @@ export const useProcessTransaction = (
             ? quoteTokenCharacter
             : baseTokenCharacter
         : isDenomBase
-        ? baseTokenCharacter
-        : quoteTokenCharacter;
+          ? baseTokenCharacter
+          : quoteTokenCharacter;
 
     const priceCharacter = isAccountView
         ? isBaseTokenMoneynessGreaterOrEqual
             ? baseTokenCharacter
             : quoteTokenCharacter
         : !isDenomBase
-        ? baseTokenCharacter
-        : quoteTokenCharacter;
+          ? baseTokenCharacter
+          : quoteTokenCharacter;
 
     // -----------------------------------------------
 
     const positiveArrow = '↑';
     const negativeArrow = '↓';
-
-    const isLimitRemove =
-        tx.entityType === 'limitOrder' && sideType === 'remove';
 
     const valueArrows = tx.entityType !== 'liqchange' && !isLimitRemove;
 

--- a/src/utils/hooks/useProcessTransaction.ts
+++ b/src/utils/hooks/useProcessTransaction.ts
@@ -477,12 +477,12 @@ export const useProcessTransaction = (
 
     const baseQuantityDisplay =
         baseFlowDisplay !== undefined
-            ? `${baseFlowDisplay && parseFloat(baseFlowDisplay) !== 0 ? baseFlowDisplay : isLimitAdd ? '...' : '0'}`
+            ? `${baseFlowDisplay && baseFlowDisplay !== '0' ? baseFlowDisplay : isLimitAdd ? '...' : '0'}`
             : '…';
 
     const quoteQuantityDisplay =
         quoteFlowDisplay !== undefined
-            ? `${quoteFlowDisplay && parseFloat(quoteFlowDisplay) !== 0 ? quoteFlowDisplay : isLimitAdd ? '...' : '0'}`
+            ? `${quoteFlowDisplay && quoteFlowDisplay !== '0' ? quoteFlowDisplay : isLimitAdd ? '...' : '0'}`
             : '…';
 
     // --------------------------------------------------------


### PR DESCRIPTION
### Describe your changes 
![image](https://github.com/user-attachments/assets/90cf8849-7d24-4726-b447-347aa2982763)

### Link the related issue
the zeros for the buy side of limit mint transactions were confusing people. 

also, as an interim solution to users getting confused as to why they can't remove limit orders or liquidity positions from the transactions table, a 'View Status' link has been added to the transactions rows for limits and ranges in place of a 'Copy Trade' button for a user's own limits and ranges.

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
