### PR TITLE
Fix code scanning alert no. 3: DOM text reinterpreted as HTML

### DIFF
--- a/src/components/Chat/DomDebugger/DomDebuggerUtils.ts
+++ b/src/components/Chat/DomDebugger/DomDebuggerUtils.ts
@@ -40,7 +40,7 @@ export const domDebug = (key: string, value: any) => {
             '.' + styles.dom_debug_value,
         )[0];
 
-        valueDiv.innerHTML = value;
+        valueDiv.textContent = value;
     } else {
         const debugNodesWrapper = el.querySelectorAll(
             '.' + styles.dom_debug_nodes_wrapper,
@@ -64,7 +64,7 @@ export const domDebug = (key: string, value: any) => {
         const valueDiv = document.createElement('div');
         valueDiv.title = value;
         valueDiv.classList.add(styles.dom_debug_value);
-        valueDiv.innerHTML = value;
+        valueDiv.textContent = value;
         newNode.appendChild(valueDiv);
     }
 };


### PR DESCRIPTION
Fixes [https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/3](https://github.com/CrocSwap/ambient-ts-app/security/code-scanning/3)

To fix the problem, we need to ensure that any text content assigned to `innerHTML` is properly escaped to prevent XSS attacks. This can be achieved by using a text node or by setting the text content directly instead of using `innerHTML`.

- Replace the usage of `innerHTML` with `textContent` to ensure that any HTML special characters are properly escaped.
- Specifically, update the lines where `value` is assigned to `innerHTML` in `src/components/Chat/DomDebugger/DomDebuggerUtils.ts`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
