### PR TITLE
Preserve trade order navigating from top pools

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "3.4.11",
+    "version": "3.4.12",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/src/components/Global/Explore/PoolRow/PoolRow.tsx
+++ b/src/components/Global/Explore/PoolRow/PoolRow.tsx
@@ -5,7 +5,9 @@ import {
 import { PoolIF, TokenIF } from '../../../../ambient-utils/types';
 import TokenIcon from '../../TokenIcon/TokenIcon';
 
+import { useContext } from 'react';
 import { GrLineChart } from 'react-icons/gr';
+import { TradeDataContext } from '../../../../contexts/TradeDataContext';
 import { FlexContainer } from '../../../../styled/Common';
 import useMediaQuery from '../../../../utils/hooks/useMediaQuery';
 import styles from './PoolRow.module.css';
@@ -18,6 +20,8 @@ interface propsIF {
 0;
 export default function PoolRow(props: propsIF) {
     const { pool, goToMarket, isExploreDollarizationEnabled } = props;
+
+    const { tokenA, tokenB } = useContext(TradeDataContext);
 
     // const [isHovered, setIsHovered] = useState(false);
 
@@ -124,11 +128,22 @@ export default function PoolRow(props: propsIF) {
         </p>
     );
 
+    const goToMarketPreservingTradeOrder = () => {
+        const shouldReverse =
+            tokenA.address.toLowerCase() === pool.quote.toLowerCase() ||
+            tokenB.address.toLowerCase() === pool.base.toLowerCase();
+
+        goToMarket(
+            shouldReverse ? pool.quote : pool.base,
+            shouldReverse ? pool.base : pool.quote,
+        );
+    };
+
     const buttonDisplay = (
         <div
             className={styles.tradeIcon}
             onClick={(event: React.MouseEvent) => {
-                goToMarket(pool.base, pool.quote);
+                goToMarketPreservingTradeOrder();
                 event?.stopPropagation();
             }}
         >
@@ -184,7 +199,7 @@ export default function PoolRow(props: propsIF) {
         <div
             className={styles.gridContainer}
             onClick={(event: React.MouseEvent) => {
-                goToMarket(pool.base, pool.quote);
+                goToMarketPreservingTradeOrder();
                 event?.stopPropagation();
             }}
         >


### PR DESCRIPTION
### Describe your changes

added logic to preserve the input/output token if the user is switching pools by clicking a Top Pool on /explore that shares a token with the previously selected pool.

e.g. user is trying to buy 100 USDC and switches between USDT/USDC and DAI/USDC by clicking DAI/USDC on explore page

### Link the related issue

in the above example, the user would then have to manually reverse the trade order and retype 100 for USDC as the fixed output.

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
