### PR TITLE
prevent accidental dragging of buttons on homepage

### DIFF
--- a/src/components/Global/PoolCard/PoolCard.tsx
+++ b/src/components/Global/PoolCard/PoolCard.tsx
@@ -1,5 +1,5 @@
 import styles from './PoolCard.module.css';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import useFetchPoolStats from '../../../App/hooks/useFetchPoolStats';
 import TokenIcon from '../TokenIcon/TokenIcon';
 import {
@@ -23,6 +23,8 @@ interface propsIF {
 
 export default function PoolCard(props: propsIF) {
     const { pool, spotPrice } = props;
+
+    const navigate = useNavigate();
 
     const {
         activeNetwork: { chainId },
@@ -144,6 +146,9 @@ export default function PoolCard(props: propsIF) {
             aria-label={ariaDescription}
             onMouseEnter={() => setIsHovered(true)}
             onMouseLeave={() => setIsHovered(false)}
+            onMouseDown={() => {
+                navigate(poolLink);
+            }}
         >
             <div className={styles.main_container}>
                 <div className={styles.row} style={{ padding: '4px' }}>

--- a/src/components/Home/Landing/TradeNowButton/TradeNowButton.tsx
+++ b/src/components/Home/Landing/TradeNowButton/TradeNowButton.tsx
@@ -11,6 +11,7 @@ import {
     useLinkGen,
 } from '../../../../utils/hooks/useLinkGen';
 import { TradeDataContext } from '../../../../contexts/TradeDataContext';
+import { useNavigate } from 'react-router-dom';
 
 interface propsIF {
     fieldId: string;
@@ -20,6 +21,7 @@ interface propsIF {
 export default function TradeNowButton(props: propsIF) {
     const { fieldId, inNav } = props;
     const linkGenMarket: linkGenMethodsIF = useLinkGen('market');
+    const navigate = useNavigate();
 
     const { tokenA, tokenB } = useContext(TradeDataContext);
 
@@ -35,6 +37,9 @@ export default function TradeNowButton(props: propsIF) {
             tabIndex={0}
             aria-label='Go to trade page button'
             inNav={inNav}
+            onMouseDown={() => {
+                navigate(linkGenMarket.getFullURL(tradeButtonParams));
+            }}
         >
             <FlexContainer
                 fullHeight


### PR DESCRIPTION
### Describe your changes 
initiate the navigation on mouse down, rather than on mouse up for the top pools buttons and the Trade Now button on the homepage, in order to prevent accidentally dragging the buttons, instead of clicking.

### Link the related issue
_Closes #0000_

### Checklist before requesting a review
- [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
- [ ] I have performed a self-review of my code.
- [ ] Did I request feedback from a team member prior to the merge? 
- [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
