### PR TITLE
Futa Tutorials | Auction page fix & Default option feature for users

### DIFF
--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -180,3 +180,5 @@ export const LS_USER_VERIFY_TOKEN = 'CHAT_user_verify';
 export const LS_USER_NON_VERIFIED_MESSAGES = 'CHAT_non_verified_messages';
 
 export const CURRENT_AUCTION_VERSION = 1;
+
+export const SHOW_TUTOS_DEFAULT = import.meta.env.VITE_SHOW_TUTOS_DEFAULT || false;

--- a/src/components/Futa/Navbar/Navbar.tsx
+++ b/src/components/Futa/Navbar/Navbar.tsx
@@ -109,7 +109,7 @@ export default function Navbar() {
 
     const { selectedTicker } = useContext(AuctionsContext);
 
-    const { showHomeVideoLocalStorage, setShowHomeVideoLocalStorage } =
+    const { showHomeVideoLocalStorage, setShowHomeVideoLocalStorage, showTutosLocalStorage, bindShowTutosLocalStorage } =
         useFutaHomeContext();
 
     // set page title
@@ -273,6 +273,24 @@ export default function Navbar() {
                 Width={36}
                 id='show_home_video_futa_toggle'
                 disabled={false}
+                />
+        </motion.div>
+    );
+    
+    const showTutosToggle = (
+        <motion.div
+        variants={dropdownItemVariants}
+        className={styles.skipAnimationContainer}
+        >
+            <p>Show Tutorials</p>
+            <Toggle
+                isOn={showTutosLocalStorage}
+                handleToggle={() =>
+                    bindShowTutosLocalStorage(!showTutosLocalStorage)
+                }
+                Width={36}
+                id='show_tutos_futa_toggle'
+                disabled={false}
             />
         </motion.div>
     );
@@ -329,6 +347,7 @@ export default function Navbar() {
                                     }`}
                             </motion.p>
                             {skipAnimationToggle}
+                            {showTutosToggle}
                             <motion.p
                                 className={styles.version}
                                 variants={dropdownItemVariants}

--- a/src/components/Global/TutorialComponent/TutorialComponent.tsx
+++ b/src/components/Global/TutorialComponent/TutorialComponent.tsx
@@ -16,7 +16,9 @@ interface propsIF {
 }
 
 function TutorialComponent(props: propsIF) {
+
     const { steps, tutoKey, initialStep, showSteps, onComplete } = props;
+    console.log(tutoKey, steps)
 
     const [hasTriggered, setHasTriggered] = useState<boolean>(false);
     const hasTriggeredRef = useRef<boolean>(false);
@@ -52,6 +54,8 @@ function TutorialComponent(props: propsIF) {
         buildOnCompletes();
         if (steps.length > 0) {
             triggerTutorial();
+        }else{
+            completeTutorial();
         }
     }, [tutoKey]);
 

--- a/src/components/Global/TutorialOverlay/TutorialOverlayUrlBased.tsx
+++ b/src/components/Global/TutorialOverlay/TutorialOverlayUrlBased.tsx
@@ -11,6 +11,7 @@ import { TutorialIF, TutorialStepExternalComponent } from '../../Chat/ChatIFs';
 import { generateObjectHash, getLS, setLS } from '../../Chat/ChatUtils';
 import TutorialComponent from '../TutorialComponent/TutorialComponent';
 import styles from './TutorialOverlayUrlBased.module.css';
+import { useFutaHomeContext } from '../../../contexts/Futa/FutaHomeContext';
 // import { MdOutlineArrowForwardIos, MdOutlineArrowBackIos, MdClose} from 'react-icons/md'
 
 interface TutorialOverlayPropsIF {
@@ -37,6 +38,8 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
     const {
         walletModal: { open: openWalletModal },
     } = useContext(AppStateContext);
+
+    const {showTutosLocalStorage} = useFutaHomeContext();
 
 
     const connectButton =         (<button
@@ -171,7 +174,7 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
         stepsFiltered.length > 0 &&
         showTutorial &&
         isTutoBuild &&
-        (selectedTutorialRef.current && !selectedTutorialRef.current.disableDefault);
+        (selectedTutorialRef.current && !selectedTutorialRef.current.disableDefault && showTutosLocalStorage);
 
     return (
         <>

--- a/src/contexts/Futa/FutaHomeContext.tsx
+++ b/src/contexts/Futa/FutaHomeContext.tsx
@@ -5,6 +5,7 @@ import React, {
     useEffect,
     ReactNode,
 } from 'react';
+import { SHOW_TUTOS_DEFAULT } from '../../ambient-utils/constants';
 
 interface FutaHomeContextProps {
     isActionButtonVisible: boolean;
@@ -15,6 +16,8 @@ interface FutaHomeContextProps {
     setHasVideoPlayedOnce: React.Dispatch<React.SetStateAction<boolean>>;
     showHomeVideoLocalStorage: boolean;
     setShowHomeVideoLocalStorage: React.Dispatch<React.SetStateAction<boolean>>;
+    showTutosLocalStorage: boolean;
+    bindShowTutosLocalStorage: (value: boolean) => void;
 }
 
 const FutaHomeContext = createContext<FutaHomeContextProps | undefined>(
@@ -35,6 +38,13 @@ export const FutaHomeContextProvider = ({
             return saved === null ? true : saved === 'true';
         },
     );
+    const [showTutosLocalStorage, setShowTutosLocalStorage] = useState(
+        () => {
+            
+            const lsValue = localStorage.getItem('showTutosLocalStorage');
+            return lsValue === null ? SHOW_TUTOS_DEFAULT === 'true' : lsValue === 'true';
+        }
+    )
 
     useEffect(() => {
         localStorage.setItem(
@@ -42,6 +52,15 @@ export const FutaHomeContextProvider = ({
             showHomeVideoLocalStorage.toString(),
         );
     }, [showHomeVideoLocalStorage]);
+    
+    
+    const bindShowTutosLocalStorage = (value : boolean) => {
+        localStorage.setItem(
+            'showTutosLocalStorage',
+            value.toString(),
+        );
+        setShowTutosLocalStorage(value);
+    }
 
     return (
         <FutaHomeContext.Provider
@@ -54,6 +73,8 @@ export const FutaHomeContextProvider = ({
                 setHasVideoPlayedOnce,
                 showHomeVideoLocalStorage,
                 setShowHomeVideoLocalStorage,
+                showTutosLocalStorage,
+                bindShowTutosLocalStorage
             }}
         >
             {children}


### PR DESCRIPTION
### Describe your changes 
- Auction page empty tutorial set problem fixed once navigated from profile page
- Show tutorials default option added into menu (will use env value if user not set it from toggle)

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
