### PR TITLE
Disable ambient mode for chart on edit panel

### DIFF
--- a/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
+++ b/src/components/Global/Tabs/TableMenu/TableMenuComponents/RangesMenu.tsx
@@ -326,7 +326,7 @@ function RangesMenu(props: propsIF) {
             {!userMatchesConnectedAccount &&
                 tableView !== 'small' &&
                 copyButton}
-            {IS_EDIT_ENABLED &&
+            {(IS_EDIT_ENABLED && position.positionType !== 'ambient') &&
             !showRepositionButton &&
             userMatchesConnectedAccount
                 ? editButton
@@ -350,7 +350,7 @@ function RangesMenu(props: propsIF) {
             {!userMatchesConnectedAccount &&
                 tableView === 'small' &&
                 copyButton}
-            {IS_EDIT_ENABLED &&
+            {(IS_EDIT_ENABLED && position.positionType !== 'ambient') &&
             showRepositionButton &&
             userMatchesConnectedAccount
                 ? editButton

--- a/src/pages/platformAmbient/Chart/Chart.tsx
+++ b/src/pages/platformAmbient/Chart/Chart.tsx
@@ -2108,6 +2108,7 @@ export default function Chart(props: propsIF) {
                                         Math.abs(
                                             pinnedTick - currentPoolPriceTick,
                                         ) / 100,
+                                        location.pathname.includes('/edit')
                                     );
 
                                     const offset = rangeWidthPercentage * 100;
@@ -2141,6 +2142,7 @@ export default function Chart(props: propsIF) {
                                         Math.abs(
                                             currentPoolPriceTick - pinnedTick,
                                         ) / 100,
+                                        location.pathname.includes('/edit')
                                     );
 
                                     const offset = rangeWidthPercentage * 100;
@@ -2853,7 +2855,7 @@ export default function Chart(props: propsIF) {
                     clickedValue === liquidityData?.topBoundary ||
                     clickedValue < liquidityData?.lowBoundary
                 ) {
-                    rangeWidthPercentage = 100;
+                    rangeWidthPercentage = location.pathname.includes('/edit') ? 99 : 100;;
                     setRanges((prevState) => {
                         const newTargets = [...prevState];
 
@@ -2882,6 +2884,7 @@ export default function Chart(props: propsIF) {
 
                         rangeWidthPercentage = roundToNearestPreset(
                             Math.abs(tickValue - currentPoolPriceTick) / 100,
+                            location.pathname.includes('/edit')
                         );
                     } else {
                         tickValue = getPinnedTickFromDisplayPrice(
@@ -2895,6 +2898,7 @@ export default function Chart(props: propsIF) {
 
                         rangeWidthPercentage = roundToNearestPreset(
                             Math.abs(currentPoolPriceTick - tickValue) / 100,
+                            location.pathname.includes('/edit')
                         );
                     }
                 }

--- a/src/pages/platformAmbient/Chart/ChartUtils/chartUtils.ts
+++ b/src/pages/platformAmbient/Chart/ChartUtils/chartUtils.ts
@@ -610,7 +610,8 @@ export function getCandleCount(
 
     return dataLenght;
 }
-export function roundToNearestPreset(closest: number) {
+export function roundToNearestPreset(closest: number,isEditMode:boolean) {
+    const maxValue = isEditMode ? 99 : 100;
     if (closest < 1) {
         if (closest < 0.1) {
             return 0.1;
@@ -618,8 +619,8 @@ export function roundToNearestPreset(closest: number) {
         return Number(closest.toFixed(2));
     }
 
-    if (closest > 100) {
-        return 100;
+    if (closest > maxValue) {
+        return maxValue;
     }
 
     return Math.floor(closest);

--- a/src/pages/platformAmbient/Trade/Range/Range.tsx
+++ b/src/pages/platformAmbient/Trade/Range/Range.tsx
@@ -557,6 +557,13 @@ function Range(props: RangePropsIF) {
         }
     }, [rangeWidthPercentage]);
 
+
+    useEffect(() => {
+       if (simpleRangeWidth === 100 && isEditPanel) {
+            setSimpleRangeWidth(99);
+        }
+    }, [advancedMode]);
+    
     useEffect(() => {
         setNewRangeTransactionHash('');
     }, [baseToken.address + quoteToken.address]);


### PR DESCRIPTION
### Describe your changes 

- [removed edit button for ambient](https://github.com/CrocSwap/ambient-ts-app/commit/4264cff412322a357041afe6fde7def8e0a352c0)

- [prevented range lines from switching to ambient mode when in edit mode](https://github.com/CrocSwap/ambient-ts-app/commit/d7551a67234ce9c40c3afa8d2fc017fc5e58a8b3)

- [bug fixed: ambient mode appears when switch advance mode on edit page](https://github.com/CrocSwap/ambient-ts-app/commit/f8f73e4e79008ce6878b48c3f93cbb7a51a586f1) 

bug steps
    1. set range value to ambient on liquidity
    2. open edit page
    3. switch advance mode




### Link the related issue

_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

4.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
