### PR TITLE
Fix small errors in string to BigInt conversion

### DIFF
--- a/src/utils/numbers.ts
+++ b/src/utils/numbers.ts
@@ -224,6 +224,9 @@ export function isValidNumberString(value: string): boolean {
 
 // Helper function to normalize exponential numbers
 export function normalizeExponential(value: string, decimals: number): string {
+    if (!value.toLowerCase().includes('e')) {
+        return value;
+    }
     const num = Number(value);
     if (!isNaN(num) && isFinite(num)) {
         return num.toFixed(decimals).replace(/\.?0+$/, ''); // High precision to avoid rounding errors


### PR DESCRIPTION
### Describe your changes

Fix a bug with number string to BigInt conversion where exponential normalization changed the value of the number due to float precision errors, which breaks the behavior of the Max button. For example, without this fix `stringToBigInt("0.100000000000000056", 18)` returns `100000000000000061`.

![image](https://github.com/user-attachments/assets/eee9a5ef-b783-45ed-8902-14b0fc2f12bc)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [X] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Press "Max" on some the input for some token with 18 decimals. It's not hard to find examples, currently I have one in my wallet - ETH on Monad. In prod it currently shows "ETH Amount Exceeds Wallet Balance".

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
