### PR TITLE
fix ambient position liquidity queries

### DIFF
--- a/src/ambient-utils/dataLayer/functions/getPositionData.ts
+++ b/src/ambient-utils/dataLayer/functions/getPositionData.ts
@@ -246,7 +246,7 @@ export const getPositionData = async (
                 position.quote,
                 position.user,
             );
-            const liqBigNum = (await pos.queryAmbient()).seeds;
+            const liqBigNum = (await pos.queryAmbientPos()).liq;
             const liqNum = bigIntToFloat(liqBigNum);
             newPosition.positionLiq = liqNum;
         } else {

--- a/src/components/RangeActionModal/RangeActionModal.tsx
+++ b/src/components/RangeActionModal/RangeActionModal.tsx
@@ -176,7 +176,7 @@ function RangeActionModal(props: propsIF) {
             );
 
             const liqBigInt = isAmbient
-                ? (await pos.queryAmbient()).seeds
+                ? (await pos.queryAmbientPos()).liq
                 : (await pos.queryRangePos(position.bidTick, position.askTick))
                       .liq;
             setCurrentLiquidity(liqBigInt);

--- a/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
+++ b/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
@@ -184,7 +184,7 @@ function RangeDetailsModal(props: propsIF) {
                 setBaseFeesDisplay('...');
                 setQuoteFeesDisplay('...');
 
-                const ambientLiqBigInt = (await pos.queryAmbient()).seeds;
+                const ambientLiqBigInt = (await pos.queryAmbientPos()).liq;
                 const liqNum = bigIntToFloat(ambientLiqBigInt);
                 const liqBaseNum = liqNum * Math.sqrt(poolPriceNonDisplay);
                 const liqQuoteNum = liqNum / Math.sqrt(poolPriceNonDisplay);

--- a/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
+++ b/src/components/Trade/TradeTabs/Ranges/Ranges.tsx
@@ -460,7 +460,7 @@ function Ranges(props: propsIF) {
                     );
 
                     const position = pendingPositionUpdate.txDetails.isAmbient
-                        ? await pos.queryAmbient()
+                        ? await pos.queryAmbientPos()
                         : await pos.queryRangePos(
                               pendingPositionUpdate.txDetails.lowTick || 0,
                               pendingPositionUpdate.txDetails.highTick || 0,
@@ -471,9 +471,7 @@ function Ranges(props: propsIF) {
 
                     if (!pendingPositionUpdate.txDetails)
                         return {} as PositionIF;
-                    const liqBigInt = pendingPositionUpdate.txDetails.isAmbient
-                        ? position.seeds
-                        : position.liq;
+                    const liqBigInt = position.liq;
                     const liqNum = bigIntToFloat(liqBigInt);
                     if (pendingPositionUpdate.txDetails.isAmbient) {
                         positionLiqBase =


### PR DESCRIPTION
### Describe your changes 
switched from `(await pos.queryAmbient()).seeds;` to `(await pos.queryAmbientPos()).liq`

![image](https://github.com/user-attachments/assets/3b598861-08c6-42f8-aca5-b6a7ec646c93)


### Link the related issue
ambient position liquidity values were not consistent due to an incorrect SDK call
![image](https://github.com/user-attachments/assets/2cbdb249-6279-4dda-bb84-d8524253969f)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
