### PR TITLE
prevent failure to save token lists when one URI fails

### DIFF
--- a/src/App/hooks/useTokens.ts
+++ b/src/App/hooks/useTokens.ts
@@ -205,17 +205,26 @@ export const useTokens = (
                 fetchAndFormatList(uri),
             );
         // resolve all promises for token lists
-        Promise.all(tokenListPromises)
-            // remove `undefined` values (URIs that did not produce a valid response)
-            .then((lists) => lists.filter((l) => l !== undefined))
-            // record token lists in local storage + persist in local storage
-            .then((lists) => {
-                localStorage.setItem(
-                    localStorageKeys.tokenLists,
-                    JSON.stringify(lists),
-                );
-                setTokenLists(lists as TokenListIF[]);
-            });
+        Promise.allSettled(tokenListPromises).then((results) => {
+            // Filter out promises that were rejected and extract values from fulfilled ones
+            const fulfilledLists = results
+                .filter(
+                    (
+                        result,
+                    ): result is PromiseFulfilledResult<
+                        TokenListIF | undefined
+                    > => result.status === 'fulfilled',
+                )
+                .map((result) => result.value)
+                .filter((l) => l !== undefined); // remove `undefined` values (URIs that did not produce a valid response)
+
+            // Record token lists in local storage + persist in local storage
+            localStorage.setItem(
+                localStorageKeys.tokenLists,
+                JSON.stringify(fulfilledLists),
+            );
+            setTokenLists(fulfilledLists as TokenListIF[]);
+        });
     }, []);
 
     // fn to verify a token is on a known list or user-acknowledged


### PR DESCRIPTION
### Describe your changes 
change Promise.all to Promise.allSettled for token list retrieval so the successfully retrieved lists are saved even when one fails.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
