### PR TITLE
prevent swap confirmation display overflow

### DIFF
--- a/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
+++ b/src/components/Trade/TradeModules/TradeConfirmationSkeleton.tsx
@@ -90,7 +90,8 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
         <>
             <ConfirmationQuantityContainer>
                 <Text fontSize='header2' color='text1'>
-                    {tokenAQuantity}
+                    {tokenAQuantity?.slice(0, 27 - tokenA.symbol.length) ||
+                        '0.000000'}
                 </Text>
                 <FlexContainer
                     alignItems='center'
@@ -117,7 +118,10 @@ export default function TradeConfirmationSkeleton(props: propsIF) {
             </FlexContainer>
             <ConfirmationQuantityContainer>
                 <Text fontSize='header2' color='text1'>
-                    <span>{tokenBQuantity}</span>
+                    <span>
+                        {tokenBQuantity?.slice(0, 27 - tokenB.symbol.length) ||
+                            '0.000000'}
+                    </span>
                     {showWarning && (
                         <span
                             style={


### PR DESCRIPTION
### Describe your changes

trim the end of estimated swap input / output quantity displays to a maximum length based on the length of the token symbol.

![image](https://github.com/user-attachments/assets/fce43f57-10bc-4842-9ecf-48d41147fb83)


### Link the related issue

![image](https://github.com/user-attachments/assets/31aa7668-c2da-4951-9c9c-53fed9d8f2aa)

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
