### PR TITLE
hotfix to displayed address on `PortfolioBannerAccount.tsx` file

### DIFF
--- a/src/components/Portfolio/PortfolioBanner/PortfolioBannerAccount/PortfolioBannerAccount.tsx
+++ b/src/components/Portfolio/PortfolioBanner/PortfolioBannerAccount/PortfolioBannerAccount.tsx
@@ -204,7 +204,7 @@ export default function PortfolioBannerAccount(props: propsIF) {
                         className={styles.address_detail}
                         onClick={handleCopyAddress}
                     >
-                        {addressToDisplay}
+                        {addressToDisplay && addressToDisplay.length > 8 ? trimString(addressToDisplay, 5, 3) : addressToDisplay}
                         {addressToDisplay ? <FiCopy size={'12px'} /> : null}
                         {addressToDisplay ? (
                             <FiExternalLink


### PR DESCRIPTION
### Describe your changes 
* Fix display bug on `/account` page
<img width="385" alt="image" src="https://github.com/user-attachments/assets/ffbe1656-3ea4-416a-98d2-b3aebfd5f20b">

### Link the related issue
[ none ]

### Checklist before requesting a review
- [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [x] I have performed a self-review of my code.
- [x] Did I request feedback from a team member prior to the merge? 
- [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**


**Environmental conditions that may result in expected but differential behavior.**

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
