### PR TITLE
remove delay before fetching top pools

### DIFF
--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -105,7 +105,6 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
     // get expanded pool metadata
     useEffect(() => {
         if (crocEnv !== undefined && poolList.length > 0) {
-            console.log('getting all pools');
             getAllPools();
         }
     }, [crocEnv, poolList.length]);

--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -104,12 +104,10 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
 
     // get expanded pool metadata
     useEffect(() => {
-        // wait 5 seconds to get data
-        setTimeout(() => {
-            if (crocEnv !== undefined && poolList.length > 0) {
-                getAllPools();
-            }
-        }, 5000);
+        if (crocEnv !== undefined && poolList.length > 0) {
+            console.log('getting all pools');
+            getAllPools();
+        }
     }, [crocEnv, poolList.length]);
 
     // fn to get data on a single pool


### PR DESCRIPTION
### Describe your changes 
remove delay before fetching top pools

the delay had been added to stagger provider calls made on initial app load. The relevant provider calls are no longer being made on /explore. 

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
