### PR TITLE
Infinite Scroll | Remove pendings from context after related data has been indexed

### DIFF
--- a/src/contexts/GraphDataContext.tsx
+++ b/src/contexts/GraphDataContext.tsx
@@ -526,7 +526,8 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
             );
         }
 
-        removeFromRecentlyUpdatedPositions(positionHash);
+        // this removal may cause problem once toggle has been switched on Limits and Ranges tabs
+        // removeFromRecentlyUpdatedPositions(positionHash);
     };
 
     const handleRedundantPendings = (pendings: RecentlyUpdatedPositionIF[]) => {

--- a/src/contexts/GraphDataContext.tsx
+++ b/src/contexts/GraphDataContext.tsx
@@ -112,6 +112,7 @@ export interface GraphDataContextIF {
     pendingRecentlyUpdatedPositions: RecentlyUpdatedPositionIF[];
     removeFromRecentlyUpdatedPositions: (positionHash: string) => void;
     prevPositionHashes: Set<string>;
+    handleIndexedPosition: (positionHash: string) => void;
 }
 
 function normalizeAddr(addr: string): string {
@@ -133,7 +134,7 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         pendingTransactions,
         allReceipts,
         sessionPositionUpdates,
-        transactionsByType,
+        transactionsByTypeIfs,
     } = useContext(ReceiptContext);
     const { setDataLoadingStatus } = useContext(DataLoadingContext);
     const {
@@ -495,7 +496,7 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         }
 
         setTimeout(() => {
-            removePendingRelevantPosition(uniqueRelevantLimitOrders);
+            handleRedundantPendings(uniqueRelevantLimitOrders);
         }, 300);
     };
 
@@ -516,9 +517,19 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         ]);
     };
 
-    const removePendingRelevantPosition = (
-        pendings: RecentlyUpdatedPositionIF[],
-    ) => {
+    const handleIndexedPosition = (positionHash: string) => {
+        if (pendingRecentlyUpdatedPositionsRef.current) {
+            setPendingRecentlyUpdatedPositions(
+                pendingRecentlyUpdatedPositionsRef.current.filter(
+                    (e) => e.positionHash !== positionHash,
+                ),
+            );
+        }
+
+        removeFromRecentlyUpdatedPositions(positionHash);
+    };
+
+    const handleRedundantPendings = (pendings: RecentlyUpdatedPositionIF[]) => {
         if (pendingRecentlyUpdatedPositionsRef.current) {
             setPendingRecentlyUpdatedPositions(
                 pendingRecentlyUpdatedPositionsRef.current.filter(
@@ -551,7 +562,7 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
     useEffect(() => {
         if (tempBool) return;
 
-        const relevantLimitOrders = transactionsByType.filter(
+        const relevantLimitOrders = transactionsByTypeIfs.filter(
             (tx) =>
                 !tx.isRemoved &&
                 unindexedNonFailedSessionLimitOrderUpdates.some(
@@ -585,13 +596,13 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         });
     }, [
         unindexedNonFailedSessionLimitOrderUpdates.length,
-        transactionsByType.length,
+        transactionsByTypeIfs.length,
     ]);
 
     useEffect(() => {
         if (tempBool) return;
 
-        const relevantPositions = transactionsByType.filter(
+        const relevantPositions = transactionsByTypeIfs.filter(
             (tx) =>
                 !tx.isRemoved &&
                 unindexedNonFailedSessionPositionUpdates.some(
@@ -642,7 +653,7 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         );
     }, [
         unindexedNonFailedSessionPositionUpdates.length,
-        transactionsByType.length,
+        transactionsByTypeIfs.length,
     ]);
 
     const onAccountRoute = location.pathname.includes('account');
@@ -796,6 +807,7 @@ export const GraphDataContextProvider = (props: { children: ReactNode }) => {
         pendingRecentlyUpdatedPositions,
         removeFromRecentlyUpdatedPositions,
         prevPositionHashes,
+        handleIndexedPosition,
     };
 
     return (


### PR DESCRIPTION
### Describe your changes

Created alternate list to keep pendings for infinite scroll component in `ReceiptContext` (named: `transactionsByTypeIfs`)
GraphDataContext has been modified to trigger with that alternate list changes.
Clear method added for that new alternate list and called in useMergeWithPendingTxs hook.



### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
