### PR TITLE
change event listener from 'mousedown' to 'click'

### DIFF
--- a/src/utils/hooks/useOnClickOutside.ts
+++ b/src/utils/hooks/useOnClickOutside.ts
@@ -16,11 +16,11 @@ const useOnClickOutside = <T extends HTMLElement = HTMLElement>(
             handler(event); // Call the handler only if the click is outside of the element passed.
         };
 
-        document.addEventListener('mousedown', listener);
+        document.addEventListener('click', listener);
         document.addEventListener('touchstart', listener);
 
         return () => {
-            document.removeEventListener('mousedown', listener);
+            document.removeEventListener('click', listener);
             document.removeEventListener('touchstart', listener);
         };
     }, [ref, handler]); // Reload only if ref or handler changes


### PR DESCRIPTION
### Describe your changes
Dismissing the notification center requires two clicks outside the element. This reduces it to one click.

### Link the related issue
[ none ]

### Checklist before requesting a review
-   [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [x] I have performed a self-review of my code.
-   [x] Did I request feedback from a team member prior to the merge?
-   [x] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers
**Functionalities or workflows that should specifically be tested.**
The changed file `useOnOutsideClick.tsx` is used in many places throughout the app. I believe I've tracked down and tested all of them to ensure they work as expected.

**Environmental conditions that may result in expected but differential behavior.**
[ none ]

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
See testing notes.