### PR TITLE
fix crash navigating to range module from liquidity table on /account

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.8.3",
+    "version": "2.8.4",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/src/App/hooks/useHandleRangeButtonMessage.ts
+++ b/src/App/hooks/useHandleRangeButtonMessage.ts
@@ -46,9 +46,9 @@ export function useHandleRangeButtonMessage(
             if (isWithdrawTokenFromDexChecked) {
                 if (
                     !isTokenInputDisabled &&
-                    fromDisplayQty(tokenAmount, token.decimals) >
-                        fromDisplayQty(tokenDexBalance, token.decimals) +
-                            fromDisplayQty(tokenBalance, token.decimals)
+                    fromDisplayQty(tokenAmount || '0', token.decimals) >
+                        fromDisplayQty(tokenDexBalance || '0', token.decimals) +
+                            fromDisplayQty(tokenBalance || '0', token.decimals)
                 ) {
                     if (
                         pendingTransactions.some(
@@ -65,7 +65,7 @@ export function useHandleRangeButtonMessage(
                             amountToReduceNativeTokenQty.toString(),
                             token.decimals,
                         ) >
-                        fromDisplayQty(tokenBalance, token.decimals)
+                        fromDisplayQty(tokenBalance || '0', token.decimals)
                 ) {
                     tokenAllowed = false;
                     rangeButtonErrorMessage = `${token.symbol} Wallet Balance Insufficient to Cover Gas`;
@@ -93,7 +93,7 @@ export function useHandleRangeButtonMessage(
                             amountToReduceNativeTokenQty.toString(),
                             token.decimals,
                         ) >
-                        fromDisplayQty(tokenBalance, token.decimals)
+                        fromDisplayQty(tokenBalance || '0', token.decimals)
                 ) {
                     tokenAllowed = false;
                     rangeButtonErrorMessage = `${token.symbol} Wallet Balance Insufficient to Cover Gas`;


### PR DESCRIPTION
- fixed crash when navigating directly to the Range module on /trade from /account/liquidity without first entering a value in the trade module