### PR TITLE
Senmessage button stays highlighted

### DIFF
--- a/src/components/Chat/MessagePanel/InputBox/MessageInput.module.css
+++ b/src/components/Chat/MessagePanel/InputBox/MessageInput.module.css
@@ -181,6 +181,7 @@
 }
 .send_message_button {
     margin-bottom: -3px;
+    
 }
 
 .not_LoggedIn_send_message_button {
@@ -388,12 +389,17 @@ section[class^='emoji-scroll-wrapper'] {
 
     .send_message_button,
     .not_LoggedIn_send_message_button {
-        box-shadow: 0px 0px 20px 0px rgba(115, 113, 252, 1);
-        background: var(--accent1);
+       
         padding: 0.2rem;
         border-radius: 0.4rem;
         margin-left: 0.5rem;
         margin-top: -0.2rem;
+        -webkit-tap-highlight-color: transparent;
+        transition: 
+        box-shadow 0.2s ease, 
+        background-color 0.2s ease;
+      touch-action: manipulation;
+        
     }
 
     .not_LoggedIn_send_message_button {
@@ -401,6 +407,14 @@ section[class^='emoji-scroll-wrapper'] {
         background: #4a6081;
         cursor: not-allowed !important;
     }
+
+   
+      .send_message_button:active {
+        box-shadow: 0 0 20px 0 rgba(115, 113, 252, 1);
+        background-color: var(--accent1);
+      }
+
+    
 
     .send_message_button svg,
     .not_LoggedIn_send_message_button svg {

--- a/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
+++ b/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
@@ -784,11 +784,6 @@ export default function MessageInput(props: MessageInputProps) {
                             onClick={handleInputClick}
                             onDoubleClick={handleInputDoubleClick}
                             autoComplete={'off'}
-                            // tabIndex={-1}
-                            // autoFocus={
-                            //     (props.appPage && !props.isMobile) ||
-                            //     props.isReplyButtonPressed
-                            // }
                             ref={inputRef}
                         />
                         {inputLength >= 100 && (

--- a/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
+++ b/src/components/Chat/MessagePanel/InputBox/MessageInput.tsx
@@ -77,6 +77,7 @@ interface MessageInputProps {
 }
 
 export default function MessageInput(props: MessageInputProps) {
+    const sendBtnRef = useRef<HTMLDivElement>(null);
     const inputRef = useRef<HTMLInputElement | null>(null);
     const [cursorPosition, setCursorPosition] = useState<number | null>(null);
 
@@ -817,12 +818,26 @@ export default function MessageInput(props: MessageInputProps) {
                         />
                         {}
                         <div
+                            ref={sendBtnRef}
                             className={
                                 isUserConnected
                                     ? styles.send_message_button
                                     : styles.not_LoggedIn_send_message_button
                             }
                             onClick={() => handleSendMessageButton()}
+                            onTouchStart={() =>
+                                sendBtnRef.current?.classList.add(styles.active)
+                            }
+                            onTouchEnd={() =>
+                                sendBtnRef.current?.classList.remove(
+                                    styles.active,
+                                )
+                            }
+                            onTouchCancel={() =>
+                                sendBtnRef.current?.classList.remove(
+                                    styles.active,
+                                )
+                            }
                         >
                             <svg
                                 width='16'


### PR DESCRIPTION
### Describe your changes

Updated MessageInput.tsx and MessageInput.module.css file to solve send Message button stays highlighted on ios
![image-2025-04-17-14-13-23-679](https://github.com/user-attachments/assets/4541383d-7c7d-44d3-a3ab-c27ec9c8ec70)


### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
