### PR TITLE
fix stuck wallet modal after adding network

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -128,7 +128,7 @@ modal.subscribeEvents(async (event) => {
 
                 const newChainId = modal.getState().selectedNetworkId as number;
 
-                if (newChainId !== desiredChainId) {
+                if (newChainId !== desiredChainId && !modal.getState().open) {
                     try {
                         await modal.switchNetwork(desiredChainId);
                         await new Promise((resolve) =>
@@ -155,6 +155,7 @@ modal.subscribeEvents(async (event) => {
         event.data.event === 'MODAL_CLOSE' &&
         event.data.properties.connected === true
     ) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
         if (
             !networkIds.includes(modal.getState().selectedNetworkId as number)
         ) {


### PR DESCRIPTION
### Describe your changes

prevent the automatic reattempt to switch chains when the modal is open

### Link the related issue

the user is prompted by their wallet to switch networks even when the modal is open asking for the user to initiate switching networks. this causes the user to get stuck after the user completes this action in their wallet without first initiating from the app.

![image](https://github.com/user-attachments/assets/c44663a7-b01f-41f9-af43-edf223c69fd7)


### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
