### PR TITLE
fix typo in `index.css` file

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -166,9 +166,11 @@
 
 [data-theme='futa_dark'] {
     /* subtract full height from navbar(56px) and footer(20px on desktop, 64 on mobile) */
-    --content-height: calc(100vh - 76px) --content-height-mobile:
-            calc(100svh - 120px) /* font */ --title-ts: 0px 0px 150px
-            rgba(242, 153, 74, 0.5),
+    --content-height: calc(100vh - 76px);
+    --content-height-mobile:
+            calc(100svh - 120px);
+    /* font */
+    --title-ts: 0px 0px 150px rgba(242, 153, 74, 0.5),
         0px 0px 100px rgba(242, 153, 74, 0.5),
         0px 0px 30px rgba(242, 153, 74, 0.5),
         0px 0px 20px rgba(242, 153, 74, 0.5),


### PR DESCRIPTION
minor syntax issue

Before
![image](https://github.com/user-attachments/assets/6784a608-8e89-4587-b066-560e98ff9af1)

After
![image](https://github.com/user-attachments/assets/238385bc-b866-4883-8575-ed09464d7f9c)
