### PR TITLE
hide swap refresh button when no primary quantity

### DIFF
--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -494,7 +494,7 @@ function SwapTokenInput(props: propsIF) {
                 handleToggleDexSelection={() => toggleDexSelection('B')}
                 showWallet={isUserConnected}
                 hideWalletMaxButton
-                handleRefresh={refreshTokenData}
+                handleRefresh={primaryQuantity ? refreshTokenData : undefined}
                 parseTokenInput={(val: string, isMax?: boolean) => {
                     setBuyQtyString(formatTokenInput(val, tokenB, isMax));
                 }}


### PR DESCRIPTION
### Describe your changes

hide the swap impact calculation refresh button until a primary quantity has been input by the user.

### Link the related issue

![image](https://github.com/user-attachments/assets/35c3df74-27f4-4571-85af-3fa26385717e)

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
