### PR TITLE
Fix double swap output qty truncation

### DIFF
--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -223,7 +223,7 @@ function SwapTokenInput(props: propsIF) {
             const normalizedEstimatedBuyString = normalizeExponential(
                 toDisplayQty(estimatedBuyBigInt, tokenB.decimals),
                 precisionForTruncation,
-            ).replace(/\.?0+$/, '');
+            );
 
             // prevent writing result of impact query to the UI if a new query has been made
             if (
@@ -257,7 +257,7 @@ function SwapTokenInput(props: propsIF) {
             const normalizedEstimatedSellString = normalizeExponential(
                 toDisplayQty(estimatedSellBigInt, tokenA.decimals),
                 precisionForTruncation,
-            ).replace(/\.?0+$/, '');
+            );
 
             // prevent writing result of impact query to the UI if a new query has been made
             const lastQueryBigInt = stringToBigInt(


### PR DESCRIPTION
### Describe your changes

If the output qty of a swap has zeroes before the floating point and only zeroes after it, both of them get truncated which results an incorrect output being shown. This happens because callers of `normalizeExponential` have a call to `replace` identical to one that is already present in that function. So if the output of a swap is 100.000000 USDT then the `SwapTokenInput` component will show `1`, and this PR fixes that.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [X] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Try to swap an amount that would result in an integer output amount, this is easiest in stable pools.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
