### PR TITLE
reduce redundant liquidity curve requests

### DIFF
--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -663,13 +663,13 @@ export function usePoolMetadata() {
         blockPollingUrl,
     ]);
 
-    const totalPositionLiq = useMemo(
+    const totalPositionUsdValue = useMemo(
         () =>
             positionsByPool.positions.reduce((sum, position) => {
-                return sum + position.positionLiq;
+                return sum + position.totalValueUSD;
             }, 0) +
             limitOrdersByPool.limitOrders.reduce((sum, order) => {
-                return sum + order.positionLiq;
+                return sum + order.totalValueUSD;
             }, 0),
         [positionsByPool, limitOrdersByPool],
     );
@@ -687,18 +687,20 @@ export function usePoolMetadata() {
         | undefined
     >();
 
-    const prevTotalPositionLiq = useRef(0);
-    const totalPositionLiqForUpdateTrigger = useRef(0);
+    const prevTotalPositionUsdValue = useRef(0);
+    const totalPositionUsdValueForUpdateTrigger = useRef(0);
 
     useEffect(() => {
         const change =
-            Math.abs(totalPositionLiq - prevTotalPositionLiq.current) /
-            prevTotalPositionLiq.current;
+            Math.abs(
+                totalPositionUsdValue - prevTotalPositionUsdValue.current,
+            ) / prevTotalPositionUsdValue.current;
+
         if (change < 0.01) return; // Skip effect if change is less than 1%
 
-        prevTotalPositionLiq.current = totalPositionLiq;
-        totalPositionLiqForUpdateTrigger.current = totalPositionLiq;
-    }, [totalPositionLiq]);
+        prevTotalPositionUsdValue.current = totalPositionUsdValue;
+        totalPositionUsdValueForUpdateTrigger.current = totalPositionUsdValue;
+    }, [totalPositionUsdValue]);
 
     useEffect(() => {
         (async () => {
@@ -706,7 +708,6 @@ export function usePoolMetadata() {
                 baseTokenAddress &&
                 quoteTokenAddress &&
                 crocEnv &&
-                totalPositionLiqForUpdateTrigger.current &&
                 GCGO_URL &&
                 (await crocEnv.context).chain.chainId === chainId
             ) {
@@ -738,7 +739,7 @@ export function usePoolMetadata() {
         quoteTokenAddress,
         poolIndex,
         GCGO_URL,
-        totalPositionLiqForUpdateTrigger.current,
+        totalPositionUsdValueForUpdateTrigger.current,
     ]);
 
     useEffect(() => {

--- a/src/App/hooks/usePoolMetadata.ts
+++ b/src/App/hooks/usePoolMetadata.ts
@@ -694,13 +694,29 @@ export function usePoolMetadata() {
         const change =
             Math.abs(
                 totalPositionUsdValue - prevTotalPositionUsdValue.current,
-            ) / prevTotalPositionUsdValue.current;
+            ) / totalPositionUsdValue;
 
         if (change < 0.01) return; // Skip effect if change is less than 1%
 
+        totalPositionUsdValueForUpdateTrigger.current =
+            prevTotalPositionUsdValue.current === 0 ? 0 : totalPositionUsdValue;
         prevTotalPositionUsdValue.current = totalPositionUsdValue;
-        totalPositionUsdValueForUpdateTrigger.current = totalPositionUsdValue;
     }, [totalPositionUsdValue]);
+
+    const [crocEnvChainMatches, setCrocEnvChainMatches] =
+        useState<boolean>(false);
+
+    useEffect(() => {
+        (async () => {
+            if (crocEnv) {
+                setCrocEnvChainMatches(
+                    (await crocEnv.context).chain.chainId === chainId,
+                );
+            } else {
+                setCrocEnvChainMatches(false);
+            }
+        })();
+    }, [crocEnv, chainId]);
 
     useEffect(() => {
         (async () => {
@@ -709,7 +725,7 @@ export function usePoolMetadata() {
                 quoteTokenAddress &&
                 crocEnv &&
                 GCGO_URL &&
-                (await crocEnv.context).chain.chainId === chainId
+                crocEnvChainMatches
             ) {
                 const request = {
                     baseAddress: baseTokenAddress.toLowerCase(),
@@ -733,7 +749,7 @@ export function usePoolMetadata() {
             }
         })();
     }, [
-        crocEnv,
+        crocEnvChainMatches,
         chainId,
         baseTokenAddress,
         quoteTokenAddress,

--- a/src/ambient-utils/api/fetchPoolLiquidity.ts
+++ b/src/ambient-utils/api/fetchPoolLiquidity.ts
@@ -5,18 +5,12 @@ import { TokenPriceFn } from './fetchTokenPrice';
 export const fetchPoolLiquidity = async (
     chainId: string,
     base: string,
-    baseTokenDecimals: number,
     quote: string,
-    quoteTokenDecimals: number,
     poolIdx: number,
-    crocEnv: CrocEnv,
     GCGO_URL: string,
-    cachedFetchTokenPrice: TokenPriceFn,
-    cachedQuerySpotTick: SpotPriceFn,
-    currentPoolPriceTick?: number | undefined,
-): Promise<LiquidityDataIF | undefined> => {
+): Promise<LiquidityCurveServerIF | undefined> => {
     const poolLiquidityCacheEndpoint = GCGO_URL + '/pool_liq_curve?';
-    return fetch(
+    return await fetch(
         poolLiquidityCacheEndpoint +
             new URLSearchParams({
                 chainId: chainId,
@@ -31,23 +25,11 @@ export const fetchPoolLiquidity = async (
                 return undefined;
             }
             const bumps = json.data as LiquidityCurveServerIF;
-            return await expandLiquidityData(
-                bumps,
-                base,
-                baseTokenDecimals,
-                quote,
-                quoteTokenDecimals,
-                poolIdx,
-                chainId,
-                crocEnv,
-                cachedFetchTokenPrice,
-                cachedQuerySpotTick,
-                currentPoolPriceTick,
-            );
+            return bumps;
         });
 };
 
-async function expandLiquidityData(
+export async function expandLiquidityData(
     liq: LiquidityCurveServerIF,
     base: string,
     baseTokenDecimals: number,
@@ -278,7 +260,7 @@ export interface LiquidityRangeIF {
     cumAverageUSD: number;
 }
 
-interface LiquidityCurveServerIF {
+export interface LiquidityCurveServerIF {
     ambientLiq: number;
     liquidityBumps: {
         bumpTick: number;

--- a/src/components/Global/Sidebar/FavoritePools.tsx
+++ b/src/components/Global/Sidebar/FavoritePools.tsx
@@ -85,11 +85,7 @@ export default function FavoritePools() {
                 // setIsFetchError(true);
                 console.warn(err);
             });
-    }, [
-        JSON.stringify(favePools.pools),
-        crocEnv === undefined,
-        JSON.stringify(explorePools),
-    ]);
+    }, [favePools.pools, crocEnv === undefined, explorePools]);
 
     return (
         <FlexContainer

--- a/src/components/Global/Sidebar/RecentPools.tsx
+++ b/src/components/Global/Sidebar/RecentPools.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect, useState } from 'react';
+import { memo, useContext, useEffect, useMemo, useState } from 'react';
 import { expandPoolStats } from '../../../ambient-utils/dataLayer';
 import { PoolIF } from '../../../ambient-utils/types';
 import {
@@ -34,8 +34,10 @@ function RecentPools() {
 
     const [expandedPoolData, setExpandedPoolData] = useState<PoolIF[]>([]);
 
+    const fiveRecentPools = useMemo(() => recentPools.get(5), [recentPools]);
+
     useEffect(() => {
-        if (!recentPools.get(5) || !crocEnv) return;
+        if (!fiveRecentPools.length || !crocEnv) return;
 
         const expandedPoolDataOnCurrentChain = recentPools
             .get(5)
@@ -74,11 +76,7 @@ function RecentPools() {
                 // setIsFetchError(true);
                 console.warn(err);
             });
-    }, [
-        JSON.stringify(recentPools.get(5)),
-        crocEnv === undefined,
-        JSON.stringify(explorePools),
-    ]);
+    }, [fiveRecentPools, crocEnv === undefined, explorePools]);
 
     return (
         <FlexContainer


### PR DESCRIPTION
### Describe your changes

- only trigger the fetch when pool liquidity changes by > 1%
- bypass downloading new data when pool price changes and only re-process

### Link the related issue

a couple issues with the current logic that would be resulting in excessive calls to /pool_liq_curve:

- we request new liq. curve data every time the total liquidity of the positions shown in the table changes

this is useful for low liquidity pools, but not as useful for high liquidity pools

- we request new liq. curve data every time the pool price changes

this isn’t helpful at all…but we’d need to separate the processing of liq. data from the downloading of liq. data in fetchPoolLiquidity.ts to only re-process when pool price changes

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
