### PR TITLE
Fix code scanning alert no. 4: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Chat/DomDebugger/DomDebuggerUtils.ts
+++ b/src/components/Chat/DomDebugger/DomDebuggerUtils.ts
@@ -1,5 +1,14 @@
 import styles from './DomDebugger.module.css';
 
+const escapeHtml = (unsafe: string): string => {
+    return unsafe
+        .replace(/&/g, "&amp;")
+        .replace(/</g, "&lt;")
+        .replace(/>/g, "&gt;")
+        .replace(/"/g, "&quot;")
+        .replace(/'/g, "&#039;");
+};
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const domDebug = (key: string, value: any) => {
     if (!value && value != 0) value = 'undefined | null';
@@ -40,7 +49,7 @@ export const domDebug = (key: string, value: any) => {
             '.' + styles.dom_debug_value,
         )[0];
 
-        valueDiv.innerHTML = value;
+        valueDiv.innerHTML = escapeHtml(value);
     } else {
         const debugNodesWrapper = el.querySelectorAll(
             '.' + styles.dom_debug_nodes_wrapper,
@@ -64,7 +73,7 @@ export const domDebug = (key: string, value: any) => {
         const valueDiv = document.createElement('div');
         valueDiv.title = value;
         valueDiv.classList.add(styles.dom_debug_value);
-        valueDiv.innerHTML = value;
+        valueDiv.innerHTML = escapeHtml(value);
         newNode.appendChild(valueDiv);
     }
 };


### PR DESCRIPTION
Fixes [https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/4](https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/4)

To fix the problem, we need to ensure that any text assigned to `innerHTML` is properly escaped to prevent XSS attacks. This can be achieved by using a utility function to escape HTML characters before assigning the text to `innerHTML`.

- We will create a utility function `escapeHtml` that replaces special HTML characters with their corresponding HTML entities.
- We will use this function to escape the `value` before assigning it to `innerHTML` on lines 43 and 67.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
