### PR TITLE
Update FUTA landing page local storages

### DIFF
--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -172,4 +172,4 @@ export const LS_USER_NON_VERIFIED_MESSAGES = 'CHAT_non_verified_messages';
 export const CURRENT_AUCTION_VERSION = 1;
 
 export const SHOW_TUTOS_DEFAULT =
-    import.meta.env.VITE_SHOW_TUTOS_DEFAULT || false;
+    import.meta.env.VITE_SHOW_TUTOS_DEFAULT || 'true';

--- a/src/components/Futa/Navbar/Navbar.tsx
+++ b/src/components/Futa/Navbar/Navbar.tsx
@@ -98,6 +98,9 @@ export default function Navbar() {
         setShowHomeVideoLocalStorage,
         showTutosLocalStorage,
         bindShowTutosLocalStorage,
+        skipLandingPage,
+        setSkipLandingPage,
+        setShowLandingPageTemp,
     } = useFutaHomeContext();
 
     // set page title
@@ -239,6 +242,21 @@ export default function Navbar() {
             />
         </motion.div>
     );
+    const skipLandingPageToggle = (
+        <motion.div
+            variants={dropdownItemVariants}
+            className={styles.skipAnimationContainer}
+        >
+            <p>Enter App on Load</p>
+            <Toggle
+                isOn={skipLandingPage}
+                handleToggle={() => setSkipLandingPage(!skipLandingPage)}
+                Width={36}
+                id='skip landing page_futa_toggle'
+                disabled={false}
+            />
+        </motion.div>
+    );
 
     const showTutosToggle = (
         <motion.div
@@ -281,7 +299,7 @@ export default function Navbar() {
                 className={`${styles.container} ${currentLocationIsHome && styles.fixedPositioned}`}
             >
                 <div className={styles.logoContainer}>
-                    <Link to='/'>
+                    <Link to='/' onClick={() => setShowLandingPageTemp(true)}>
                         <h3>FU/TA</h3>
                     </Link>
                     {desktopScreen && tabLinks}
@@ -329,6 +347,7 @@ export default function Navbar() {
                                         }`}
                                 </motion.p>
                                 {skipAnimationToggle}
+                                {skipLandingPageToggle}
                                 {showTutosToggle}
                                 <motion.p
                                     className={styles.version}

--- a/src/components/Futa/Navbar/Navbar.tsx
+++ b/src/components/Futa/Navbar/Navbar.tsx
@@ -230,14 +230,14 @@ export default function Navbar() {
             variants={dropdownItemVariants}
             className={styles.skipAnimationContainer}
         >
-            <p>Show Home Animation</p>
+            <p>Skip Home Animation</p>
             <Toggle
-                isOn={showHomeVideoLocalStorage}
+                isOn={!showHomeVideoLocalStorage}
                 handleToggle={() =>
                     setShowHomeVideoLocalStorage(!showHomeVideoLocalStorage)
                 }
                 Width={36}
-                id='show_home_video_futa_toggle'
+                id='skip_home_video_futa_toggle'
                 disabled={false}
             />
         </motion.div>
@@ -247,7 +247,7 @@ export default function Navbar() {
             variants={dropdownItemVariants}
             className={styles.skipAnimationContainer}
         >
-            <p>Enter App on Load</p>
+            <p>Skip Home Page</p>
             <Toggle
                 isOn={skipLandingPage}
                 handleToggle={() => setSkipLandingPage(!skipLandingPage)}

--- a/src/contexts/Futa/FutaHomeContext.tsx
+++ b/src/contexts/Futa/FutaHomeContext.tsx
@@ -16,6 +16,10 @@ interface FutaHomeContextProps {
     setHasVideoPlayedOnce: React.Dispatch<React.SetStateAction<boolean>>;
     showHomeVideoLocalStorage: boolean;
     setShowHomeVideoLocalStorage: React.Dispatch<React.SetStateAction<boolean>>;
+    skipLandingPage: boolean;
+    setSkipLandingPage: React.Dispatch<React.SetStateAction<boolean>>;
+    showLandingPageTemp: boolean;
+    setShowLandingPageTemp: React.Dispatch<React.SetStateAction<boolean>>;
     showTutosLocalStorage: boolean;
     bindShowTutosLocalStorage: (value: boolean) => void;
 }
@@ -31,6 +35,7 @@ export const FutaHomeContextProvider = ({
 }) => {
     const [isActionButtonVisible, setIsActionButtonVisible] = useState(false);
     const [showTerminal, setShowTerminal] = useState(true);
+    const [showLandingPageTemp, setShowLandingPageTemp] = useState(false);
     const [hasVideoPlayedOnce, setHasVideoPlayedOnce] = useState(false);
     const [showHomeVideoLocalStorage, setShowHomeVideoLocalStorage] = useState(
         () => {
@@ -44,6 +49,10 @@ export const FutaHomeContextProvider = ({
             ? SHOW_TUTOS_DEFAULT === 'true'
             : lsValue === 'true';
     });
+    const [skipLandingPage, setSkipLandingPage] = useState(() => {
+        const saved = localStorage.getItem('skipLandingPage');
+        return saved === null ? false : saved === 'true';
+    });
 
     useEffect(() => {
         localStorage.setItem(
@@ -51,6 +60,10 @@ export const FutaHomeContextProvider = ({
             showHomeVideoLocalStorage.toString(),
         );
     }, [showHomeVideoLocalStorage]);
+
+    useEffect(() => {
+        localStorage.setItem('skipLandingPage', skipLandingPage.toString());
+    }, [skipLandingPage]);
 
     const bindShowTutosLocalStorage = (value: boolean) => {
         localStorage.setItem('showTutosLocalStorage', value.toString());
@@ -70,6 +83,10 @@ export const FutaHomeContextProvider = ({
                 setShowHomeVideoLocalStorage,
                 showTutosLocalStorage,
                 bindShowTutosLocalStorage,
+                skipLandingPage,
+                setSkipLandingPage,
+                showLandingPageTemp,
+                setShowLandingPageTemp,
             }}
         >
             {children}

--- a/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
@@ -126,7 +126,6 @@ export default function FutaNewLanding() {
         });
     }, []);
 
-    console.log({ skipLandingPage });
     useEffect(() => {
         if (!showLandingPageTemp && skipLandingPage) {
             navigate('/auctions/');

--- a/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
@@ -18,6 +18,8 @@ export default function FutaNewLanding() {
         hasVideoPlayedOnce,
         setHasVideoPlayedOnce,
         showHomeVideoLocalStorage,
+        skipLandingPage,
+        showLandingPageTemp,
     } = useFutaHomeContext();
     const [activeSection, setActiveSection] = useState(0);
     const [showMainContent, setShowMainContent] = useState(false);
@@ -123,6 +125,13 @@ export default function FutaNewLanding() {
             block: 'start',
         });
     }, []);
+
+    console.log({ skipLandingPage });
+    useEffect(() => {
+        if (!showLandingPageTemp && skipLandingPage) {
+            navigate('/auctions/');
+        }
+    }, [skipLandingPage, navigate, showLandingPageTemp]);
 
     // Memoized keyboard handler
     const handleKeyDown = useCallback(

--- a/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaNewLanding.tsx
@@ -14,7 +14,11 @@ const INITIAL_DELAY = 7000;
 const TOTAL_SECTIONS = 5;
 
 export default function FutaNewLanding() {
-    const { hasVideoPlayedOnce, setHasVideoPlayedOnce } = useFutaHomeContext();
+    const {
+        hasVideoPlayedOnce,
+        setHasVideoPlayedOnce,
+        showHomeVideoLocalStorage,
+    } = useFutaHomeContext();
     const [activeSection, setActiveSection] = useState(0);
     const [showMainContent, setShowMainContent] = useState(false);
     const navigate = useNavigate();
@@ -164,13 +168,21 @@ export default function FutaNewLanding() {
     }, [handleScroll]);
 
     // Initial delay for showing main content
+
     useEffect(() => {
-        const timer = setTimeout(() => {
+        if (!showHomeVideoLocalStorage) {
+            // If the user has chosen to skip, immediately show main content
             setShowMainContent(true);
             setHasVideoPlayedOnce(true);
-        }, INITIAL_DELAY);
-        return () => clearTimeout(timer);
-    }, []);
+        } else {
+            // Otherwise, use the timer for the initial delay
+            const timer = setTimeout(() => {
+                setShowMainContent(true);
+                setHasVideoPlayedOnce(true);
+            }, INITIAL_DELAY);
+            return () => clearTimeout(timer);
+        }
+    }, [showHomeVideoLocalStorage, setHasVideoPlayedOnce]);
 
     // Sections configuration
     const sections = [


### PR DESCRIPTION
### Describe your changes

**Added Conditional Navigation to Auctions on Page Load:**
Implemented a _useEffect_ in the _LandingPage_ component that automatically navigates users to the _/auctions/_ route if the _skipLandingPage_ setting is enabled in the context. This respects user preferences to bypass the landing page while keeping the landing page functional for users who do not have this setting enabled.

**Enabled Intentional Access to Landing Page via Logo Click:**
Updated the navigation flow to allow users to explicitly view the landing page by clicking the site logo in the navbar. Clicking the logo bypasses the _skipLandingPage_ logic, rendering the landing page without altering the _skipLandingPage_ value in local storage. This ensures users can revisit the landing page without impacting their saved preferences.

**Skipped Landing Page Animation Based on User Preferences:**
Added logic to conditionally skip the animation on the landing page if the _showHomeVideoLocalStorage_ setting is set to _false_. The landing page still loads but bypasses the animation to provide a faster user experience for those who opt out. This preference is managed through the context and synchronized with local storage.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [x] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [x] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [x] Does my code following the style guide at `docs/CODING-STYLE.md`?


