### PR TITLE
Remove placeholder if second try needed

### DIFF
--- a/src/ambient-utils/constants/networks/plumeLegacy.ts
+++ b/src/ambient-utils/constants/networks/plumeLegacy.ts
@@ -110,4 +110,5 @@ export const plumeLegacy: NetworkIF = {
     tempestApiNetworkName: '',
     topPools,
     getGasPriceInGwei,
+    indexerTimeout: 2000,
 };

--- a/src/ambient-utils/types/NetworkIF.ts
+++ b/src/ambient-utils/types/NetworkIF.ts
@@ -33,6 +33,7 @@ export interface NetworkIF {
     tempestApiNetworkName: string;
     chainSpec: ChainSpec;
     getGasPriceInGwei: (provider?: Provider) => Promise<number | undefined>;
+    indexerTimeout?: number;
 }
 
 export interface NetworkSessionIF {

--- a/src/components/Trade/InfiniteScroll/useGenFakeTableRow.tsx
+++ b/src/components/Trade/InfiniteScroll/useGenFakeTableRow.tsx
@@ -41,12 +41,16 @@ const useGenFakeTableRow = () => {
         useContext(CachedDataContext);
 
     const {
-        activeNetwork: { chainId, poolIndex },
+        activeNetwork: { chainId, poolIndex, indexerTimeout },
     } = useContext(AppStateContext);
 
     const getDelayTime = () => {
         // can be used to test if indexed data overrides pendings correctly
         const factor = 1;
+
+        if (indexerTimeout) {
+            return indexerTimeout * factor;
+        }
 
         switch (chainId) {
             case '0x1': // eth-mainnet

--- a/src/components/Trade/InfiniteScroll/useMergeWithPendingTxs.tsx
+++ b/src/components/Trade/InfiniteScroll/useMergeWithPendingTxs.tsx
@@ -23,6 +23,7 @@ const useMergeWithPendingTxs = (props: propsIF) => {
         recentlyUpdatedPositions,
         prevPositionHashes,
         handleIndexedPosition,
+        pendingRecentlyUpdatedPositions,
     } = useContext(GraphDataContext);
 
     const { removePendingTxIfs } = useContext(ReceiptContext);
@@ -106,6 +107,23 @@ const useMergeWithPendingTxs = (props: propsIF) => {
                 (e) => !recentlyUpdatedHashes.has(e.positionHash),
             );
 
+            // placeholder list check with infinitescroll data
+            pendingRecentlyUpdatedPositions.forEach((e) => {
+                const matchingOrder = (data as LimitOrderIF[]).find(
+                    (order) => order.positionHash === e.positionHash,
+                );
+                if (matchingOrder) {
+                    if (
+                        matchingOrder.liqRefreshTime &&
+                        matchingOrder.liqRefreshTime > e.timestamp / 1000
+                    ) {
+                        removePendingTxIfs(e.positionHash);
+                        handleIndexedPosition(e.positionHash);
+                        return;
+                    }
+                }
+            });
+
             return [
                 ...recentlyUpdatedToShow.reverse(),
                 ...clearedData,
@@ -114,6 +132,23 @@ const useMergeWithPendingTxs = (props: propsIF) => {
             clearedData = (data as PositionIF[]).filter(
                 (e) => !recentlyUpdatedHashes.has(e.positionId),
             );
+
+            // placeholder list check with infinitescroll data
+            pendingRecentlyUpdatedPositions.forEach((e) => {
+                const matchingPosition = (data as PositionIF[]).find(
+                    (position) => position.positionId === e.positionHash,
+                );
+                if (matchingPosition) {
+                    if (
+                        matchingPosition.liqRefreshTime &&
+                        matchingPosition.liqRefreshTime > e.timestamp / 1000
+                    ) {
+                        removePendingTxIfs(e.positionHash);
+                        handleIndexedPosition(e.positionHash);
+                        return;
+                    }
+                }
+            });
 
             return [
                 ...recentlyUpdatedToShow.reverse(),


### PR DESCRIPTION
### Describe your changes
These changes targets to remove placeholder row if synthetic row match missed on first try.
Also defining timeout per network can be used with assigning `indexerTimeout` prop on `NetworkIF` (which is optional)


### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
