### PR TITLE
Fixes candle fetching issues 

### DIFF
--- a/src/contexts/CandleContext.tsx
+++ b/src/contexts/CandleContext.tsx
@@ -442,8 +442,12 @@ export const CandleContextProvider = (props: { children: React.ReactNode }) => {
                         incrCandles.candles.length === 0 ||
                         incrCandles.candles.length < numDurations - 1
                     ) {
+                        const tempCandleData =
+                            incrCandles.candles.length === 0
+                                ? candleData.candles
+                                : incrCandles.candles;
                         const minDate = Math.min(
-                            ...incrCandles.candles.map((i) => i.time),
+                            ...tempCandleData.map((i) => i.time),
                         );
                         minDate && setTimeOfEndCandle(minDate * 1000);
                     }

--- a/src/pages/platformAmbient/Chart/Chart.tsx
+++ b/src/pages/platformAmbient/Chart/Chart.tsx
@@ -1278,6 +1278,22 @@ export default function Chart(props: propsIF) {
             localCandleDomains.domainBoundry &&
             localCandleDomains.lastCandleDate
         ) {
+            if (visibleCandleData.length > 0) {
+                const minDomain = scaleData.xScale.domain()[0];
+                const visibleCandleDataFirstCandleTime =
+                    visibleCandleData[visibleCandleData.length - 1]?.time *
+                    1000;
+
+                if (
+                    Math.floor(
+                        (visibleCandleDataFirstCandleTime - minDomain) /
+                            (period * 1000),
+                    ) > 2
+                ) {
+                    localCandleDomains.lastCandleDate =
+                        visibleCandleDataFirstCandleTime;
+                }
+            }
             setCandleDomains(localCandleDomains);
         }
     }, [debouncedGetNewCandleDataRight]);

--- a/src/pages/platformAmbient/Chart/ChartUtils/zoom.ts
+++ b/src/pages/platformAmbient/Chart/ChartUtils/zoom.ts
@@ -227,21 +227,18 @@ export class Zoom {
 
     public getNewCandleDataLeft(newBoundary: number, firstCandleTime: number) {
         // Implementation for getting new candle data
-        if (newBoundary && firstCandleTime && newBoundary < firstCandleTime) {
-            const newCandleCount = this.isDiscontinuityScaleEnabled ? 500 : 100;
-            const newLastCandle =
-                newBoundary - newCandleCount * this.period * 1000;
+        const newCandleCount = this.isDiscontinuityScaleEnabled ? 500 : 100;
+        const newLastCandle = newBoundary - newCandleCount * this.period * 1000;
 
-            const candleDomain = {
-                lastCandleDate: firstCandleTime,
-                domainBoundry: newLastCandle,
-                isAbortedRequest: false,
-                isResetRequest: false,
-                isCondensedFetching: this.candleDomains.isCondensedFetching,
-            };
+        const candleDomain = {
+            lastCandleDate: firstCandleTime,
+            domainBoundry: newLastCandle,
+            isAbortedRequest: false,
+            isResetRequest: false,
+            isCondensedFetching: this.candleDomains.isCondensedFetching,
+        };
 
-            this.setCandleDomains(candleDomain);
-        }
+        this.setCandleDomains(candleDomain);
     }
 
     public changeCandleSize(


### PR DESCRIPTION
**Fixed bugs :**
  -  **disappears egg when zoom**
  **details :** 
    After you see the egg in any pool, zoom in, the egg will disappear 
  **workflow that should specifically be tested :**
    1. open this pool https://dev-ambi.netlify.app/trade/market/chain=0x18231&tokenA=0xD630fb6A07c9c723cf709d2DaA9B63325d0E0B73&tokenB=0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F
    2.  after zoom 

  -  **new candles not fetching when zoom switch pool**
    **details :** 
      When the chart is reset, the first candles fetched, but when zoomed in, since the candle fetched according to the old area, the request is sent according to the first candle of that old candle data and the gap in between is not filled.
    **workflow that should specifically be tested :**
    1. open this pool in 15m https://dev-ambi.netlify.app/trade/market/chain=0x18231&tokenA=0xD630fb6A07c9c723cf709d2DaA9B63325d0E0B73&tokenB=0xdddD73F5Df1F0DC31373357beAC77545dC5A6f3F
    2.  Zoom in until only the last 2 candles are visible
    3.  switch ETH / USDC.e
    4. zoom to left side 

