### PR TITLE
Remove lookbehind from a regex for outdated Safari versions

### DIFF
--- a/src/components/Trade/TradeModules/TradeModuleSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeModuleSkeleton.tsx
@@ -131,7 +131,7 @@ export const TradeModuleSkeleton = (props: PropsIF) => {
     ]);
 
     const formattedAckTokenMessage = ackTokenMessage.replace(
-        /\b(not|(?<!many\s)fraudulent)\b/gi,
+        /\b(not|fraudulent)\b/i,
         '<span style="color: var(--negative); text-transform: uppercase;">$1</span>',
     );
 


### PR DESCRIPTION
### Describe your changes

The regex for unknown token warnings was using a lookbehind and that was crashing old versions of Safari. This PR rewrites that regex to not use that feature while retaining the same behavior.
![image](https://github.com/user-attachments/assets/eded5eb9-f5e8-499d-93e2-57ff3aefa935)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. In Safari on iOS 15.5 open an existing pool with a token that's not in any of the token lists (for example [this one](https://blast.ambient.finance/trade/market/chain=0x13e31&tokenA=0x0000000000000000000000000000000000000000&tokenB=0x5f59ecf360f19444173d120fec7d1fb0c42e0f26)) and after connecting the wallet look at the warning under the swap button.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
