### PR TITLE
Integration of CrocSmartSwapPlan for multihop swaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "private": true,
     "type": "module",
     "dependencies": {
-        "@crocswap-libs/sdk": "^1.1.2",
+        "@crocswap-libs/sdk": "^1.2.0",
         "@d3fc/d3fc-extent": "^4.0.2",
         "@emotion/react": "^11.13.5",
         "@emotion/styled": "^11.10.5",

--- a/src/App/functions/calcImpact.ts
+++ b/src/App/functions/calcImpact.ts
@@ -1,23 +1,38 @@
-import { CrocEnv, CrocImpact } from '@crocswap-libs/sdk';
+import { CrocEnv, CrocSmartSwapImpact } from '@crocswap-libs/sdk';
+import { getSwapPlan } from '../../ambient-utils/dataLayer';
+import { SinglePoolDataIF } from '../../ambient-utils/types';
+
+// Should be a multiple of `batchMaxCount` from BatchedJsonRpcProvider to
+// maximize the number of routes that are evaluated in one `eth_call`.
+const MAX_IMPACTS_PER_CALL = 40;
 
 export const calcImpact = async (
     isQtySell: boolean,
-    env: CrocEnv,
+    crocEnv: CrocEnv,
     sellTokenAddress: string,
     buyTokenAddress: string,
     slippageTolerancePercentage: number,
     qty: string,
-): Promise<CrocImpact | undefined> => {
+    allPoolStats: SinglePoolDataIF[],
+    directSwapsOnly?: boolean,
+): Promise<CrocSmartSwapImpact | undefined> => {
     try {
-        const args = { slippage: slippageTolerancePercentage };
-        const swapPlan = isQtySell
-            ? env.sell(sellTokenAddress, qty).for(buyTokenAddress, args)
-            : env.buy(buyTokenAddress, qty).with(sellTokenAddress, args);
-        return await swapPlan.impact;
+        const plan = getSwapPlan({
+            crocEnv,
+            isQtySell,
+            qty,
+            buyTokenAddress,
+            sellTokenAddress,
+            slippageTolerancePercentage,
+            allPoolStats,
+            directSwapsOnly,
+        });
+        return await plan.calcImpacts(MAX_IMPACTS_PER_CALL);
 
         // For valid pools, the impact calculation will fail only if liquidity
         // in the pool is insufficient
     } catch (e) {
+        console.error('calcImpact error:', e);
         return undefined;
     }
 };

--- a/src/App/hooks/useDirectSwapsOnlyPref.ts
+++ b/src/App/hooks/useDirectSwapsOnlyPref.ts
@@ -1,0 +1,38 @@
+import { useMemo, useState } from 'react';
+
+export interface directSwapsOnlyIF {
+    isEnabled: boolean;
+    setValue: (newVal: boolean) => void;
+    enable: () => void;
+    disable: () => void;
+    toggle: () => void;
+}
+
+export const useDirectSwapsOnly = (): directSwapsOnlyIF => {
+    const localStorageKey = 'direct_swaps_only';
+
+    const checkPref = (): boolean | undefined => {
+        const output: boolean =
+            JSON.parse(localStorage.getItem(localStorageKey) as string) ||
+            false;
+        return output;
+    };
+
+    const [pref, setPref] = useState<boolean>(checkPref() ?? false);
+
+    const updatePref = (newVal: boolean): void => {
+        localStorage.setItem(localStorageKey, JSON.stringify(newVal));
+        setPref(newVal);
+    };
+
+    return useMemo(
+        () => ({
+            isEnabled: pref,
+            setValue: updatePref,
+            enable: () => updatePref(true),
+            disable: () => updatePref(false),
+            toggle: () => updatePref(!pref),
+        }),
+        [pref],
+    );
+};

--- a/src/App/hooks/useFetchPoolStats.ts
+++ b/src/App/hooks/useFetchPoolStats.ts
@@ -183,7 +183,7 @@ const useFetchPoolStats = (
                     setPoolPriceDisplay(undefined);
                     setLocalPoolPriceNonDisplay(undefined);
                     setPoolPriceDisplayNum(undefined);
-                    setIsPoolInitialized(false);
+                    // setIsPoolInitialized(false); // TODO: revert
                 }
             })();
         }
@@ -335,6 +335,7 @@ const useFetchPoolStats = (
                 lastPriceLiq: currentPoolStats?.lastPriceLiq || 0,
                 lastPriceSwap: currentPoolStats?.lastPriceSwap || 0,
                 latestTime: currentPoolStats?.latestTime || 0,
+                events: currentPoolStats?.events || 0,
                 isHistorical: false,
             };
 
@@ -362,6 +363,7 @@ const useFetchPoolStats = (
                 lastPriceLiq: currentPoolStats?.lastPriceLiq || 0,
                 lastPriceSwap: currentPoolStats?.lastPriceSwap || 0,
                 latestTime: currentPoolStats?.latestTime || 0,
+                events: currentPoolStats?.events || 0,
                 isHistorical: true,
             };
 

--- a/src/App/hooks/useSimulatedIsPoolInitialized.ts
+++ b/src/App/hooks/useSimulatedIsPoolInitialized.ts
@@ -17,7 +17,7 @@ export const useSimulatedIsPoolInitialized = () => {
         if (isUserOnline) {
             // Simulate the pool initialization for the first 10 seconds
             const timeoutId = setTimeout(() => {
-                setSimulatedIsPoolInitialized(false);
+                // setSimulatedIsPoolInitialized(false); // TODO: revert
             }, 10000);
             // Clean up the timeout when the component unmounts
             return () => clearTimeout(timeoutId);

--- a/src/ambient-utils/dataLayer/functions/getPoolStats.ts
+++ b/src/ambient-utils/dataLayer/functions/getPoolStats.ts
@@ -293,6 +293,7 @@ interface PoolStatsServerIF {
     lastPriceIndic: number;
     lastPriceSwap: number;
     feeRate: number;
+    events: number;
     isHistorical: boolean;
 }
 

--- a/src/ambient-utils/dataLayer/transactions/swap.ts
+++ b/src/ambient-utils/dataLayer/transactions/swap.ts
@@ -1,4 +1,9 @@
-import { CrocEnv } from '@crocswap-libs/sdk';
+import {
+    CrocEnv,
+    CrocSmartSwapImpact,
+    CrocSmartSwapPoolRouter,
+} from '@crocswap-libs/sdk';
+import { SinglePoolDataIF } from '../../types';
 
 interface PerformSwapParams {
     crocEnv: CrocEnv;
@@ -9,9 +14,11 @@ interface PerformSwapParams {
     slippageTolerancePercentage: number; // TODO: add comments about params and their expected values
     isWithdrawFromDexChecked?: boolean;
     isSaveAsDexSurplusChecked?: boolean;
+    allPoolStats?: SinglePoolDataIF[];
+    directSwapsOnly?: boolean;
 }
 
-export async function performSwap(params: PerformSwapParams) {
+export function getSwapPlan(params: PerformSwapParams) {
     const {
         crocEnv,
         isQtySell,
@@ -23,20 +30,25 @@ export async function performSwap(params: PerformSwapParams) {
         isSaveAsDexSurplusChecked = false,
     } = params;
 
-    const plan = isQtySell
-        ? crocEnv.sell(sellTokenAddress, qty).for(buyTokenAddress, {
-              slippage: slippageTolerancePercentage / 100,
-          })
-        : crocEnv.buy(buyTokenAddress, qty).with(sellTokenAddress, {
-              slippage: slippageTolerancePercentage / 100,
-          });
+    const plan = crocEnv
+        .smartSwap(sellTokenAddress, buyTokenAddress, qty, !isQtySell, {
+            slippage: slippageTolerancePercentage / 100,
+            settlement: {
+                fromSurplus: isWithdrawFromDexChecked || false,
+                toSurplus: isSaveAsDexSurplusChecked || false,
+            },
+            disableMultihop: params.directSwapsOnly || false,
+        })
+        .withRouter(new CrocSmartSwapPoolRouter(params.allPoolStats || []));
 
-    const tx = await plan.swap({
-        settlement: {
-            sellDexSurplus: isWithdrawFromDexChecked,
-            buyDexSurplus: isSaveAsDexSurplusChecked,
-        },
-    });
+    return plan;
+}
 
+export async function performSwap(
+    params: PerformSwapParams,
+    lastImpact: CrocSmartSwapImpact,
+) {
+    const plan = getSwapPlan(params);
+    const tx = await plan.swap(lastImpact);
     return tx;
 }

--- a/src/components/Global/DirectSwapsOnlyControl/DirectSwapsOnlyControl.module.css
+++ b/src/components/Global/DirectSwapsOnlyControl/DirectSwapsOnlyControl.module.css
@@ -1,0 +1,11 @@
+.main_container {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    align-items: center;
+
+    color: var(--text2);
+    font-size: var(--body-size);
+    line-height: var(--body-lh);
+    margin: 1rem;
+}

--- a/src/components/Global/DirectSwapsOnlyControl/DirectSwapsOnlyControl.tsx
+++ b/src/components/Global/DirectSwapsOnlyControl/DirectSwapsOnlyControl.tsx
@@ -1,60 +1,48 @@
 import { Dispatch, SetStateAction, useContext, useId } from 'react';
-// import{ useLocation } from 'react-router-dom';
 import { AiOutlineInfoCircle } from 'react-icons/ai';
 import { AppStateContext } from '../../../contexts/AppStateContext';
 import { FlexContainer } from '../../../styled/Common';
 import { ExplanationButton } from '../../Form/Icons/Icons.styles';
 import Toggle from '../../Form/Toggle';
-import styles from './SendToDexBalControl.module.css';
+import styles from './DirectSwapsOnlyControl.module.css';
 
 interface propsIF {
-    tempSaveToDex: boolean;
-    setTempSaveToDex: Dispatch<SetStateAction<boolean>>;
+    tempDirectSwapsOnly: boolean;
+    setTempDirectSwapsOnly: Dispatch<SetStateAction<boolean>>;
     displayInSettings?: boolean;
 }
 
-export default function SaveToDexBalanceModalControl(props: propsIF) {
-    const { tempSaveToDex, setTempSaveToDex, displayInSettings } = props;
+export default function DirectSwapsOnlyModalControl(props: propsIF) {
+    const { tempDirectSwapsOnly, setTempDirectSwapsOnly, displayInSettings } =
+        props;
     const {
         globalPopup: { open: openGlobalPopup },
     } = useContext(AppStateContext);
-    // const { pathname } = useLocation();
 
     const compKey = useId();
 
-    // const moduleName = pathname.includes('swap')
-    //     ? 'Swaps'
-    //     : pathname.includes('market')
-    //     ? 'Swaps'
-    //     : pathname.includes('pool')
-    //     ? 'Pool Orders'
-    //     : pathname.includes('reposition')
-    //     ? 'Repositions'
-    //     : pathname.includes('limit')
-    //     ? 'Limit Orders'
-    //     : 'unhandled';
-
     const toggleAriaLabel = `${
-        tempSaveToDex ? 'disable save' : 'save'
+        tempDirectSwapsOnly ? 'disable save' : 'save'
     } to exchange balance for future trading at lower gas costs`;
 
     return (
         <div className={styles.main_container}>
             {displayInSettings ? (
                 <FlexContainer alignItems='center' gap={8}>
-                    <p tabIndex={0}>{'Send to exchange balance'}</p>
+                    <p tabIndex={0}>{'Direct swaps only'}</p>
                     <ExplanationButton
                         onClick={() =>
                             openGlobalPopup(
                                 <div>
-                                    Deposited collateral can be traded later at
-                                    lower gas costs and withdrawn at any time.
+                                    Forcing direct swaps may result in reduced
+                                    swap output compared to multihop swaps but
+                                    with lower fees.
                                 </div>,
-                                'Exchange Balance',
+                                'Direct swaps only',
                                 'right',
                             )
                         }
-                        aria-label='Open exchange balance explanation popup.'
+                        aria-label='Open direct swaps explanation popup.'
                     >
                         <AiOutlineInfoCircle color='var(--text2)' />
                     </ExplanationButton>
@@ -65,9 +53,11 @@ export default function SaveToDexBalanceModalControl(props: propsIF) {
 
             <Toggle
                 key={compKey}
-                isOn={tempSaveToDex}
+                isOn={tempDirectSwapsOnly}
                 disabled={false}
-                handleToggle={() => setTempSaveToDex(!tempSaveToDex)}
+                handleToggle={() =>
+                    setTempDirectSwapsOnly(!tempDirectSwapsOnly)
+                }
                 id='disabled_confirmation_modal_toggle'
                 aria-label={toggleAriaLabel}
             />

--- a/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
+++ b/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
@@ -13,7 +13,9 @@ import ConfirmationModalControl from '../ConfirmationModalControl/ConfirmationMo
 import DollarizationModalControl from '../DollarizationModalControl/DollarizationModalControl';
 import Modal from '../Modal/Modal';
 import SendToDexBalControl from '../SendToDexBalControl/SendToDexBalControl';
+import DirectSwapsOnlyModalControl from '../DirectSwapsOnlyControl/DirectSwapsOnlyControl';
 import SlippageTolerance from '../SlippageTolerance/SlippageTolerance';
+import { directSwapsOnlyIF } from '../../../App/hooks/useDirectSwapsOnlyPref';
 
 export type TransactionModuleType =
     | 'Swap'
@@ -27,11 +29,19 @@ interface propsIF {
     slippage: SlippageMethodsIF;
     dexBalSwap?: dexBalanceMethodsIF;
     bypassConfirm: skipConfirmIF;
+    directSwapsOnly?: directSwapsOnlyIF;
     onClose: () => void;
 }
 
 export default function TransactionSettingsModal(props: propsIF) {
-    const { module, slippage, dexBalSwap, onClose, bypassConfirm } = props;
+    const {
+        module,
+        slippage,
+        dexBalSwap,
+        directSwapsOnly,
+        onClose,
+        bypassConfirm,
+    } = props;
     const { tokenA, tokenB } = useContext(TradeDataContext);
     const { isTradeDollarizationEnabled, setIsTradeDollarizationEnabled } =
         useContext(PoolContext);
@@ -50,11 +60,18 @@ export default function TransactionSettingsModal(props: propsIF) {
         ? dexBalSwap.outputToDexBal.isEnabled
         : false;
 
+    const persistedDirectSwapsOnly: boolean = directSwapsOnly
+        ? directSwapsOnly.isEnabled
+        : false;
+
     const [currentSlippage, setCurrentSlippage] =
         useState<number>(persistedSlippage);
 
     const [currentSaveSwapToDexBal, setCurrentSaveSwapToDexBal] =
         useState<boolean>(persistedSaveSwapToDexBal);
+
+    const [currentDirectSwapsOnly, setCurrentDirectSwapsOnly] =
+        useState<boolean>(persistedDirectSwapsOnly);
 
     const [currentSkipConfirm, setCurrentSkipConfirm] = useState<boolean>(
         bypassConfirm.isEnabled,
@@ -74,6 +91,11 @@ export default function TransactionSettingsModal(props: propsIF) {
                 : dexBalSwap.outputToDexBal.disable()
             : undefined;
         setIsTradeDollarizationEnabled(currentDollarizationMode);
+        directSwapsOnly
+            ? currentDirectSwapsOnly
+                ? directSwapsOnly.enable()
+                : directSwapsOnly.disable()
+            : undefined;
         onClose();
     };
 
@@ -128,6 +150,14 @@ export default function TransactionSettingsModal(props: propsIF) {
                         <SendToDexBalControl
                             tempSaveToDex={currentSaveSwapToDexBal}
                             setTempSaveToDex={setCurrentSaveSwapToDexBal}
+                            displayInSettings={true}
+                        />
+                    )}
+
+                    {module === 'Swap' && (
+                        <DirectSwapsOnlyModalControl
+                            tempDirectSwapsOnly={currentDirectSwapsOnly}
+                            setTempDirectSwapsOnly={setCurrentDirectSwapsOnly}
                             displayInSettings={true}
                         />
                     )}

--- a/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
+++ b/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
@@ -1,4 +1,4 @@
-import { CrocImpact } from '@crocswap-libs/sdk';
+import { CrocSmartSwapImpact, CrocSmartSwapRoute } from '@crocswap-libs/sdk';
 import { memo, useContext } from 'react';
 import {
     getFormattedNumber,
@@ -7,9 +7,11 @@ import {
 import { PoolContext } from '../../../contexts/PoolContext';
 import { TradeDataContext } from '../../../contexts/TradeDataContext';
 import { ExtraInfo } from '../../Trade/TradeModules/ExtraInfo/ExtraInfo';
+import { useTokens } from '../../../App/hooks/useTokens';
+import { AppStateContext } from '../../../contexts';
 
 interface propsIF {
-    priceImpact: CrocImpact | undefined;
+    priceImpact: CrocSmartSwapImpact | undefined;
     slippageTolerance: number;
     liquidityFee: number | undefined;
     swapGasPriceinDollars: string | undefined;
@@ -17,6 +19,7 @@ interface propsIF {
     effectivePriceWithDenom: number | undefined;
     showExtraInfoDropdown: boolean;
     showWarning: boolean;
+    route: CrocSmartSwapRoute | undefined;
 }
 
 function SwapExtraInfo(props: propsIF) {
@@ -28,12 +31,15 @@ function SwapExtraInfo(props: propsIF) {
         swapGasPriceinDollars,
         showExtraInfoDropdown,
         showWarning,
+        route,
     } = props;
 
     const { poolPriceDisplay, isTradeDollarizationEnabled, usdPrice } =
         useContext(PoolContext);
 
     const { baseToken, quoteToken, isDenomBase } = useContext(TradeDataContext);
+    const { activeNetwork } = useContext(AppStateContext);
+    const { getTokenByAddress } = useTokens(activeNetwork.chainId, undefined);
 
     const baseTokenSymbol = baseToken.symbol;
     const quoteTokenSymbol = quoteToken.symbol;
@@ -77,13 +83,23 @@ function SwapExtraInfo(props: propsIF) {
     const priceImpactExceedsThreshold =
         priceImpactNum !== undefined && priceImpactNum > 2;
 
+    let swapRoute = '';
+    if (route) {
+        for (let i = 0; i < route?.paths[0].hops.length; i++) {
+            const tokenAddr = route?.paths[0].hops[i].token;
+            const token = getTokenByAddress(tokenAddr);
+            swapRoute += token?.symbol;
+            if (i < route?.paths[0].hops.length - 1) swapRoute += ' ➔ ';
+        }
+    }
+
     const extraInfo = [
         {
             title: 'Avg. Rate',
             tooltipTitle:
                 'Expected Conversion Rate After Price Impact and Provider Fee',
             data:
-                priceImpactNum !== undefined
+                effectivePriceWithDenom !== undefined
                     ? isDenomBase
                         ? `${getFormattedNumber({
                               value: effectivePriceWithDenom,
@@ -94,42 +110,60 @@ function SwapExtraInfo(props: propsIF) {
                     : '...',
             placement: 'bottom',
         },
-        {
-            title: 'Final Price',
-            tooltipTitle: 'Expected Pool Price After Swap',
-            data:
-                priceImpactNum !== undefined
-                    ? isDenomBase
-                        ? `${finalPriceString} ${quoteTokenSymbol} per ${baseTokenSymbol}`
-                        : `${finalPriceString} ${baseTokenSymbol} per ${quoteTokenSymbol}`
-                    : '...',
-            placement: 'bottom',
-        },
-        {
-            title: 'Price Impact',
-            tooltipTitle:
-                'Difference Between Current (Spot) Price and Final Price',
-            data: priceImpactNum
-                ? `${getPriceImpactString(priceImpactNum)} %`
-                : '...',
-            placement: 'bottom',
-        },
-        {
-            title: 'Slippage Tolerance',
-            tooltipTitle: 'This can be changed in settings.',
-            data: `${slippageTolerance} %`,
-        },
-        {
-            title: 'Liquidity Provider Fee',
-            tooltipTitle: `This is a dynamically updated rate to reward ${
-                isDenomBase ? baseTokenSymbol : quoteTokenSymbol
-            } / ${
-                isDenomBase ? quoteTokenSymbol : baseTokenSymbol
-            } liquidity providers.`,
-            data: liquidityProviderFeeString,
-            placement: 'bottom',
-        },
     ];
+    if (route && route?.paths[0].hops.length > 2) {
+        extraInfo.push({
+            title: 'Swap route',
+            tooltipTitle: 'Tokens involved in the multihop swap',
+            data: swapRoute,
+            placement: 'bottom',
+        });
+    } else {
+        extraInfo.push(
+            ...[
+                {
+                    title: 'Final Price',
+                    tooltipTitle: 'Expected Pool Price After Swap',
+                    data:
+                        priceImpactNum !== undefined
+                            ? isDenomBase
+                                ? `${finalPriceString} ${quoteTokenSymbol} per ${baseTokenSymbol}`
+                                : `${finalPriceString} ${baseTokenSymbol} per ${quoteTokenSymbol}`
+                            : '...',
+                    placement: 'bottom',
+                },
+                {
+                    title: 'Price Impact',
+                    tooltipTitle:
+                        'Difference Between Current (Spot) Price and Final Price',
+                    data: priceImpactNum
+                        ? `${getPriceImpactString(priceImpactNum)} %`
+                        : '...',
+                    placement: 'bottom',
+                },
+            ],
+        );
+    }
+    extraInfo.push(
+        ...[
+            {
+                title: 'Slippage Tolerance',
+                tooltipTitle: 'This can be changed in settings.',
+                data: `${slippageTolerance} %`,
+                placement: 'bottom', // TODO: is this needed?
+            },
+            {
+                title: 'Liquidity Provider Fee',
+                tooltipTitle: `This is a dynamically updated rate to reward ${
+                    isDenomBase ? baseTokenSymbol : quoteTokenSymbol
+                } / ${
+                    isDenomBase ? quoteTokenSymbol : baseTokenSymbol
+                } liquidity providers.`,
+                data: liquidityProviderFeeString,
+                placement: 'bottom',
+            },
+        ],
+    );
 
     const conversionRateNonUsd = isDenomBase
         ? `1 ${baseTokenSymbol} ≈ ${displayPriceString} ${quoteTokenSymbol}`
@@ -151,6 +185,7 @@ function SwapExtraInfo(props: propsIF) {
             showDropdown={showExtraInfoDropdown}
             showWarning={showWarning}
             priceImpactExceedsThreshold={priceImpactExceedsThreshold}
+            route={route}
         />
     );
 }

--- a/src/components/Trade/Range/RangeExtraInfo/RangeExtraInfo.tsx
+++ b/src/components/Trade/Range/RangeExtraInfo/RangeExtraInfo.tsx
@@ -89,7 +89,7 @@ function RangeExtraInfo(props: propsIF) {
             title: 'Estimated APR',
             tooltipTitle: `Estimated APR is based on selected range width, historical volume, fee rate, and pool
                 liquidity. This value is only a historical estimate, and does not account
-                for divergence loss from large price swings. 
+                for divergence loss from large price swings.
                 Very concentrated or unbalanced ranges are more likely to go out of range and not earn fees while out of range.
                 Returns not guaranteed.`,
             data: estRangeAprString,

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -9,6 +9,7 @@ import {
 
 import { TradeDataContext } from '../../../../contexts/TradeDataContext';
 import TooltipComponent from '../../../Global/TooltipComponent/TooltipComponent';
+import { CrocSmartSwapRoute } from '@crocswap-libs/sdk';
 
 interface PropsIF {
     extraInfo: {
@@ -21,6 +22,7 @@ interface PropsIF {
     showDropdown: boolean;
     showWarning?: boolean;
     priceImpactExceedsThreshold?: boolean;
+    route?: CrocSmartSwapRoute;
 }
 
 export const ExtraInfo = (props: PropsIF) => {

--- a/src/components/Trade/TradeModules/TradeModuleHeader.tsx
+++ b/src/components/Trade/TradeModules/TradeModuleHeader.tsx
@@ -17,17 +17,25 @@ import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 import { useModal } from '../../Global/Modal/useModal';
 import TradeLinks from './TradeLinks';
 import styles from './TradeModuleHeader.module.css';
+import { directSwapsOnlyIF } from '../../../App/hooks/useDirectSwapsOnlyPref';
 interface propsIF {
     slippage: SlippageMethodsIF;
     dexBalSwap?: dexBalanceMethodsIF;
+    directSwapsOnly?: directSwapsOnlyIF;
     bypassConfirm: skipConfirmIF;
     settingsTitle: TransactionModuleType;
     isSwapPage?: boolean;
 }
 
 function TradeModuleHeader(props: propsIF) {
-    const { slippage, dexBalSwap, bypassConfirm, settingsTitle, isSwapPage } =
-        props;
+    const {
+        slippage,
+        dexBalSwap,
+        directSwapsOnly,
+        bypassConfirm,
+        settingsTitle,
+        isSwapPage,
+    } = props;
 
     const [isSettingsModalOpen, openSettingsModal, closeSettingsModal] =
         useModal();
@@ -86,6 +94,7 @@ function TradeModuleHeader(props: propsIF) {
                         module={settingsTitle}
                         slippage={slippage}
                         dexBalSwap={dexBalSwap}
+                        directSwapsOnly={directSwapsOnly}
                         bypassConfirm={bypassConfirm}
                         onClose={closeSettingsModal}
                     />
@@ -141,6 +150,7 @@ function TradeModuleHeader(props: propsIF) {
                     module={settingsTitle}
                     slippage={slippage}
                     dexBalSwap={dexBalSwap}
+                    directSwapsOnly={directSwapsOnly}
                     bypassConfirm={bypassConfirm}
                     onClose={closeSettingsModal}
                 />

--- a/src/contexts/ExploreContext.tsx
+++ b/src/contexts/ExploreContext.tsx
@@ -170,6 +170,7 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
             lastPriceLiq: poolStats?.lastPriceLiq || 0,
             lastPriceSwap: poolStats?.lastPriceSwap || 0,
             latestTime: poolStats?.latestTime || 0,
+            events: poolStats?.events || 0,
             isHistorical: false,
         };
 
@@ -196,6 +197,7 @@ export const ExploreContextProvider = (props: { children: ReactNode }) => {
             lastPriceLiq: poolStats?.lastPriceLiq || 0,
             lastPriceSwap: poolStats?.lastPriceSwap || 0,
             latestTime: poolStats?.latestTime || 0,
+            events: poolStats?.events || 0,
             isHistorical: false,
         };
 

--- a/src/contexts/UserPreferenceContext.tsx
+++ b/src/contexts/UserPreferenceContext.tsx
@@ -11,6 +11,10 @@ import { getMoneynessRankByAddr } from '../ambient-utils/dataLayer';
 import { AppStateContext } from './AppStateContext';
 import { TradeDataContext } from './TradeDataContext';
 import { TradeTokenContext } from './TradeTokenContext';
+import {
+    directSwapsOnlyIF,
+    useDirectSwapsOnly,
+} from '../App/hooks/useDirectSwapsOnlyPref';
 
 export interface UserPreferenceContextIF {
     favePools: favePoolsMethodsIF;
@@ -24,6 +28,7 @@ export interface UserPreferenceContextIF {
     bypassConfirmLimit: skipConfirmIF;
     bypassConfirmRange: skipConfirmIF;
     bypassConfirmRepo: skipConfirmIF;
+    directSwapsOnly: directSwapsOnlyIF;
     cssDebug: {
         cache: (k: string, v: string) => void;
         check: (k: string) => string | undefined;
@@ -112,6 +117,7 @@ export const UserPreferenceContextProvider = (props: {
         bypassConfirmLimit: useSkipConfirm('limit'),
         bypassConfirmRange: useSkipConfirm('range'),
         bypassConfirmRepo: useSkipConfirm('repo'),
+        directSwapsOnly: useDirectSwapsOnly(),
         cssDebug: {
             cache: cacheCSSProperty,
             check: checkCSSPropertyCache,


### PR DESCRIPTION
### Describe your changes

This is a WIP integration of [the new swap class in the SDK](https://github.com/CrocSwap/sdk/pull/62) that supports fully client-side multihop swaps. This PR (when used with with the WIP SDK PR) currently has mostly complete multihop swaps which are testable on Scroll mainnet, what remains is additional work to improve integration of that functionality into the frontend.

While integration which would only improve swap output compared to illiquid pools is quite simple, allowing users to make swaps "in non-existent pools" requires many small changes to the frontend since it makes many assumptions that the currently selected token pair in the swap UI represents the chosen pool and not just an intention to swap between the two tokens. But I suppose shipping only the former at first wouldn't be that bad, it's still a significant improvement.

So the remaining integration steps are split into two categories:

- General integration:
    - `SwapExtraInfo` improvements:
        - Better swap route - depending on the number of tokens and their symbols it can be too long to display.
        - Conversion rate should show the average swap rate for multihop swaps, since the pool price is either irrelevant or doesn't exist.
        - Since the number of rows in that element differs between direct swaps and multihop swaps, maybe some should be added/removed?
    - Gas fee scaling with route length.
    - LP fee scaling with route length.
    - Swap route selector that takes USD prices of transacted tokens and estimated gas fees of multihop swaps into account (currently the SDK just selects the route with highest output or lowest input).
    - Something else?
- Decoupling the swap UI from the pool:
    - What to do with the "This pool has not been initialized. Do you want to initialize it?" element?
        - I think it should not be displayed in the swap component, only on the limit and pool components.
        - But since "Direct swaps only" setting exists, maybe it should be shown in those cases too? Perhaps with additional text to remind the user that the setting is enabled?
    - Prevent non-pool ghost transactions getting added to the TX table.
    - Fix USD values in token input components from being bound to pools instead of tokens - they either don't show up or don't change when switching to a non-existent pool, which results in wildly incorrect USD token values.
    - Something else?

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Swap different tokens in different ways. Try small amounts and/or weird pairs - pairs with high liquidity will most likely be executed as a direct swap.

**Environmental conditions that may result in expected but differential behavior.**

1. Swap settings (slippage, surplus, direct swaps only).
2. Swap direction (fixed input or fixed output).
3. Chain (since multihop swap support depends on a new view-only contract that currently only exists on Scroll, and the new swap class should be behaving identically to the old one on chains without that contract).

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
