### PR TITLE
fix pool stats fetch for ETH-Sinu on first app load

### DIFF
--- a/public/ambient-token-list.json
+++ b/public/ambient-token-list.json
@@ -374,7 +374,7 @@
         {
             "name": "Scroll Inu",
             "address": "0x3660020acc6e993bbdc618dd63b15ad2a3a6d139",
-            "symbol": "SINU",
+            "symbol": "Sinu",
             "decimals": 18,
             "chainId": 534352,
             "logoURI": ""

--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -477,7 +477,6 @@ const useFetchPoolStats = (
         poolVolume === undefined,
         isServerEnabled,
         shouldInvertDisplay,
-        lastBlockNumber === 0,
         !!crocEnv,
         !!provider,
         poolIndex,

--- a/src/ambient-utils/constants/ambient-token-list.json
+++ b/src/ambient-utils/constants/ambient-token-list.json
@@ -374,7 +374,7 @@
         {
             "name": "Scroll Inu",
             "address": "0x3660020acc6e993bbdc618dd63b15ad2a3a6d139",
-            "symbol": "SINU",
+            "symbol": "Sinu",
             "decimals": 18,
             "chainId": 534352,
             "logoURI": ""

--- a/src/ambient-utils/constants/defaultTokens.ts
+++ b/src/ambient-utils/constants/defaultTokens.ts
@@ -630,7 +630,7 @@ export const scrollKNC: TokenIF = {
 export const scrollSINU: TokenIF = {
     name: 'Scroll Inu',
     address: '0x3660020acc6e993bbdc618dd63b15ad2a3a6d139',
-    symbol: 'SINU',
+    symbol: 'Sinu',
     decimals: 18,
     chainId: 534352,
     logoURI: '',


### PR DESCRIPTION
### Describe your changes 
for some reason the pool stats fetch was getting triggered with the default token addresses with the lastBlockNum === 0 useEffect dependency, so i removed it. This was causing pools with a token not on any token list to temporarily display the incorrect pool stats when the app was launched on that pool.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
