### PR TITLE
Fix code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/e2e/helpers/utils.ts
+++ b/e2e/helpers/utils.ts
@@ -73,8 +73,7 @@ export async function initWallet(context: BrowserContext) {
     await waiter(2);
 
     console.log('.............................');
-    console.log(process.env);
-    console.log(process.env.local);
+    console.log('Environment variables loaded');
     console.log('.............................');
 
     const seedEnv = process.env.TEST_METAMASK_SEED
@@ -82,7 +81,7 @@ export async function initWallet(context: BrowserContext) {
         : '';
     const seed = seedEnv.split(',');
 
-    console.log(seed);
+    console.log('Seed phrase loaded');
 
     async function processWallet(page) {
         const elementHandle = await page.$('#onboarding__terms-checkbox');
@@ -162,7 +161,7 @@ export async function initWallet(context: BrowserContext) {
             page.url().includes('chrome-extension') &&
             page.url().includes('home.html')
         ) {
-            console.log('page found', page.url());
+            console.log('Page found with URL:', page.url());
             await processWallet(page);
         }
     });


### PR DESCRIPTION
Fixes [https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/2](https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/2)

To fix the problem, we should avoid logging the entire `process.env` object. Instead, we can log only non-sensitive information or remove the logging statements altogether if they are not necessary. If specific environment variables need to be logged for debugging purposes, ensure they do not contain sensitive information.

1. Identify and remove or replace the logging of `process.env` on lines 76, 77, and 78.
2. Ensure that no sensitive information is logged by replacing the logging statements with safer alternatives.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
