### PR TITLE
add buffer for mint approvals on plume

### DIFF
--- a/src/pages/platformAmbient/InitPool/InitButton.tsx
+++ b/src/pages/platformAmbient/InitPool/InitButton.tsx
@@ -39,6 +39,7 @@ interface PropsIF {
     selectedPoolPriceTick: number;
     tokenAQtyCoveredByWalletBalance: bigint;
     tokenBQtyCoveredByWalletBalance: bigint;
+    isTokenAPrimary: boolean;
 }
 export default function InitButton(props: PropsIF) {
     const {
@@ -71,6 +72,7 @@ export default function InitButton(props: PropsIF) {
         selectedPoolPriceTick,
         tokenAQtyCoveredByWalletBalance,
         tokenBQtyCoveredByWalletBalance,
+        isTokenAPrimary,
     } = props;
 
     const { isActiveNetworkPlume } = useContext(ChainDataContext);
@@ -99,7 +101,12 @@ export default function InitButton(props: PropsIF) {
                     tokenA.address,
                     tokenA.symbol,
                     undefined,
-                    isActiveNetworkPlume ? tokenAQtyForApproval : undefined,
+                    isActiveNetworkPlume
+                        ? isTokenAPrimary
+                            ? tokenAQtyForApproval
+                            : // add 1% buffer to avoid rounding errors
+                              (tokenAQtyCoveredByWalletBalance * 101n) / 100n
+                        : undefined,
                 );
             }}
             flat={true}
@@ -121,7 +128,12 @@ export default function InitButton(props: PropsIF) {
                     tokenB.address,
                     tokenB.symbol,
                     undefined,
-                    isActiveNetworkPlume ? tokenBQtyForApproval : undefined,
+                    isActiveNetworkPlume
+                        ? !isTokenAPrimary
+                            ? tokenBQtyForApproval
+                            : // add 1% buffer to avoid rounding errors
+                              (tokenBQtyCoveredByWalletBalance * 101n) / 100n
+                        : undefined,
                 );
             }}
             flat={true}

--- a/src/pages/platformAmbient/InitPool/InitPool.tsx
+++ b/src/pages/platformAmbient/InitPool/InitPool.tsx
@@ -133,6 +133,7 @@ export default function InitPool() {
         quoteToken,
         setIsTokenAPrimary,
         setPrimaryQuantity,
+        isTokenAPrimary,
     } = useContext(TradeDataContext);
 
     useEffect(() => {
@@ -1140,6 +1141,7 @@ export default function InitPool() {
         selectedPoolPriceTick,
         tokenAQtyCoveredByWalletBalance,
         tokenBQtyCoveredByWalletBalance,
+        isTokenAPrimary,
     };
 
     const minPriceDisplay = isAmbient ? '0' : pinnedMinPriceDisplayTruncated;

--- a/src/pages/platformAmbient/Trade/Range/Range.tsx
+++ b/src/pages/platformAmbient/Trade/Range/Range.tsx
@@ -1281,7 +1281,12 @@ function Range() {
                                 tokenA.symbol,
                                 undefined,
                                 isActiveNetworkPlume
-                                    ? tokenAQtyCoveredByWalletBalance
+                                    ? isTokenAPrimary
+                                        ? tokenAQtyCoveredByWalletBalance
+                                        : // add 1% buffer to avoid rounding errors
+                                          (tokenAQtyCoveredByWalletBalance *
+                                              101n) /
+                                          100n
                                     : undefined,
                             );
                         }}
@@ -1306,7 +1311,12 @@ function Range() {
                                 tokenB.symbol,
                                 undefined,
                                 isActiveNetworkPlume
-                                    ? tokenBQtyCoveredByWalletBalance
+                                    ? !isTokenAPrimary
+                                        ? tokenBQtyCoveredByWalletBalance
+                                        : // add 1% buffer to avoid rounding errors
+                                          (tokenBQtyCoveredByWalletBalance *
+                                              101n) /
+                                          100n
                                     : undefined,
                             );
                         }}


### PR DESCRIPTION
### Describe your changes

due to a rounding issue, approvals for the exact amount of a token to be minted as a range position might fail when the approval amount is the exact amount estimated. This PR adds 1% to the approval amount for the non-primary token when the user needs to approve that token.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
