### PR TITLE
increase default size of table on smaller screens

### DIFF
--- a/src/contexts/ChartContext.tsx
+++ b/src/contexts/ChartContext.tsx
@@ -184,9 +184,12 @@ export const ChartContextProvider = (props: { children: React.ReactNode }) => {
     const isFuta = ['futa'].includes(platformName);
 
     // 2:1 ratio of the window height subtracted by main header and token info header
+    // 1:1 ratio, if the screen is less than 1000px in height
     const CHART_MAX_HEIGHT = window.innerHeight - 160;
     const CHART_MIN_HEIGHT = 4;
-    const CHART_DEFAULT_HEIGHT = Math.floor((CHART_MAX_HEIGHT * 2) / 3);
+    const CHART_DEFAULT_HEIGHT = Math.floor(
+        (CHART_MAX_HEIGHT * 2) / (window.innerHeight > 1000 ? 3 : 4),
+    );
     let CHART_SAVED_HEIGHT = CHART_DEFAULT_HEIGHT;
 
     // Fetch alternative default height from local storage if it exists


### PR DESCRIPTION
### Describe your changes

on smaller screens (<1000 px in height) use 1:1 ratio as default for chart to table height.

ratio remains 2:1 for chart to table height on larger screens.

### Link the related issue

the table seems to small and the scroll bar flickers on laptop sized screens

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
