### PR TITLE
show APR instead of My Deposits on mobile when not connected

### DIFF
--- a/src/pages/platformAmbient/Vaults/VaultRow/VaultRow.module.css
+++ b/src/pages/platformAmbient/Vaults/VaultRow/VaultRow.module.css
@@ -80,7 +80,7 @@
     letter-spacing: -0.36px;
 }
 
-.apyDisplay {
+.aprDisplay {
     display: flex;
     flex-direction: row;
     justify-content: flex-end;
@@ -155,7 +155,7 @@
     }
 
     .tvlDisplay,
-    .apyDisplay,
+    .aprDisplay,
     .depositContainer {
         font-size: 14px;
     }
@@ -164,7 +164,7 @@
 @media only screen and (max-width: 500px) {
     .mainContent,
     .vaultHeader {
-        grid-template-columns: 100px repeat(2, 1fr) 80px;
+        grid-template-columns: 80px repeat(2, 1fr) 80px;
     }
 
     .tempestDisplay {
@@ -175,7 +175,17 @@
         word-wrap: break-word;
     }
 
-    .apyDisplay {
+    .aprDisplay {
         display: none;
+    }
+
+    /* Hide deposit container when user is not connected */
+    .hideDepositOnMobile {
+        display: none;
+    }
+
+    /* Show APR when deposit is hidden */
+    .showAprOnMobile {
+        display: block;
     }
 }

--- a/src/pages/platformAmbient/Vaults/VaultRow/VaultRow.tsx
+++ b/src/pages/platformAmbient/Vaults/VaultRow/VaultRow.tsx
@@ -1,32 +1,32 @@
 import styles from './VaultRow.module.css';
 import tempestLogoColor from './tempestLogoColor.svg';
 // import tempestLogo from './tempestLogo.svg';
-import { FlexContainer } from '../../../../styled/Common';
+import { toDisplayQty } from '@crocswap-libs/sdk';
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { RiExternalLinkLine } from 'react-icons/ri';
 import {
     getFormattedNumber,
     uriToHttp,
 } from '../../../../ambient-utils/dataLayer';
-import TokenIcon from '../../../../components/Global/TokenIcon/TokenIcon';
-import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
-import { useModal } from '../../../../components/Global/Modal/useModal';
 import { VaultIF } from '../../../../ambient-utils/types';
-import { useContext, useEffect, useMemo, useState } from 'react';
+import IconWithTooltip from '../../../../components/Global/IconWithTooltip/IconWithTooltip';
+import { useModal } from '../../../../components/Global/Modal/useModal';
+import { DefaultTooltip } from '../../../../components/Global/StyledTooltip/StyledTooltip';
+import TokenIcon from '../../../../components/Global/TokenIcon/TokenIcon';
+import TooltipComponent from '../../../../components/Global/TooltipComponent/TooltipComponent';
 import {
     AppStateContext,
-    UserDataContext,
-    TokenContext,
     CrocEnvContext,
     ReceiptContext,
+    TokenContext,
+    UserDataContext,
 } from '../../../../contexts';
+import { useBottomSheet } from '../../../../contexts/BottomSheetContext';
+import { FlexContainer } from '../../../../styled/Common';
+import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import { formatDollarAmount } from '../../../../utils/numbers';
 import VaultDeposit from '../VaultActionModal/VaultDeposit/VaultDeposit';
 import VaultWithdraw from '../VaultActionModal/VaultWithdraw/VaultWithdraw';
-import { RiExternalLinkLine } from 'react-icons/ri';
-import { toDisplayQty } from '@crocswap-libs/sdk';
-import TooltipComponent from '../../../../components/Global/TooltipComponent/TooltipComponent';
-import { DefaultTooltip } from '../../../../components/Global/StyledTooltip/StyledTooltip';
-import IconWithTooltip from '../../../../components/Global/IconWithTooltip/IconWithTooltip';
-import { useBottomSheet } from '../../../../contexts/BottomSheetContext';
 
 interface propsIF {
     idForDOM: string;
@@ -60,6 +60,7 @@ export default function VaultRow(props: propsIF) {
     const secondaryAsset = tokens.getTokenByAddress(secondaryAssetAddress);
 
     const showMobileVersion = useMediaQuery('(max-width: 768px)');
+    const showPhoneVersion = useMediaQuery('(max-width: 500px)');
 
     const [crocEnvBal, setCrocEnvBal] = useState<bigint>();
 
@@ -153,7 +154,6 @@ export default function VaultRow(props: propsIF) {
             justifyContent='flex-end'
             gap={5}
             style={{ flexShrink: 0 }}
-            className={styles.depositContainer}
         >
             <FlexContainer flexDirection='row' alignItems='center' gap={4}>
                 {balDisplay}
@@ -165,6 +165,7 @@ export default function VaultRow(props: propsIF) {
                             alt={mainAsset.symbol}
                             size={'m'}
                         />
+
                         <TooltipComponent
                             placement='top'
                             title='Vault positions can hold both tokens in a pair. Displayed position values represent estimated redeemable token positions for the primary token on withdrawal.'
@@ -251,16 +252,23 @@ export default function VaultRow(props: propsIF) {
                         <p className={styles.tvlDisplay}>
                             {formatDollarAmount(parseFloat(vault.tvlUsd))}
                         </p>
-                        {depositsDisplay}
                         <p
-                            className={styles.apyDisplay}
+                            className={`${styles.depositContainer} ${!isUserConnected && styles.hideDepositOnMobile}`}
+                        >
+                            {depositsDisplay}
+                        </p>
+
+                        <p
+                            className={`${styles.aprDisplay} ${!isUserConnected && styles.showAprOnMobile}`}
                             style={{ color: 'var(--other-green' }}
                         >
                             {formattedAPR}
-                            <TooltipComponent
-                                placement='top-end'
-                                title='APR estimates provided by vault provider.'
-                            />
+                            {(isUserConnected || !showPhoneVersion) && (
+                                <TooltipComponent
+                                    placement='top-end'
+                                    title='APR estimates provided by vault provider.'
+                                />
+                            )}
                         </p>
                         <div className={styles.actionButtonContainer}>
                             <button

--- a/src/pages/platformAmbient/Vaults/Vaults.module.css
+++ b/src/pages/platformAmbient/Vaults/Vaults.module.css
@@ -73,11 +73,11 @@
 }
 
 .depositContainer,
-.apyDisplay {
+.aprDisplay {
     padding-right: 12px;
 }
 
-.apyDisplay {
+.aprDisplay {
     padding-right: 17px;
 }
 .tvl {
@@ -94,7 +94,7 @@
     }
 
     .tvlDisplay,
-    .apyDisplay,
+    .aprDisplay,
     .depositContainer {
         font-size: 14px;
     }
@@ -103,7 +103,7 @@
 @media only screen and (max-width: 500px) {
     .mainContent,
     .vaultHeader {
-        grid-template-columns: 100px repeat(2, 1fr) 80px;
+        grid-template-columns: 80px repeat(2, 1fr) 80px;
     }
 
     .tempestDisplay {
@@ -111,15 +111,25 @@
     }
 
     .depositContainer,
-    .apyDisplay {
+    .aprDisplay {
         word-wrap: break-word;
         padding-right: 10px;
     }
-    .apyDisplay {
+    .aprDisplay {
         display: none;
     }
 
     .scrollableContainer {
         margin-bottom: 56px;
+    }
+
+    /* Hide deposit container when user is not connected */
+    .hideDepositOnMobile {
+        display: none;
+    }
+
+    /* Show APR when deposit is hidden */
+    .showAprOnMobile {
+        display: block;
     }
 }

--- a/src/pages/platformAmbient/Vaults/Vaults.tsx
+++ b/src/pages/platformAmbient/Vaults/Vaults.tsx
@@ -1,6 +1,5 @@
 import { memo, useContext, useEffect, useState } from 'react';
-import styles from './Vaults.module.css';
-import VaultRow from './VaultRow/VaultRow';
+import { VAULTS_API_URL } from '../../../ambient-utils/constants';
 import {
     AllVaultsServerIF,
     UserVaultsServerIF,
@@ -11,9 +10,10 @@ import {
     ReceiptContext,
     UserDataContext,
 } from '../../../contexts';
-import { VAULTS_API_URL } from '../../../ambient-utils/constants';
 import { placeholderVaultsListData } from './placeholderVaultsData';
 import { Vault } from './Vault';
+import VaultRow from './VaultRow/VaultRow';
+import styles from './Vaults.module.css';
 
 function Vaults() {
     // !important:  once we have mock data, change the type on this
@@ -26,15 +26,23 @@ function Vaults() {
     } = useContext(AppStateContext);
     const { sessionReceipts } = useContext(ReceiptContext);
 
-    const { userAddress } = useContext(UserDataContext);
+    const { userAddress, isUserConnected } = useContext(UserDataContext);
 
     const vaultHeader = (
         <div className={styles.vaultHeader}>
             <span />
             <span className={styles.poolName} />
             <span className={styles.tvl}>TVL</span>
-            <span className={styles.depositContainer}>My Deposit</span>
-            <span className={styles.apyDisplay}>APR</span>
+            <span
+                className={`${styles.depositContainer} ${!isUserConnected && styles.hideDepositOnMobile}`}
+            >
+                My Deposit
+            </span>
+            <span
+                className={`${styles.aprDisplay} ${!isUserConnected && styles.showAprOnMobile}`}
+            >
+                APR
+            </span>
             <span className={styles.actionButtonContainer} />
         </div>
     );


### PR DESCRIPTION
### Describe your changes

hide My Deposits and display APR on the vaults list on a phone when a wallet is not connected, since it's more useful.

![image](https://github.com/user-attachments/assets/5c552f3f-b9f5-4b80-8442-dd6ec782798b)

![image](https://github.com/user-attachments/assets/aec68b42-6e92-4fbc-8614-97bbfc81b6d7)


### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
