### PR TITLE
Futa Comments | Comments component styling fix for global rules

### DIFF
--- a/src/components/Futa/Comments/CommentCard/CommentCard.module.css
+++ b/src/components/Futa/Comments/CommentCard/CommentCard.module.css
@@ -19,8 +19,8 @@
 }
 
 .comment_card_wrapper {
-    margin-top: 0.3rem;
-    padding-top: 0.3rem;
+    margin-top: 0.25rem;
+    padding-top: 0.25rem;
     position: relative;
     border-top: 1px solid rgba(255, 255, 255, 0.1);
     opacity: 0;
@@ -71,7 +71,7 @@
 
 .comment_bottom_info {
     position: absolute;
-    bottom: 0.3rem;
+    bottom: 0.25rem;
     right: 0.5rem;
     font-size: 0.8rem;
     animation: kf_comment_bottom_info_anim 0.9s ease-in-out 1 forwards;

--- a/src/components/Futa/Comments/Comments.module.css
+++ b/src/components/Futa/Comments/Comments.module.css
@@ -9,7 +9,7 @@
 
 .comments_outer.small {
     position: relative;
-    width: 90%;
+    padding: .5rem 1rem 1rem 1rem;
     margin: 0 auto;
 }
 

--- a/src/components/Futa/Comments/Comments.tsx
+++ b/src/components/Futa/Comments/Comments.tsx
@@ -118,7 +118,9 @@ function Comments(props: propsIF) {
                     tradeWrapper.getBoundingClientRect().height;
                 domDebug('screen height', window.screen.height);
                 domDebug('trader section height', tradeSectionHeight);
-                setPanelMaxHeight(window.innerHeight - tradeSectionHeight - 90);
+                setPanelMaxHeight(
+                    window.innerHeight - tradeSectionHeight - 108,
+                );
             }
         }
     };
@@ -217,7 +219,7 @@ function Comments(props: propsIF) {
     };
 
     const scrollToMessage = (messageId: string, instant: boolean) => {
-        const scrollTopPadding = -100;
+        const scrollTopPadding = -60;
         const msgEl = document.querySelector(
             '.commentBubble[data-message-id="' + messageId + '"]',
         );


### PR DESCRIPTION
### Describe your changes

Comments wrapper section padding changed with global padding rules
Bottom alignment fixed to make it parallel with left section
Scroll back offsets has been changed to adapt new padding rules (auto scroll after fetching old messages)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
