### PR TITLE
Infinite scroll  | Fix empty tx table issue after opening position

### DIFF
--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -206,10 +206,12 @@ export function usePoolMetadata() {
                         );
                     // Sort and remove the oldest transactions if necessary
                     const prevChangesCopy = [...prev.changes]; // Create a copy to avoid mutating state directly
-                    if (newUniqueTxByPoolData.length > 0) {
-                        prevChangesCopy.sort((a, b) => a.txTime - b.txTime);
-                        prevChangesCopy.splice(0, newUniqueTxByPoolData.length);
-                    }
+
+                    // splite action disabled for infinite scroll, was triggering redundant page skip issue
+                    // if (newUniqueTxByPoolData.length > 0) {
+                    //     prevChangesCopy.sort((a, b) => a.txTime - b.txTime);
+                    //     prevChangesCopy.splice(0, newUniqueTxByPoolData.length);
+                    // }
 
                     const newTxsArray = [
                         ...prevChangesCopy,

--- a/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
+++ b/src/components/Trade/TradeTabs/Transactions/Transactions.tsx
@@ -259,8 +259,8 @@ function Transactions(props: propsIF) {
             });
         }
     }, [
-        transactionsByPool.changes,
-        userTransactionsByPool.changes,
+        transactionsByPool,
+        userTransactionsByPool,
         activeAccountTransactionData,
     ]);
 
@@ -370,13 +370,13 @@ function Transactions(props: propsIF) {
     }, [pagesVisible[0]]);
 
     const oldestTxTime = useMemo(() => {
-        const dataToFilter = fetchedTransactions.changes;
+        const dataToFilter = fetchedTransactionsRef.current?.changes || [];
         return dataToFilter.length > 0
             ? dataToFilter.reduce((min, transaction) => {
                   return transaction.txTime < min ? transaction.txTime : min;
               }, dataToFilter[0].txTime)
             : 0;
-    }, [fetchedTransactions.changes, showAllData, isAccountView]);
+    }, [fetchedTransactions, showAllData, isAccountView]);
 
     const oldestTxTimeRef = useRef<number>(oldestTxTime);
     oldestTxTimeRef.current = oldestTxTime;


### PR DESCRIPTION
…e on tx tab

### Describe your changes
Disabled code block which merges new found txs with existing list on  `usePoolMetaData` hook which was causing removal from end of `transactionsByPool`
That emoval was changing oldest tx time on transactions.tsx component, once backend services provides refreshed list, transactions.tsx component assuming it got new coming txs so was increasing page count

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
