### PR TITLE
Remove incorrect token listing for stakestone on scroll

### DIFF
--- a/public/ambient-token-list.json
+++ b/public/ambient-token-list.json
@@ -51,6 +51,14 @@
             "symbol": "rswETH"
         },
         {
+            "name": "StakeStone Ether",
+            "address": "0x7122985656e38bdc0302db86685bb972b145bd3c",
+            "symbol": "STONE",
+            "decimals": 18,
+            "chainId": 1,
+            "logoURI": "https://etherscan.io/token/images/stakestone_32.png"
+        },
+        {
             "name": "Maker",
             "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
             "chainId": 1,
@@ -374,11 +382,11 @@
         },
         {
             "name": "StakeStone Ether",
-            "address": "0x80137510979822322193FC997d400D5A6C747bf7",
+            "address": "0x80137510979822322193fc997d400d5a6c747bf7",
             "symbol": "STONE",
             "decimals": 18,
             "chainId": 534352,
-            "logoURI": ""
+            "logoURI": "https://etherscan.io/token/images/stakestone_32.png"
         },
         {
             "name": "StargateToken",

--- a/src/App/hooks/useTokens.ts
+++ b/src/App/hooks/useTokens.ts
@@ -72,6 +72,15 @@ export const useTokens = (
     // User acknowledge tokens
     const [ackTokens, setAckTokens] = useState<TokenIF[]>(INIT_ACK);
 
+    // Hardcoded list of excluded tokens
+    const excludedTokens = [
+        {
+            // mistake on coingecko's scroll lsit
+            address: '0x7122985656e38bdc0302db86685bb972b145bd3c',
+            chainId: 534352,
+        },
+    ];
+
     // Universe of tokens within the given chain. Combines both tokens from
     // lists and user-acknowledge tokens
     const tokenMap = useMemo<Map<string, TokenIF>>(() => {
@@ -81,7 +90,18 @@ export const useTokens = (
             // .reverse()
             .flatMap((tl) => tl.tokens)
             .concat(ackTokens)
-            .filter((t) => chainNumToString(t.chainId) === chainId)
+            .filter((t) => {
+                // First filter by chainId
+                if (chainNumToString(t.chainId) !== chainId) return false;
+
+                // Then check if token is in exclusion list
+                return !excludedTokens.some(
+                    (excluded) =>
+                        excluded.address.toLowerCase() ===
+                            t.address.toLowerCase() &&
+                        excluded.chainId === t.chainId,
+                );
+            })
             .forEach((t) => {
                 // list URI of this iteration of the token
                 const originatingList: string = t.fromList ?? 'unknown';

--- a/src/ambient-utils/constants/ambient-token-list.json
+++ b/src/ambient-utils/constants/ambient-token-list.json
@@ -51,6 +51,14 @@
             "symbol": "rswETH"
         },
         {
+            "name": "StakeStone Ether",
+            "address": "0x7122985656e38bdc0302db86685bb972b145bd3c",
+            "symbol": "STONE",
+            "decimals": 18,
+            "chainId": 1,
+            "logoURI": "https://etherscan.io/token/images/stakestone_32.png"
+        },
+        {
             "name": "Maker",
             "address": "0x9f8F72aA9304c8B593d555F12eF6589cC3A579A2",
             "chainId": 1,
@@ -374,11 +382,11 @@
         },
         {
             "name": "StakeStone Ether",
-            "address": "0x80137510979822322193FC997d400D5A6C747bf7",
+            "address": "0x80137510979822322193fc997d400d5a6c747bf7",
             "symbol": "STONE",
             "decimals": 18,
             "chainId": 534352,
-            "logoURI": ""
+            "logoURI": "https://etherscan.io/token/images/stakestone_32.png"
         },
         {
             "name": "StargateToken",

--- a/src/ambient-utils/constants/defaultTokens.ts
+++ b/src/ambient-utils/constants/defaultTokens.ts
@@ -58,6 +58,15 @@ export const mainnetRSWETH: TokenIF = {
     symbol: 'rswETH',
 };
 
+export const mainnetSTONE: TokenIF = {
+    name: 'StakeStone Ether',
+    address: '0x7122985656e38bdc0302db86685bb972b145bd3c',
+    symbol: 'STONE',
+    decimals: 18,
+    chainId: 1,
+    logoURI: 'https://etherscan.io/token/images/stakestone_32.png',
+};
+
 export const mainnetLIDO: TokenIF = {
     address: '0x5a98fcbea516cf06857215779fd812ca3bef1b32',
     chainId: 1,
@@ -717,6 +726,7 @@ export const defaultTokens: TokenIF[] = [
     mainnetMATIC,
     mainnetSWETH,
     mainnetRSWETH,
+    mainnetSTONE,
     mainnetMKR,
     mainnetLIDO,
     mainnetLUSD,

--- a/src/ambient-utils/dataLayer/functions/stablePairs.ts
+++ b/src/ambient-utils/dataLayer/functions/stablePairs.ts
@@ -38,6 +38,7 @@ import {
     scrollWeETH,
     scrollsUSDe,
     scrollSOLVBTC,
+    mainnetSTONE,
 } from '../../constants/defaultTokens';
 
 //       any sort of specific guaranteed relation between the tokens.
@@ -134,6 +135,7 @@ export const STAKED_ETH_TOKENS = [
     mainnetWstETH.address,
     mainnetSWETH.address,
     mainnetRSWETH.address,
+    mainnetSTONE.address,
     scrollWstETH.address,
     scrollWrsETH.address,
     scrollSTONE.address,


### PR DESCRIPTION
### Describe your changes 
Add list of tokens found on trusted lists to be excluded from token universe. 

Coingecko's token list for the scroll network was found to have a mistaken listing for the mainnet address:

![image](https://github.com/user-attachments/assets/197878cb-33aa-480f-8648-8707e10a6ee1)




### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
