### PR TITLE
fix token price inference for pool stats

### DIFF
--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -380,7 +380,7 @@ const useFetchPoolStats = (
             const volumeChange24h = volumeTotalNow - volumeTotal24hAgo;
 
             const nowPrice = localPoolPriceNonDisplay[1];
-            const ydayPrice = expandedPoolStats24hAgo?.lastPriceSwap;
+            const ydayPrice = currentPoolStats?.priceSwap24hAgo;
 
             const priceChangeResult =
                 ydayPrice && nowPrice && ydayPrice > 0 && nowPrice > 0

--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -345,7 +345,6 @@ const useFetchPoolStats = (
                 crocEnv,
                 cachedFetchTokenPrice,
                 cachedTokenDetails,
-                cachedQuerySpotPrice,
                 tokens.allDefaultTokens,
                 enableTotalSupply,
             );
@@ -358,9 +357,9 @@ const useFetchPoolStats = (
                 quoteTvl: currentPoolStats?.quoteTvl || 0,
                 quoteVolume: currentPoolStats?.quoteVolume24hAgo || 0,
                 feeRate: currentPoolStats?.feeRate || 0,
-                lastPriceIndic: currentPoolStats?.priceIndic24hAgo || 0,
-                lastPriceLiq: currentPoolStats?.priceLiq24hAgo || 0,
-                lastPriceSwap: currentPoolStats?.priceSwap24hAgo || 0,
+                lastPriceIndic: currentPoolStats?.lastPriceIndic || 0,
+                lastPriceLiq: currentPoolStats?.lastPriceLiq || 0,
+                lastPriceSwap: currentPoolStats?.lastPriceSwap || 0,
                 latestTime: currentPoolStats?.latestTime || 0,
                 isHistorical: true,
             };
@@ -373,7 +372,6 @@ const useFetchPoolStats = (
                 crocEnv,
                 cachedFetchTokenPrice,
                 cachedTokenDetails,
-                cachedQuerySpotPrice,
                 tokens.allDefaultTokens,
             );
 
@@ -429,6 +427,7 @@ const useFetchPoolStats = (
                 const volumeChange24hString = getFormattedNumber({
                     value: volumeChange24h,
                 });
+
                 setPoolVolume24h(volumeChange24hString);
             }
             if (feesChange24h) {

--- a/src/ambient-utils/dataLayer/functions/getPoolStats.ts
+++ b/src/ambient-utils/dataLayer/functions/getPoolStats.ts
@@ -9,7 +9,6 @@ import {
 import { FetchContractDetailsFn, TokenPriceFn } from '../../api';
 import { memoizeCacheQueryFn } from './memoizePromiseFn';
 import { SinglePoolDataIF, TokenIF } from '../../types';
-import { PoolQueryFn } from './querySpotPrice';
 import { isETHorStakedEthToken } from '..';
 
 const getLiquidityFee = async (
@@ -153,7 +152,6 @@ export async function expandPoolStats(
     crocEnv: CrocEnv,
     cachedFetchTokenPrice: TokenPriceFn,
     cachedTokenDetails: FetchContractDetailsFn,
-    cachedQuerySpotPrice: PoolQueryFn,
     tokenList: TokenIF[],
     enableTotalSupply?: boolean,
 ): Promise<PoolStatsIF> {
@@ -233,6 +231,7 @@ export async function expandPoolStats(
           : quoteUsdPrice
             ? quoteUsdPrice / displayPoolPrice
             : 0.0;
+
     const quotePrice = quoteUsdPrice
         ? quoteUsdPrice
         : isETHorStakedEthToken(quote)

--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -62,7 +62,7 @@ export const ExploreContext = createContext<ExploreContextIF>(
 
 export const ExploreContextProvider = (props: { children: ReactNode }) => {
     const { activeNetwork } = useContext(AppStateContext);
-    const { cachedQuerySpotPrice, cachedFetchTokenPrice, cachedTokenDetails } =
+    const { cachedFetchTokenPrice, cachedTokenDetails } =
         useContext(CachedDataContext);
     const { crocEnv, provider } = useContext(CrocEnvContext);
     const { tokens } = useContext(TokenContext);
@@ -163,7 +163,6 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
             crocEnv,
             cachedFetchTokenPrice,
             cachedTokenDetails,
-            cachedQuerySpotPrice,
             tokens.tokenUniv,
         );
 
@@ -190,7 +189,6 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
             crocEnv,
             cachedFetchTokenPrice,
             cachedTokenDetails,
-            cachedQuerySpotPrice,
             tokens.tokenUniv,
         );
 

--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -198,7 +198,7 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
         const volumeChange24h = volumeTotalNow - volumeTotal24hAgo;
 
         const nowPrice = expandedPoolStatsNow?.lastPriceSwap;
-        const ydayPrice = expandedPoolStats24hAgo?.lastPriceSwap;
+        const ydayPrice = poolStats?.priceSwap24hAgo;
 
         const feesTotalNow = expandedPoolStatsNow?.feesTotalUsd;
         const feesTotal24hAgo = expandedPoolStats24hAgo?.feesTotalUsd;

--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -174,9 +174,9 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
             quoteTvl: poolStats?.quoteTvl || 0,
             quoteVolume: poolStats?.quoteVolume24hAgo || 0,
             feeRate: poolStats?.feeRate || 0,
-            lastPriceIndic: poolStats?.priceIndic24hAgo || 0,
-            lastPriceLiq: poolStats?.priceLiq24hAgo || 0,
-            lastPriceSwap: poolStats?.priceSwap24hAgo || 0,
+            lastPriceIndic: poolStats?.lastPriceIndic || 0,
+            lastPriceLiq: poolStats?.lastPriceLiq || 0,
+            lastPriceSwap: poolStats?.lastPriceSwap || 0,
             latestTime: poolStats?.latestTime || 0,
             isHistorical: false,
         };


### PR DESCRIPTION
### Describe your changes 
use the current pool price to infer USD token prices when calculating pool stats for 24 hours prior, instead of the pool price 24 hours prior, in order to avoid unexpected volume and fee differences.

### Link the related issue
![image](https://github.com/user-attachments/assets/15621561-e37d-438a-a262-538e6979f524)

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
