### PR TITLE
Address frontend review home

### DIFF
--- a/src/App/App.tsx
+++ b/src/App/App.tsx
@@ -155,7 +155,7 @@ export default function App() {
                 data-theme={skin.active}
                 style={{
                     height:
-                        location.pathname == '/'
+                        location.pathname == '/' && platformName !== 'futa'
                             ? 'calc(100vh - 56px)'
                             : '100dvh',
                 }}

--- a/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.module.css
+++ b/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.module.css
@@ -90,11 +90,12 @@ margin-bottom: -8px;
 
     /* Mono 12 */
     font-family: var(--mainFont, 'Fira Mono');
-    font-size: var(--fontSizes-fontSize_small, 12px);
+    font-size: var(--body-size, 12px);
     font-style: normal;
     font-weight: 500;
     line-height: normal;
     margin-bottom: 6px;
+    transition: all var(--animation-speed) ease-in-out;
     
 }
 

--- a/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.module.css
+++ b/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.module.css
@@ -42,7 +42,7 @@
     /* align-items: end; */
     justify-content: flex-end;
     flex: 1;
-    gap: 10px;
+    gap: 39px;
 
    
     
@@ -99,11 +99,17 @@ margin-bottom: -8px;
 }
 
 .enterButton button{
-    background: var(--base-text1, #AACFD1);
+    background: var(--text1, #AACFD1);
     display: inline-flex;
-    padding: 4px 8px;
+    padding: 8px 16px;
     outline: none;
     border: none;
+    width: 119px;
+    height: 45px;
+    font-size: 24px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
  
     
 }

--- a/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.tsx
@@ -2,6 +2,7 @@ import { IoIosArrowDown } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import styles from './FutaLandingNav.module.css';
+import { BsChevronDown } from 'react-icons/bs';
 
 interface propsIF {
     scrollToSection: ScrollToSectionFn;
@@ -28,7 +29,10 @@ export default function FutaLandingNav(props: propsIF) {
                 <span>/</span>
                 <span className={styles.taText}>TA</span>
             </div>
-            <div className={styles.enterButton}>
+            <div
+                className={styles.enterButton}
+                style={{ opacity: activeSection == 0 ? 0 : 1 }}
+            >
                 <button onClick={() => navigate('/auctions')}>/ENTER</button>
             </div>
         </div>
@@ -44,11 +48,11 @@ export default function FutaLandingNav(props: propsIF) {
             </div>
             {showMobileVersion ? (
                 futaText
-            ) : (
-                <IoIosArrowDown
-                    size={120}
+            ) : activeSection === 0 ? null : (
+                <BsChevronDown
+                    size={85}
                     onClick={handleNextSection}
-                    style={{ cursor: 'pointer' }}
+                    style={{ cursor: 'pointer', marginBottom: '12px' }}
                 />
             )}
 

--- a/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/FutaLandingNav.tsx
@@ -1,4 +1,3 @@
-import { IoIosArrowDown } from 'react-icons/io';
 import { useNavigate } from 'react-router-dom';
 import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import styles from './FutaLandingNav.module.css';

--- a/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaLanding.module.css
+++ b/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaLanding.module.css
@@ -38,7 +38,7 @@
 
 .container a {
     display: flex;
-    padding: 8px 16px;
+    padding: 32px 16px;
     justify-content: center;
     align-items: center;
     background: var(--base-text1, #AACFD1);
@@ -46,13 +46,18 @@
     text-align: center;
     /* Mono 24 */
     font-family: 'Fira Mono';
-    font-size: 24px;
+    font-size: 48px;
     font-style: normal;
     font-weight: 400;
     line-height: normal;
     outline: none;
     border: none;
     cursor: pointer;
+    width: 237px;
+    height: 90px;
+    text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
+    text-transform: uppercase;
+
 }
 
 .content a:hover{

--- a/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaLanding1.tsx
+++ b/src/pages/platformFuta/Home/FutaLandings/NewLandings/FutaLanding1.tsx
@@ -1,12 +1,15 @@
 import { Link } from 'react-router-dom';
 import styles from './FutaLanding.module.css';
+import HexReveal from '../../Animations/HexReveal';
 export default function FutaLanding() {
     return (
         <div className={styles.container}>
-            <div className={styles.content}>
-                <p>No pictures. No devs. Just tickers.</p>
-                <p>To move forwards, we must go back.</p>
-                <Link to='/auctions'>/Enter</Link>
+            <div className={styles.content} style={{ gap: '64px' }}>
+                <HexReveal>
+                    <p>No pictures. No devs. Just tickers.</p>
+                    <p>To move forwards, we must go back.</p>
+                    <Link to='/auctions'>/Enter</Link>
+                </HexReveal>
             </div>
         </div>
     );


### PR DESCRIPTION
### Describe your changes

This PR addresses the following frontend issues on the Home Page and implements the requested fixes:

Corrected the font during the initial animation to match the design specifications.

Fixed the background color and CSS to ensure it covers the entire window, eliminating the black bar at the bottom of the screen.

Adjusted the background graphic dots pattern to apply correctly across the entire page. (To be discussed in the product meeting.)

Enlarged the center “/ENTER” button for better visibility and alignment with the design.

Increased the spacing between the smaller “/ENTER” button and the FUTA text in the bottom left corner for improved readability.

Increased the text size of the smaller “/ENTER” button to make it more prominent.

Reduced the thickness of the arrow that transitions to the next page to make it less bold and more visually balanced.

Added a line break between “No Pictures…” and “To move forwards…” for better text separation.

Applied the hex reveal animation to the “No Pictures…” text as per the reference in the "futa front end" Telegram chat, ensuring it matches the expected style.

