### PR TITLE
update limit confirmation wording

### DIFF
--- a/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
+++ b/src/components/Trade/Limit/ConfirmLimitModal/ConfirmLimitModal.tsx
@@ -117,8 +117,11 @@ export default function ConfirmLimitModal(props: propsIF) {
 
     const extraNotes = (
         <Text fontSize='body' color='accent2' style={{ textAlign: 'center' }}>
-            {`${tokenB.symbol} will be available for withdrawal after the limit order is filled.
-        ${tokenA.symbol} can be withdrawn at any time before fill completion.`}
+            <div>
+                {`A button to claim ${tokenB.symbol} will appear in your Limits tab once filled.`}
+            </div>
+            <div>{' '}</div>
+            <div>{` ${tokenA.symbol} can be withdrawn at any time before fill completion.`}</div>
         </Text>
     );
 


### PR DESCRIPTION
### Describe your changes 
clarified the wording to better indicate that the user is required to make a subsequent transaction in order to claim the output of a limit order:

![image](https://github.com/user-attachments/assets/d37849a8-573b-44d9-b7c9-08214e865408)


### Link the related issue

several users had reached out for help indicating that they were not aware that a separate transaction was needed to receive the output of a limit order.

previous wording:

![image](https://github.com/user-attachments/assets/cd282441-ebef-4dca-8777-09e347a36f9f)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
