### PR TITLE
Add swap changes

### DIFF
--- a/src/App/App.css
+++ b/src/App/App.css
@@ -58,6 +58,7 @@ svg:hover {
     cursor: pointer;
 }
 
+
 button:hover > svg {
     color: var(--accent1);
     cursor: pointer;

--- a/src/components/Form/Button.module.css
+++ b/src/components/Form/Button.module.css
@@ -61,7 +61,7 @@
     background: var(--accent1, #0ccdff);
     color: var(--dark1);
     border: none;
-    text-transform: uppercase;
+    text-transform: uppercase !important;
     border-radius: 0;
 }
 

--- a/src/components/Form/TokenInputQuantity.module.css
+++ b/src/components/Form/TokenInputQuantity.module.css
@@ -109,7 +109,7 @@
 
 .futaLayout {
     display: grid;
-    grid-template-columns: 70% 27%;
+    grid-template-columns: auto 120px;
     gap: 8px;
     width: 100%;
     font-family: 'Fira Mono';
@@ -156,7 +156,7 @@
     align-items: center;
     justify-content: space-between;
     padding: 0 8px;
-    height: 60%;
+    height: 39px;
     color: var(--text1);
     font-size: 18px;
 }
@@ -169,5 +169,5 @@
     font-size: 18px;
     color: var(--text2);
     cursor: pointer;
-    height: 39%;
+    height: 22px;
 }

--- a/src/components/Form/TokenInputQuantity.tsx
+++ b/src/components/Form/TokenInputQuantity.tsx
@@ -24,6 +24,7 @@ import TokenIcon from '../Global/TokenIcon/TokenIcon';
 import { SoloTokenSelect } from '../Global/TokenSelectContainer/SoloTokenSelect';
 import { SoloTokenSelectModal } from '../Global/TokenSelectContainer/SoloTokenSelectModal';
 import styles from './TokenInputQuantity.module.css';
+import { brand } from '../../ambient-utils/constants';
 
 interface propsIF {
     tokenAorB: 'A' | 'B' | null;
@@ -80,6 +81,8 @@ function TokenInputQuantity(props: propsIF) {
     const {
         activeNetwork: { chainId },
     } = useContext(AppStateContext);
+
+    const isFuta = brand === 'futa';
 
     const linkGenInitPool: linkGenMethodsIF = useLinkGen('initpool');
 
@@ -296,15 +299,20 @@ function TokenInputQuantity(props: propsIF) {
             <div className={styles.futaLayoutRight}>
                 <button
                     className={styles.tokenButton}
-                    style={{ cursor: 'default' }}
+                    style={{
+                        cursor: 'default',
+                        justifyContent: isFuta ? 'center' : 'space-between',
+                    }}
                     onClick={() => setIsTickerModalOpen(true)}
                 >
-                    <TokenIcon
-                        token={token}
-                        src={uriToHttp(token.logoURI)}
-                        alt={token.symbol}
-                        size='xl'
-                    />
+                    {!isFuta && (
+                        <TokenIcon
+                            token={token}
+                            src={uriToHttp(token.logoURI)}
+                            alt={token.symbol}
+                            size='xl'
+                        />
+                    )}
                     {tokenSymbol}
                 </button>
                 <button

--- a/src/components/Form/TokenInputWithWalletBalance.tsx
+++ b/src/components/Form/TokenInputWithWalletBalance.tsx
@@ -4,10 +4,14 @@ import { FiRefreshCw } from 'react-icons/fi';
 import { getFormattedNumber } from '../../ambient-utils/dataLayer';
 import { TokenIF } from '../../ambient-utils/types';
 import { useSimulatedIsPoolInitialized } from '../../App/hooks/useSimulatedIsPoolInitialized';
-import { RefreshButton } from '../../styled/Components/TradeModules';
+import {
+    RefreshButton,
+    RefreshButtonFuta,
+} from '../../styled/Components/TradeModules';
 import { formatTokenInput, stringToBigInt } from '../../utils/numbers';
 import TokenInputQuantity from './TokenInputQuantity';
 import WalletBalanceSubinfo from './WalletBalanceSubinfo';
+import { brand } from '../../ambient-utils/constants';
 
 interface propsIF {
     tokenAorB: 'A' | 'B';
@@ -64,6 +68,8 @@ function TokenInputWithWalletBalance(props: propsIF) {
         usdValue,
         percentDiffUsdValue,
     } = props;
+
+    const isFuta = brand === 'futa';
 
     const usdValueForDom =
         usdValue && parseFloat(tokenInput) > 0
@@ -221,14 +227,22 @@ function TokenInputWithWalletBalance(props: propsIF) {
                 usdValue={usdValueForDom}
                 percentDiffUsdValue={percentDiffUsdValue}
             />
-            {handleRefresh && (
-                <RefreshButton
-                    onClick={handleRefresh}
-                    aria-label='Refresh data'
-                >
-                    <FiRefreshCw size={18} />
-                </RefreshButton>
-            )}
+            {handleRefresh &&
+                (isFuta ? (
+                    <RefreshButtonFuta
+                        onClick={handleRefresh}
+                        aria-label='Refresh data'
+                    >
+                        REFRESH
+                    </RefreshButtonFuta>
+                ) : (
+                    <RefreshButton
+                        onClick={handleRefresh}
+                        aria-label='Refresh data'
+                    >
+                        <FiRefreshCw size={18} />
+                    </RefreshButton>
+                ))}
         </>
     );
 }

--- a/src/components/Futa/TickerComponent/TickerComponent.tsx
+++ b/src/components/Futa/TickerComponent/TickerComponent.tsx
@@ -42,8 +42,8 @@ import { linkGenMethodsIF, useLinkGen } from '../../../utils/hooks/useLinkGen';
 import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 import BreadCrumb from '../Breadcrumb/Breadcrumb';
 import Comments from '../Comments/Comments';
-import { tickerDisplayElements } from './tickerDisplayElements';
 import FutaDivider2 from '../Divider/FutaDivider2';
+import { tickerDisplayElements } from './tickerDisplayElements';
 interface PropsIF {
     isAuctionPage?: boolean;
     placeholderTicker?: boolean;

--- a/src/components/Global/TooltipComponent/TooltipComponent.module.css
+++ b/src/components/Global/TooltipComponent/TooltipComponent.module.css
@@ -21,3 +21,7 @@
     line-height: var(--body-lh);
     padding-right: 8px;
 }
+
+.futaStyleSvg{
+    color: var(--text3) !important;
+}

--- a/src/components/Global/TooltipComponent/TooltipComponent.tsx
+++ b/src/components/Global/TooltipComponent/TooltipComponent.tsx
@@ -7,12 +7,14 @@ import {
     TextOnlyTooltip,
 } from '../StyledTooltip/StyledTooltip';
 import styles from './TooltipComponent.module.css';
+import { brand } from '../../../ambient-utils/constants';
 
 interface TooltipComponentProps {
     title: string | JSX.Element;
     noBg?: boolean;
     usePopups?: boolean;
     icon?: JSX.Element;
+    svgColor?: string;
     placement?:
         | 'right'
         | 'bottom-end'
@@ -33,6 +35,7 @@ function TooltipComponent(props: TooltipComponentProps) {
     const [open, setOpen] = useState(false);
     const isMobile = useMediaQuery('(max-width:600px)');
     const containerRef = useRef<HTMLDivElement>(null);
+    const isFuta = brand === 'futa';
 
     const clickOutsideHandler = () => {
         setOpen(false);
@@ -57,7 +60,11 @@ function TooltipComponent(props: TooltipComponentProps) {
                     {props.icon ? (
                         props.icon
                     ) : (
-                        <AiOutlineQuestionCircle size={18} />
+                        <AiOutlineQuestionCircle
+                            size={18}
+                            color={props.svgColor ?? 'var(--text2)'}
+                            className='futaStyleSvg'
+                        />
                     )}
                 </div>
             </TextOnlyTooltip>
@@ -81,6 +88,7 @@ function TooltipComponent(props: TooltipComponentProps) {
                         <AiOutlineQuestionCircle
                             size={15}
                             onClick={() => setOpen(!open)}
+                            color={props.svgColor ?? 'var(--text2)'}
                         />
                     )}
                 </div>

--- a/src/components/Global/TooltipComponent/TooltipComponent.tsx
+++ b/src/components/Global/TooltipComponent/TooltipComponent.tsx
@@ -7,7 +7,6 @@ import {
     TextOnlyTooltip,
 } from '../StyledTooltip/StyledTooltip';
 import styles from './TooltipComponent.module.css';
-import { brand } from '../../../ambient-utils/constants';
 
 interface TooltipComponentProps {
     title: string | JSX.Element;
@@ -35,7 +34,6 @@ function TooltipComponent(props: TooltipComponentProps) {
     const [open, setOpen] = useState(false);
     const isMobile = useMediaQuery('(max-width:600px)');
     const containerRef = useRef<HTMLDivElement>(null);
-    const isFuta = brand === 'futa';
 
     const clickOutsideHandler = () => {
         setOpen(false);

--- a/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
+++ b/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
@@ -1,5 +1,6 @@
 import { CrocImpact } from '@crocswap-libs/sdk';
 import { memo, useContext } from 'react';
+import { brand } from '../../../ambient-utils/constants';
 import {
     getFormattedNumber,
     getPriceImpactString,
@@ -7,7 +8,6 @@ import {
 import { PoolContext } from '../../../contexts/PoolContext';
 import { TradeDataContext } from '../../../contexts/TradeDataContext';
 import { ExtraInfo } from '../../Trade/TradeModules/ExtraInfo/ExtraInfo';
-import { brand } from '../../../ambient-utils/constants';
 
 interface propsIF {
     priceImpact: CrocImpact | undefined;
@@ -146,8 +146,8 @@ function SwapExtraInfo(props: propsIF) {
         ...(isFuta
             ? [
                   {
-                      title: 'Gas Price',
-                      tooltipTitle: `Gas cost is ${swapGasPriceinDollars}. Conversion rate is ${conversionRate}.`,
+                      title: 'Network Fee',
+                      tooltipTitle: `Estimated cost of gas for this swap is ${swapGasPriceinDollars}`,
                       data: swapGasPriceinDollars,
                       placement: 'bottom',
                   },

--- a/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
+++ b/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
@@ -7,6 +7,7 @@ import {
 import { PoolContext } from '../../../contexts/PoolContext';
 import { TradeDataContext } from '../../../contexts/TradeDataContext';
 import { ExtraInfo } from '../../Trade/TradeModules/ExtraInfo/ExtraInfo';
+import { brand } from '../../../ambient-utils/constants';
 
 interface propsIF {
     priceImpact: CrocImpact | undefined;
@@ -28,6 +29,8 @@ function SwapExtraInfo(props: propsIF) {
         swapGasPriceinDollars,
         showExtraInfoDropdown,
     } = props;
+
+    const isFuta = brand === 'futa';
 
     const { poolPriceDisplay, isTradeDollarizationEnabled, usdPrice } =
         useContext(PoolContext);
@@ -75,6 +78,18 @@ function SwapExtraInfo(props: propsIF) {
 
     const priceImpactExceedsThreshold =
         priceImpactNum !== undefined && priceImpactNum > 2;
+
+    const conversionRateNonUsd = isDenomBase
+        ? `1 ${baseTokenSymbol} ≈ ${displayPriceString} ${quoteTokenSymbol}`
+        : `1 ${quoteTokenSymbol} ≈ ${displayPriceString} ${baseTokenSymbol}`;
+
+    const conversionRateUsd = isDenomBase
+        ? `1 ${baseTokenSymbol} ≈ ${usdPriceDisplay} USD`
+        : `1 ${quoteTokenSymbol} ≈ ${usdPriceDisplay} USD`;
+
+    const conversionRate = isTradeDollarizationEnabled
+        ? conversionRateUsd
+        : conversionRateNonUsd;
 
     const extraInfo = [
         {
@@ -128,19 +143,17 @@ function SwapExtraInfo(props: propsIF) {
             data: liquidityProviderFeeString,
             placement: 'bottom',
         },
-    ];
-
-    const conversionRateNonUsd = isDenomBase
-        ? `1 ${baseTokenSymbol} ≈ ${displayPriceString} ${quoteTokenSymbol}`
-        : `1 ${quoteTokenSymbol} ≈ ${displayPriceString} ${baseTokenSymbol}`;
-
-    const conversionRateUsd = isDenomBase
-        ? `1 ${baseTokenSymbol} ≈ ${usdPriceDisplay} USD`
-        : `1 ${quoteTokenSymbol} ≈ ${usdPriceDisplay} USD`;
-
-    const conversionRate = isTradeDollarizationEnabled
-        ? conversionRateUsd
-        : conversionRateNonUsd;
+        ...(isFuta
+            ? [
+                  {
+                      title: 'Gas Prie',
+                      tooltipTitle: `Gas cost is ${swapGasPriceinDollars}. Conversion rate is ${conversionRate}.`,
+                      data: conversionRate,
+                      placement: 'bottom',
+                  },
+              ]
+            : []),
+    ].filter(Boolean); // Filters out any `null` or `undefined` items
 
     return (
         <ExtraInfo

--- a/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
+++ b/src/components/Swap/SwapExtraInfo/SwapExtraInfo.tsx
@@ -146,9 +146,9 @@ function SwapExtraInfo(props: propsIF) {
         ...(isFuta
             ? [
                   {
-                      title: 'Gas Prie',
+                      title: 'Gas Price',
                       tooltipTitle: `Gas cost is ${swapGasPriceinDollars}. Conversion rate is ${conversionRate}.`,
-                      data: conversionRate,
+                      data: swapGasPriceinDollars,
                       placement: 'bottom',
                   },
               ]

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -12,11 +12,13 @@ import TooltipComponent from '../../../Global/TooltipComponent/TooltipComponent'
 import { brand } from '../../../../ambient-utils/constants';
 
 interface PropsIF {
-    extraInfo: {
-        title: string;
-        tooltipTitle: string;
-        data: React.ReactNode;
-    }[];
+    extraInfo:
+        | null
+        | {
+              title: string;
+              tooltipTitle: string;
+              data: React.ReactNode;
+          }[];
     conversionRate: string;
     gasPrice: string | undefined;
     showDropdown: boolean;
@@ -103,7 +105,7 @@ export const ExtraInfo = (props: PropsIF) => {
                 <ExtraDetailsContainer
                     style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
                 >
-                    {extraInfo.map((item, idx) => (
+                    {extraInfo?.map((item, idx) => (
                         <FlexContainer
                             key={idx}
                             justifyContent='space-between'

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -46,7 +46,7 @@ export const ExtraInfo = (props: PropsIF) => {
         }
     }, [showWarning]);
 
-    const arrowToRender = isFuta ? null : showDropdown ? (
+    const arrowToRender = showDropdown ? (
         showExtraInfo ? (
             <RiArrowUpSLine size={22} />
         ) : (
@@ -59,7 +59,7 @@ export const ExtraInfo = (props: PropsIF) => {
     return (
         <>
             <ExtraInfoContainer
-                // style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
+                style={{ display: isFuta ? 'none' : 'flex' }}
                 role='button'
                 justifyContent='space-between'
                 alignItems='center'
@@ -121,8 +121,17 @@ export const ExtraInfo = (props: PropsIF) => {
                             }
                         >
                             <FlexContainer gap={4}>
-                                <div>{item.title}</div>
-                                <TooltipComponent title={item.tooltipTitle} />
+                                <div
+                                    style={{
+                                        color: isFuta ? 'var(--text3)' : '',
+                                    }}
+                                >
+                                    {item.title}
+                                </div>
+                                <TooltipComponent
+                                    title={item.tooltipTitle}
+                                    svgColor='#4D5255'
+                                />
                             </FlexContainer>
                             <div style={{ textAlign: 'end' }}>{item.data}</div>
                         </FlexContainer>

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -46,7 +46,7 @@ export const ExtraInfo = (props: PropsIF) => {
         }
     }, [showWarning]);
 
-    const arrowToRender = showDropdown ? (
+    const arrowToRender = isFuta ? null : showDropdown ? (
         showExtraInfo ? (
             <RiArrowUpSLine size={22} />
         ) : (
@@ -54,10 +54,12 @@ export const ExtraInfo = (props: PropsIF) => {
         )
     ) : null;
 
+    const staticDropdown = isFuta ? true : showExtraInfo && showDropdown;
+
     return (
         <>
             <ExtraInfoContainer
-                style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
+                // style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
                 role='button'
                 justifyContent='space-between'
                 alignItems='center'
@@ -66,6 +68,7 @@ export const ExtraInfo = (props: PropsIF) => {
                 fontSize='body'
                 padding='4px'
                 active={showDropdown}
+                isFuta={isFuta}
                 onClick={
                     showDropdown
                         ? () => setShowExtraInfo(!showExtraInfo)
@@ -96,8 +99,10 @@ export const ExtraInfo = (props: PropsIF) => {
                 </FlexContainer>
                 <div style={{ height: '22px' }}>{arrowToRender}</div>
             </ExtraInfoContainer>
-            {showExtraInfo && showDropdown && (
-                <ExtraDetailsContainer>
+            {staticDropdown && (
+                <ExtraDetailsContainer
+                    style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
+                >
                     {extraInfo.map((item, idx) => (
                         <FlexContainer
                             key={idx}
@@ -119,7 +124,7 @@ export const ExtraInfo = (props: PropsIF) => {
                                 <div>{item.title}</div>
                                 <TooltipComponent title={item.tooltipTitle} />
                             </FlexContainer>
-                            <div>{item.data}</div>
+                            <div style={{ textAlign: 'end' }}>{item.data}</div>
                         </FlexContainer>
                     ))}
                 </ExtraDetailsContainer>

--- a/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
+++ b/src/components/Trade/TradeModules/ExtraInfo/ExtraInfo.tsx
@@ -9,6 +9,7 @@ import {
 
 import { TradeDataContext } from '../../../../contexts/TradeDataContext';
 import TooltipComponent from '../../../Global/TooltipComponent/TooltipComponent';
+import { brand } from '../../../../ambient-utils/constants';
 
 interface PropsIF {
     extraInfo: {
@@ -33,6 +34,8 @@ export const ExtraInfo = (props: PropsIF) => {
         priceImpactExceedsThreshold,
     } = props;
 
+    const isFuta = brand === 'futa';
+
     const { toggleDidUserFlipDenom } = useContext(TradeDataContext);
 
     const [showExtraInfo, setShowExtraInfo] = useState<boolean>(false);
@@ -54,6 +57,7 @@ export const ExtraInfo = (props: PropsIF) => {
     return (
         <>
             <ExtraInfoContainer
+                style={{ textTransform: isFuta ? 'uppercase' : 'none' }}
                 role='button'
                 justifyContent='space-between'
                 alignItems='center'

--- a/src/components/Trade/TradeModules/TradeModuleHeader.module.css
+++ b/src/components/Trade/TradeModules/TradeModuleHeader.module.css
@@ -49,3 +49,19 @@
 .swap_title {
     color: var(--text1);
 }
+.settings_button_futa{
+    width: 44px;
+    height: 36px;
+    display: flex;
+padding: 0px 12px;
+justify-content: center;
+align-items: center;
+gap: 10px;
+align-self: stretch;
+border: 1px solid var(--dark2, #14161A);
+background: var(--dark2, #14161A);
+}
+.settings_button_futa:hover{
+    border: 1px solid var(--dark3);
+
+}

--- a/src/components/Trade/TradeModules/TradeModuleHeader.tsx
+++ b/src/components/Trade/TradeModules/TradeModuleHeader.tsx
@@ -17,6 +17,8 @@ import useMediaQuery from '../../../utils/hooks/useMediaQuery';
 import { useModal } from '../../Global/Modal/useModal';
 import TradeLinks from './TradeLinks';
 import styles from './TradeModuleHeader.module.css';
+import { IoSettingsOutline } from 'react-icons/io5';
+import { brand } from '../../../ambient-utils/constants';
 interface propsIF {
     slippage: SlippageMethodsIF;
     dexBalSwap?: dexBalanceMethodsIF;
@@ -35,6 +37,8 @@ function TradeModuleHeader(props: propsIF) {
     const [isShareModalOpen, openShareModal, closeShareModal] = useModal();
 
     const smallScreen = useMediaQuery('(max-width: 768px)');
+
+    const isFuta = brand === 'futa';
 
     const {
         baseToken,
@@ -97,13 +101,17 @@ function TradeModuleHeader(props: propsIF) {
         <>
             <div style={{ paddingBottom: isSwapPage ? '16px' : '' }}>
                 <header className={styles.main_container}>
-                    <AiOutlineShareAlt
-                        onClick={openShareModal}
-                        id='share_button'
-                        role='button'
-                        tabIndex={0}
-                        aria-label='Share button'
-                    />
+                    {isFuta ? (
+                        <span />
+                    ) : (
+                        <AiOutlineShareAlt
+                            onClick={openShareModal}
+                            id='share_button'
+                            role='button'
+                            tabIndex={0}
+                            aria-label='Share button'
+                        />
+                    )}
 
                     {isSwapPage ? (
                         <h4
@@ -123,6 +131,7 @@ function TradeModuleHeader(props: propsIF) {
                             {isDenomBase ? quoteTokenSymbol : baseTokenSymbol}
                         </h4>
                     )}
+
                     <IconWithTooltip title='Settings' placement='left'>
                         <div
                             onClick={openSettingsModal}
@@ -130,8 +139,19 @@ function TradeModuleHeader(props: propsIF) {
                             role='button'
                             tabIndex={0}
                             aria-label='Settings button'
+                            className={
+                                isFuta ? styles.settings_button_futa : ''
+                            }
                         >
-                            {<SettingsSvg />}
+                            {isFuta ? (
+                                <IoSettingsOutline
+                                    size={18}
+                                    id='swap_settings_symbol'
+                                    aria-label='Chart settings button'
+                                />
+                            ) : (
+                                <SettingsSvg />
+                            )}
                         </div>
                     </IconWithTooltip>
                 </header>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -82,7 +82,7 @@ const modal = createWeb3Modal({
         '--w3m-color-mix': 'var(--dark2)',
         '--w3m-color-mix-strength': 10,
         '--w3m-font-family': 'var(--font-family)',
-        '--w3m-accent': brand === 'futa' ? '#0CCDFF' : 'var(--accent1)',
+        '--w3m-accent': brand === 'futa' ? '#aacfd1' : 'var(--accent1)',
     },
     featuredWalletIds: [
         'c57ca95b47569778a828d19178114f4db188b89b763c899ba0be274e97267d96', // MetaMask

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.module.css
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.module.css
@@ -14,17 +14,97 @@
     line-height: var(--body-lh);
     color: var(--text2);
     text-align: center;
-
     outline: none;
     border: none;
     padding: 1px 8px;
     position: relative;
 }
+
 .active_selected_button:hover,
 .non_active_selected_button:hover {
     background-color: var(--dark3);
+    color: var(--text1);
 }
 
+.futa_active_selected_button,
+.futa_non_active_selected_button {
+    display: flex;
+    background: var(--dark2);
+    transition: var(--transition);
+    cursor: pointer;
+    font-size: var(--body-size);
+    line-height: var(--body-lh);
+    color: var(--text2);
+    text-align: center;
+    text-justify: auto;
+    outline: none;
+    position: relative;
+
+    align-items: center;
+    justify-content: center;
+
+    border: none;
+
+    width: 49px;
+    height: 25px;
+    padding: 4px 16px 4px 16px;
+}
+
+.futa_active_selected_button:hover,
+.futa_non_active_selected_button:hover {
+    background-color: var(--dark3);
+    color: var(--accent1);
+}
+
+.futa_active_selected_button {
+    color: var(--accent1);
+    border: 1px solid var(--accent1);
+}
+
+.active_selected_button {
+    width: 100%;
+    height: 100%;
+    color: var(--text1);
+}
+
+.futa_non_active_selected_button {
+    color: var(--text2);
+}
+
+.non_active_selected_button {
+    color: var(--text2);
+}
+
+.non_active_selected_button {
+    color: var(--text2);
+}
+
+.futa_active_selected_button {
+    color: var(--accent1);
+    border: 1px solid var(--accent1);
+}
+
+.active_selected_button {
+    width: 100%;
+    height: 100%;
+    color: var(--text1);
+}
+
+.futa_non_active_selected_button {
+    color: var(--text2);
+}
+
+.non_active_selected_button {
+    color: var(--text2);
+}
+
+.main_time_frame_container button:focus-visible,
+.active_selected_button:focus-visible,
+.futa_active_selected_button:focus-visible,
+.futa_non_active_selected_button:focus-visible,
+.non_active_selected_button:focus-visible {
+    box-shadow: var(--glow-light-box-shadow);
+}
 .settings_container button:focus-visible {
     box-shadow: var(--glow-light-box-shadow);
 }

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.module.css
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.module.css
@@ -39,7 +39,7 @@
     text-justify: auto;
     outline: none;
     position: relative;
-
+text-transform: uppercase;
     align-items: center;
     justify-content: center;
 

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.tsx
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeCharts.tsx
@@ -308,9 +308,13 @@ function TradeCharts(props: propsIF) {
                             setRescale(true);
                         }}
                         className={
-                            reset
-                                ? styles.active_selected_button
-                                : styles.non_active_selected_button
+                            ['futa'].includes(platformName)
+                                ? reset
+                                    ? styles.futa_active_selected_button
+                                    : styles.futa_non_active_selected_button
+                                : reset
+                                  ? styles.active_selected_button
+                                  : styles.non_active_selected_button
                         }
                         aria-label='Reset.'
                     >
@@ -326,9 +330,13 @@ function TradeCharts(props: propsIF) {
                             });
                         }}
                         className={
-                            rescale
-                                ? styles.active_selected_button
-                                : styles.non_active_selected_button
+                            ['futa'].includes(platformName)
+                                ? rescale
+                                    ? styles.futa_active_selected_button
+                                    : styles.futa_non_active_selected_button
+                                : rescale
+                                  ? styles.active_selected_button
+                                  : styles.non_active_selected_button
                         }
                         aria-label='Auto rescale.'
                     >

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsComponents/VolumeTVLFee.module.css
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsComponents/VolumeTVLFee.module.css
@@ -51,7 +51,7 @@
     color: var(--text2);
     text-align: center;
     position: relative;
-
+text-transform: uppercase;
     outline: none;
     border: none;
 

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsComponents/VolumeTVLFee.tsx
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsComponents/VolumeTVLFee.tsx
@@ -1,6 +1,7 @@
-import { Dispatch, SetStateAction, memo } from 'react';
+import { Dispatch, SetStateAction, memo, useContext } from 'react';
 import { LS_KEY_SUBCHART_SETTINGS } from '../../../../../ambient-utils/constants';
 import styles from './VolumeTVLFee.module.css';
+import { BrandContext } from '../../../../../contexts';
 
 interface VolumeTVLFeePropsIF {
     setShowVolume: Dispatch<SetStateAction<boolean>>;
@@ -11,6 +12,8 @@ interface VolumeTVLFeePropsIF {
     showFeeRate: boolean;
 }
 function VolumeTVLFee(props: VolumeTVLFeePropsIF) {
+    const { platformName } = useContext(BrandContext);
+
     const {
         setShowVolume,
         setShowTvl,
@@ -80,9 +83,13 @@ function VolumeTVLFee(props: VolumeTVLFeePropsIF) {
                     <button
                         onClick={button.action}
                         className={
-                            button.selected
-                                ? styles.active_selected_button
-                                : styles.non_active_selected_button
+                            ['futa'].includes(platformName)
+                                ? button.selected
+                                    ? styles.futa_active_selected_button
+                                    : styles.futa_non_active_selected_button
+                                : button.selected
+                                  ? styles.active_selected_button
+                                  : styles.non_active_selected_button
                         }
                         aria-label={`${button.selected ? 'hide' : 'show'} ${
                             button.name

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
@@ -130,6 +130,8 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                         setIsCondensedModeEnabled(!isCondensedModeEnabled)
                     }
                     mobileHide={activeMobileComponent !== 'chart'}
+                    isActive={isCondensedModeEnabled}
+                    isFuta
                 >
                     <AiOutlineAreaChart
                         size={20}
@@ -159,6 +161,8 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                         setIsTradeDollarizationEnabled((prev) => !prev)
                     }
                     mobileHide={activeMobileComponent !== 'chart'}
+                    isActive={isTradeDollarizationEnabled}
+                    isFuta
                 >
                     <AiOutlineDollarCircle
                         size={20}
@@ -230,6 +234,8 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                         });
                     }}
                     id='chart_settings_button'
+                    isActive={contextmenu}
+                    isFuta
                 >
                     <IoSettingsOutline
                         size={20}

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
@@ -172,41 +172,45 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                     />
                 </HeaderButtons>
             </DefaultTooltip>
-            <DefaultTooltip
-                interactive
-                title={
-                    isChartFullScreen
-                        ? 'Close full screen chart'
-                        : 'Display full screen chart'
-                }
-                enterDelay={500}
-            >
-                <HeaderButtons
-                    mobileHide
-                    onClick={() => {
-                        setIsChartFullScreen(!isChartFullScreen);
-                    }}
+            {!isFuta && (
+                <DefaultTooltip
+                    interactive
+                    title={
+                        isChartFullScreen
+                            ? 'Close full screen chart'
+                            : 'Display full screen chart'
+                    }
+                    enterDelay={500}
                 >
-                    <BsFullscreen
-                        size={16}
-                        id='trade_chart_full_screen_button'
-                        aria-label='Full screen chart button'
-                    />
-                </HeaderButtons>
-            </DefaultTooltip>
-            <DefaultTooltip
-                interactive
-                title={'Copy image of chart to clipboard'}
-                enterDelay={500}
-            >
-                <HeaderButtons mobileHide onClick={copyChartToClipboard}>
-                    <RiScreenshot2Fill
-                        size={20}
-                        id='trade_chart_save_image'
-                        aria-label='Copy chart image button'
-                    />
-                </HeaderButtons>
-            </DefaultTooltip>
+                    <HeaderButtons
+                        mobileHide
+                        onClick={() => {
+                            setIsChartFullScreen(!isChartFullScreen);
+                        }}
+                    >
+                        <BsFullscreen
+                            size={16}
+                            id='trade_chart_full_screen_button'
+                            aria-label='Full screen chart button'
+                        />
+                    </HeaderButtons>
+                </DefaultTooltip>
+            )}
+            {!isFuta && (
+                <DefaultTooltip
+                    interactive
+                    title={'Copy image of chart to clipboard'}
+                    enterDelay={500}
+                >
+                    <HeaderButtons mobileHide onClick={copyChartToClipboard}>
+                        <RiScreenshot2Fill
+                            size={20}
+                            id='trade_chart_save_image'
+                            aria-label='Copy chart image button'
+                        />
+                    </HeaderButtons>
+                </DefaultTooltip>
+            )}
             <DefaultTooltip
                 interactive
                 title={'Open chart settings'}

--- a/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
+++ b/src/pages/platformAmbient/Trade/TradeCharts/TradeChartsHeader/TradeChartsHeader.tsx
@@ -131,7 +131,7 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                     }
                     mobileHide={activeMobileComponent !== 'chart'}
                     isActive={isCondensedModeEnabled}
-                    isFuta
+                    isFuta={isFuta}
                 >
                     <AiOutlineAreaChart
                         size={20}
@@ -162,7 +162,7 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                     }
                     mobileHide={activeMobileComponent !== 'chart'}
                     isActive={isTradeDollarizationEnabled}
-                    isFuta
+                    isFuta={isFuta}
                 >
                     <AiOutlineDollarCircle
                         size={20}
@@ -206,7 +206,11 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                     title={'Copy image of chart to clipboard'}
                     enterDelay={500}
                 >
-                    <HeaderButtons mobileHide onClick={copyChartToClipboard}>
+                    <HeaderButtons
+                        mobileHide
+                        onClick={copyChartToClipboard}
+                        isFuta={isFuta}
+                    >
                         <RiScreenshot2Fill
                             size={20}
                             id='trade_chart_save_image'
@@ -235,7 +239,7 @@ export const TradeChartsHeader = (props: { tradePage?: boolean }) => {
                     }}
                     id='chart_settings_button'
                     isActive={contextmenu}
-                    isFuta
+                    isFuta={isFuta}
                 >
                     <IoSettingsOutline
                         size={20}

--- a/src/pages/platformFuta/Account/Account.tsx
+++ b/src/pages/platformFuta/Account/Account.tsx
@@ -21,6 +21,7 @@ import {
     useSortedAuctions,
 } from '../Auctions/useSortedAuctions';
 import FutaDivider2 from '../../../components/Futa/Divider/FutaDivider2';
+import HexReveal from '../Home/Animations/HexReveal';
 
 export type auctionDataSets = 'bids' | 'created';
 
@@ -261,10 +262,10 @@ export default function Account() {
             </div>
 
             <div className={styles.rightLayout}>
-                <div>
+                <HexReveal>
                     <p className={styles.label}>CLAIM</p>
                     <FutaDivider2 />
-                </div>
+                </HexReveal>
                 {claimAllContainer}
             </div>
         </div>

--- a/src/pages/platformFuta/Auctions/Auctions.tsx
+++ b/src/pages/platformFuta/Auctions/Auctions.tsx
@@ -1,13 +1,14 @@
 import { useContext, useEffect } from 'react';
+import FutaDivider2 from '../../../components/Futa/Divider/FutaDivider2';
 import SearchableTicker from '../../../components/Futa/SearchableTicker/SearchableTicker';
 import TickerComponent from '../../../components/Futa/TickerComponent/TickerComponent';
 import { AppStateContext } from '../../../contexts';
 import { AuctionsContext } from '../../../contexts/AuctionsContext';
 import { UserDataContext } from '../../../contexts/UserDataContext';
 import useMediaQuery from '../../../utils/hooks/useMediaQuery';
+import HexReveal from '../Home/Animations/HexReveal';
 import styles from './Auctions.module.css';
 import { sortedAuctionsIF, useSortedAuctions } from './useSortedAuctions';
-import FutaDivider2 from '../../../components/Futa/Divider/FutaDivider2';
 
 interface propsIF {
     hideTicker?: boolean;
@@ -61,7 +62,9 @@ export default function Auctions(props: propsIF) {
                         />
                     </div>
                     <div className={styles.flexColumn}>
-                        <p className={styles.label}>TICKER</p>
+                        <HexReveal>
+                            <p className={styles.label}>TICKER</p>
+                        </HexReveal>
                         <FutaDivider2 />
                         {!hideTicker && (
                             <TickerComponent

--- a/src/pages/platformFuta/Home/Animations/HexReveal.tsx
+++ b/src/pages/platformFuta/Home/Animations/HexReveal.tsx
@@ -71,7 +71,7 @@ const HexReveal: React.FC<HexRevealProps> = ({
         }, interval);
 
         return () => clearInterval(intervalId);
-    }, [children, interval]);
+    }, []);
 
     return (
         <>

--- a/src/pages/platformFuta/SwapFuta/SwapFuta.module.css
+++ b/src/pages/platformFuta/SwapFuta/SwapFuta.module.css
@@ -87,10 +87,19 @@
 }
 
 @media (min-width: 768px) {
+
+
 .chartSection{
     border: 2px solid var(--borders, #5C6F72);
     padding: 0 8px;
 }
+}
+@media (min-width: 1280px) {
+    .mainSection{
+        display: grid;
+        grid-template-columns: auto 390px;
+    }
+
 }
 @media (max-width: 600px) {
     .mainSection {

--- a/src/pages/platformFuta/SwapFuta/SwapFuta.tsx
+++ b/src/pages/platformFuta/SwapFuta/SwapFuta.tsx
@@ -7,6 +7,7 @@ import Swap from '../../platformAmbient/Trade/Swap/Swap';
 import Trade from '../../platformAmbient/Trade/Trade';
 import styles from './SwapFuta.module.css';
 import FutaDivider2 from '../../../components/Futa/Divider/FutaDivider2';
+import HexReveal from '../Home/Animations/HexReveal';
 
 function SwapFuta() {
     const tradeWrapperID = 'swapFutaTradeWrapper';
@@ -116,11 +117,15 @@ function SwapFuta() {
             {!isFullScreen && (
                 <div>
                     <span id={tradeWrapperID}>
-                        <p className={styles.label}>order</p>
+                        <HexReveal>
+                            <p className={styles.label}>order</p>
+                        </HexReveal>
                         <FutaDivider2 />
                         <Swap isOnTradeRoute />
                     </span>
-                    <p className={styles.label}>comments</p>
+                    <HexReveal>
+                        <p className={styles.label}>comments</p>
+                    </HexReveal>
                     <FutaDivider2 />
                     <Comments
                         isForTrade={true}

--- a/src/styled/Components/Chart.ts
+++ b/src/styled/Components/Chart.ts
@@ -4,6 +4,7 @@ import { FlexContainer, Text } from '../Common';
 export const HeaderButtons = styled.button<{
     mobileHide?: boolean;
     isFuta?: boolean;
+    isActive?: boolean;
 }>`
     display: flex;
     flex-direction: row;
@@ -11,11 +12,27 @@ export const HeaderButtons = styled.button<{
     align-items: center;
     outline: none;
     border: none;
-    border-radius: 5px;
     background: transparent;
     cursor: pointer;
     gap: 8px;
     padding: 4px;
+
+    ${({ isFuta }) =>
+        isFuta &&
+        `
+            border: 1px solid var(--dark2, #14161A);
+            background: var(--dark2, #14161A);
+            height: var(--buttonHeightSmall, 25px);
+            padding: 0px 12px;
+            gap: 10px;
+        `}
+
+    ${({ isFuta, isActive }) =>
+        isFuta &&
+        isActive &&
+        `
+            border: 1px solid var(--accent1);
+        `}
 
     &:hover {
         ${({ isFuta }) =>
@@ -25,6 +42,7 @@ export const HeaderButtons = styled.button<{
     &:focus-visible {
         box-shadow: var(--glow-light-box-shadow);
     }
+
     @media (max-width: 680px) {
         ${({ mobileHide }) => mobileHide && 'display: none'};
     }

--- a/src/styled/Components/TradeModules.ts
+++ b/src/styled/Components/TradeModules.ts
@@ -314,6 +314,39 @@ export const RefreshButton = styled(IconButton)`
     }
 `;
 
+export const RefreshButtonFuta = styled.button`
+    display: flex;
+    width: 98px;
+    margin-left: auto;
+    padding: 0px 12px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    background: var(--dark2, #14161a);
+    color: var(--text2, #939c9e);
+    text-align: center;
+
+    font-family: 'Fira Mono';
+    font-size: 18px;
+    font-style: normal;
+    font-weight: 400;
+    line-height: normal;
+    letter-spacing: -0.36px;
+
+    border: none;
+    cursor: pointer;
+    transition: color 0.3s ease;
+
+    &:hover {
+        color: var(--text1);
+    }
+
+    &:focus-visible {
+        color: var(--text1);
+        cursor: pointer;
+    }
+`;
+
 export const ExtraInfoContainer = styled(FlexContainer)<{ active: boolean }>`
     border-radius: var(--border-radius);
 

--- a/src/styled/Components/TradeModules.ts
+++ b/src/styled/Components/TradeModules.ts
@@ -599,8 +599,10 @@ export const LPButton = styled.button`
     letter-spacing: -0.36px;
     text-decoration-line: underline;
     transition: color 0.3s ease;
-    cursor: pointer;
+    cursor: pointer !important;
     text-transform: uppercase;
+    width: 150px;
+    margin: 0 auto;
 
     &:hover {
         color: var(--accent2);

--- a/src/styled/Components/TradeModules.ts
+++ b/src/styled/Components/TradeModules.ts
@@ -347,7 +347,10 @@ export const RefreshButtonFuta = styled.button`
     }
 `;
 
-export const ExtraInfoContainer = styled(FlexContainer)<{ active: boolean }>`
+export const ExtraInfoContainer = styled(FlexContainer)<{
+    active: boolean;
+    isFuta?: boolean;
+}>`
     border-radius: var(--border-radius);
 
     ${({ active }) =>
@@ -382,6 +385,15 @@ export const ExtraInfoContainer = styled(FlexContainer)<{ active: boolean }>`
             background: transparent;
         }
     `}
+
+    ${({ isFuta }) =>
+        isFuta
+            ? `
+        & {
+          text-transform: uppercase !important;
+        }
+    `
+            : ''}
 `;
 
 export const ExtraDetailsContainer = styled.div`

--- a/src/styled/Components/TradeModules.ts
+++ b/src/styled/Components/TradeModules.ts
@@ -316,7 +316,7 @@ export const RefreshButton = styled(IconButton)`
 
 export const RefreshButtonFuta = styled.button`
     display: flex;
-    width: 98px;
+    width: 82px;
     margin-left: auto;
     padding: 0px 12px;
     justify-content: center;


### PR DESCRIPTION
### Describe your changes
<img width="1508" alt="image" src="https://github.com/user-attachments/assets/0aae035c-0ad3-4643-a178-dc823c829308" />

Can all the chart buttons have a similar style to the timeframe buttons (background fill, and outline when selected/hovered)
Volume/TVL/Fee Rate
Reset/Auto
Hide Empty/USD/Settings

Remove the chart fullscreen and snapshot buttons entirely

Make the Volume/TVL/Fee Rate/Reset/Auto button text all caps

Remove the header entirely

Order and Comments headings should have the hexreveal wrapper applied like on the auctions page

Add typical button styling to the swap settings button

Add typical button styling to the refresh button in the mockup

Swap info should be all caps

Swap button Should be caps too

Remove the dropdown section and just make the extra info table visible all the time

Move the gas fee into the table like the mockup(extra info)

Remove the token logos


