### PR TITLE
fix total value display in range details modal

### DIFF
--- a/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
+++ b/src/components/RangeDetails/RangeDetailsModal/RangeDetailsModal.tsx
@@ -316,9 +316,11 @@ function RangeDetailsModal(props: propsIF) {
                         getFormattedNumber({
                             value:
                                 basePrice.usdPrice *
-                                    positionLiqBaseDecimalCorrected +
+                                    (positionLiqBaseDecimalCorrected +
+                                        feesLiqBaseDecimalCorrected) +
                                 quotePrice.usdPrice *
-                                    positionLiqQuoteDecimalCorrected,
+                                    (positionLiqQuoteDecimalCorrected +
+                                        feesLiqQuoteDecimalCorrected),
                             zeroDisplay: '0',
                             prefix: '$',
                         }),
@@ -329,8 +331,11 @@ function RangeDetailsModal(props: propsIF) {
                         getFormattedNumber({
                             value:
                                 basePrice.usdPrice *
-                                    positionLiqBaseDecimalCorrected +
-                                quotePrice * positionLiqQuoteDecimalCorrected,
+                                    (positionLiqBaseDecimalCorrected +
+                                        feesLiqBaseDecimalCorrected) +
+                                quotePrice *
+                                    (positionLiqQuoteDecimalCorrected +
+                                        feesLiqQuoteDecimalCorrected),
                             zeroDisplay: '0',
                             prefix: '$',
                         }),
@@ -341,8 +346,11 @@ function RangeDetailsModal(props: propsIF) {
                         getFormattedNumber({
                             value:
                                 quotePrice.usdPrice *
-                                    positionLiqQuoteDecimalCorrected +
-                                basePrice * positionLiqBaseDecimalCorrected,
+                                    (positionLiqQuoteDecimalCorrected +
+                                        feesLiqQuoteDecimalCorrected) +
+                                basePrice *
+                                    (positionLiqBaseDecimalCorrected +
+                                        feesLiqBaseDecimalCorrected),
                             zeroDisplay: '0',
                             prefix: '$',
                         }),


### PR DESCRIPTION
### Describe your changes 
added the value of the accumulated fees to the total value displayed on the initial screen of the range details cards

![image](https://github.com/user-attachments/assets/b6f0249c-46e2-44ee-9929-e7a275cd133c)


### Link the related issue
USD values shown on the default screen of the range details modal did not add the value of accumulated rewards/fees.

![image](https://github.com/user-attachments/assets/39446f60-f3ca-45be-a022-869ae9722ea5)
![image](https://github.com/user-attachments/assets/5a5cff75-c498-42c6-9274-3396aa79f10a)


### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
