### PR TITLE
Futa | Fix replay-tutorial btn positioning

### DIFF
--- a/src/components/Futa/Navbar/Navbar.module.css
+++ b/src/components/Futa/Navbar/Navbar.module.css
@@ -135,6 +135,16 @@
     color: var(--text1);
 }
 
+.tutorialBtn {
+    cursor: pointer;
+    font-size: 1.3rem;
+    vertical-align: middle;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    margin-right: .2rem;
+}
+
 @media (min-width: 768px) and (max-width: 1024px) {
     .container {
         padding: 0px;

--- a/src/components/Futa/Navbar/Navbar.tsx
+++ b/src/components/Futa/Navbar/Navbar.tsx
@@ -37,6 +37,7 @@ import Toggle from '../../Form/Toggle';
 import NotificationCenter from '../../Global/NotificationCenter/NotificationCenter';
 import TutorialOverlayUrlBased from '../../Global/TutorialOverlay/TutorialOverlayUrlBased';
 import styles from './Navbar.module.css';
+import { AiOutlineQuestionCircle } from 'react-icons/ai';
 
 // Animation Variants
 const dropdownVariants = {
@@ -65,6 +66,8 @@ const dropdownItemVariants = {
 export default function Navbar() {
     // States
     const [isDropdownOpen, setIsDropdownOpen] = useState(false);
+    const [replayTutorial, setReplayTutorial] = useState(false);
+    const tutorialBtnRef = useRef<HTMLDivElement>(null);
     const currentLocationIsHome = location.pathname == '/';
 
     // Context
@@ -288,6 +291,14 @@ export default function Navbar() {
                 </div>
                 <div className={styles.rightContainer}>
                     {!desktopScreen && <NetworkSelector customBR={'50%'} />}
+                    <div
+                        className={styles.tutorialBtn}
+                        ref={tutorialBtnRef}
+                        onClick={() => setReplayTutorial(true)}
+                    >
+                        {' '}
+                        <AiOutlineQuestionCircle />{' '}
+                    </div>
                     {!isUserConnected && connectWagmiButton}
                     <NotificationCenter />
                     <div className={styles.moreContainer} ref={dropdownRef}>
@@ -354,7 +365,11 @@ export default function Navbar() {
                     </div>
                 </div>
             </div>
-            <TutorialOverlayUrlBased />
+            <TutorialOverlayUrlBased
+                replayTutorial={replayTutorial}
+                setReplayTutorial={setReplayTutorial}
+                tutorialBtnRef={tutorialBtnRef}
+            />
         </>
     );
 }

--- a/src/components/Global/TutorialOverlay/TutorialOverlayUrlBased.tsx
+++ b/src/components/Global/TutorialOverlay/TutorialOverlayUrlBased.tsx
@@ -1,9 +1,15 @@
 import { Step } from 'intro.js-react';
-import { memo, useContext, useEffect, useRef, useState } from 'react';
-import { AiOutlineQuestionCircle } from 'react-icons/ai';
+import {
+    Dispatch,
+    memo,
+    SetStateAction,
+    useContext,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 import { AppStateContext } from '../../../contexts/AppStateContext';
 import { useFutaHomeContext } from '../../../contexts/Futa/FutaHomeContext';
-import { UserDataContext } from '../../../contexts/UserDataContext';
 import { useLinkGen } from '../../../utils/hooks/useLinkGen';
 import { futaAuctionsSteps } from '../../../utils/tutorial/Futa/AuctionsSteps';
 import { futaAccountSteps } from '../../../utils/tutorial/Futa/FutaAccountSteps';
@@ -15,14 +21,14 @@ import styles from './TutorialOverlayUrlBased.module.css';
 // import{ MdOutlineArrowForwardIos, MdOutlineArrowBackIos, MdClose} from 'react-icons/md'
 
 interface TutorialOverlayPropsIF {
+    replayTutorial: boolean;
+    setReplayTutorial: Dispatch<SetStateAction<boolean>>;
+    tutorialBtnRef: React.RefObject<HTMLDivElement>;
     checkStepHash?: boolean;
 }
 function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
-    const { isUserConnected } = useContext(UserDataContext);
-
-    const { checkStepHash } = props;
-
-    const [showTutorial, setShowTutorial] = useState<boolean>(false);
+    const { checkStepHash, replayTutorial, setReplayTutorial, tutorialBtnRef } =
+        props;
 
     const { currentPage } = useLinkGen();
     const [selectedTutorial, setSelectedTutorial] = useState<
@@ -33,7 +39,7 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
     const [isTutoBuild, setIsTutoBuild] = useState<boolean>(false);
     const [stepsFiltered, setStepsFiltered] = useState<Step[]>([]);
 
-    const [replayTutorial, setReplayTutorial] = useState<boolean>(false);
+    const [showTutorial, setShowTutorial] = useState<boolean>(false);
 
     const {
         walletModal: { open: openWalletModal },
@@ -179,10 +185,6 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
         setReplayTutorial(false);
     }, [selectedTutorial]);
 
-    const replayBtnListener = () => {
-        setReplayTutorial(true);
-    };
-
     const shouldTutoComponentShown =
         validateURL() &&
         stepsFiltered.length > 0 &&
@@ -191,6 +193,16 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
         selectedTutorialRef.current &&
         !selectedTutorialRef.current.disableDefault &&
         showTutosLocalStorage;
+
+    if (!shouldTutoComponentShown && filterRenderedSteps().length > 0) {
+        if (tutorialBtnRef.current?.style) {
+            tutorialBtnRef.current.style.display = 'flex';
+        }
+    } else {
+        if (tutorialBtnRef.current?.style) {
+            tutorialBtnRef.current.style.display = 'none';
+        }
+    }
 
     return (
         <>
@@ -210,17 +222,6 @@ function TutorialOverlayUrlBased(props: TutorialOverlayPropsIF) {
                         />
                     </>
                 )}
-
-            {!shouldTutoComponentShown && filterRenderedSteps().length > 0 && (
-                <div
-                    className={`${styles.replay_tuto_btn} ${!isUserConnected ? styles.not_connected : ' '}`}
-                    onClick={replayBtnListener}
-                >
-                    {' '}
-                    <AiOutlineQuestionCircle />
-                </div>
-            )}
-            {/* {(<div className={`${styles.replay_tuto_btn} ${!isUserConnected ? styles.not_connected  : ' ' }`} onClick={replayBtnListener}> <AiOutlineQuestionCircle /></div>)} */}
         </>
     );
 }


### PR DESCRIPTION
### Describe your changes

Replay tutorial btn has been moved into Navbar component to position relatively to other navbar elements
(it was positioning with fixed, left, right rules)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
