### PR TITLE
Release 2.9.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "2.9.13",
+    "version": "2.9.14",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/src/App/hooks/useTokens.ts
+++ b/src/App/hooks/useTokens.ts
@@ -75,9 +75,14 @@ export const useTokens = (
     // Hardcoded list of excluded tokens
     const excludedTokens = [
         {
-            // mistake on coingecko's scroll lsit
+            // mistake on coingecko's scroll list
             address: '0x7122985656e38bdc0302db86685bb972b145bd3c',
             chainId: 534352,
+        },
+        {
+            // different sepolia USDC on Scroll-Tech's scroll list
+            address: '0x1c7D4B196Cb0C7B01d743Fbc6116a902379C7238',
+            chainId: 11155111,
         },
     ];
 

--- a/src/ambient-utils/constants/tokenListURIs.ts
+++ b/src/ambient-utils/constants/tokenListURIs.ts
@@ -8,8 +8,8 @@ export const tokenListURIs = {
     blastCoingecko: 'https://tokens.coingecko.com/blast/all.json',
     // broken: '/broken-list.json',
     scrollCoingecko: 'https://tokens.coingecko.com/scroll/all.json',
-    // scrollTech:
-    //     'https://raw.githubusercontent.com/scroll-tech/token-list/main/scroll.tokenlist.json',
+    scrollTech:
+        'https://raw.githubusercontent.com/scroll-tech/token-list/main/scroll.tokenlist.json',
     uniswap: 'https://tokens.uniswap.org',
     futa: '/futa-token-list.json',
     baseCoingecko: 'https://tokens.coingecko.com/base/all.json',


### PR DESCRIPTION
- re-enable scrollTech's token list for testnet
- specifically exclude scrollTech's sepolia USDC 

