### PR TITLE
fix ability to switch to user's tx table on /trade

### DIFF
--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -108,7 +108,8 @@ function Transactions(props: propsIF) {
         provider,
         chainData: { chainId, poolIndex },
     } = useContext<CrocEnvContextIF>(CrocEnvContext);
-    const { setOutsideControl } =
+
+    const { setOutsideControl, showAllData: showAllDataSelection } =
         useContext<TradeTableContextIF>(TradeTableContext);
     const { tokens } = useContext<TokenContextIF>(TokenContext);
 
@@ -139,17 +140,20 @@ function Transactions(props: propsIF) {
         TransactionIF[]
     >([]);
 
-    const showAllData = true;
+    const showAllData = !isAccountView && showAllDataSelection;
 
     const transactionData = useMemo<TransactionIF[]>(
         () =>
             isAccountView
                 ? activeAccountTransactionData || []
-                : transactionsByPool.changes,
+                : !showAllData
+                  ? userTransactionsByPool.changes
+                  : transactionsByPool.changes,
         [
             activeAccountTransactionData,
             userTransactionsByPool,
             transactionsByPool,
+            showAllData,
         ],
     );
 


### PR DESCRIPTION
### Describe your changes 
re-implemented the switching functionality

### Link the related issue
switching to My Transactions no longer switched the view to display only the user's transactions
![image](https://github.com/user-attachments/assets/0f7f3bd9-ae9b-4834-8ba4-34a3a2d04b99)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
