### PR TITLE
Fix endless loading when swap impact call fails

### DIFF
--- a/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
+++ b/src/components/Swap/SwapTokenInput/SwapTokenInput.tsx
@@ -193,7 +193,15 @@ function SwapTokenInput(props: propsIF) {
             slippageTolerancePercentage / 100,
             input,
         );
-        if (impact === undefined) return;
+        if (impact === undefined) {
+            setIsLiquidityInsufficient(true);
+            setSwapAllowed(false);
+            setIsBuyLoading(false);
+            setIsSellLoading(false);
+            return;
+        }
+
+        setIsLiquidityInsufficient(false);
 
         setLastImpactQuery({
             input,


### PR DESCRIPTION
### Describe your changes

Currently the frontend keeps spinning even after the `calcImpact` call reverted, which should [typically only happen in low liquidity situations](https://github.com/CrocSwap/ambient-ts-app/blob/1c915aac27ff97cbd1f7ed58879567e9a40f5236/src/App/functions/calcImpact.ts#L18-L19). This PR makes the fronted stop the loading spinner and show the insufficient liquidity error.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [X] I have performed a self-review of my code.
-   [X] Did I request feedback from a team member prior to the merge?
-   [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Estimating a swap that reverts, for example by asking for swap output of 1 WMON in this pool: https://monad.ambient.finance/trade/market/chain=0x279f&tokenA=0xcf5a6076cfa32686c0Df13aBaDa2b40dec133F1d&tokenB=0x760AfE86e5de5fa0Ee542fc7B7B713e1c5425701

**Environmental conditions that may result in expected but differential behavior.**

1. RPC errors could show the insufficient liquidity error, but I think for now that's better UX than spinning. Future improvements to RPC fallback and retry logic will address that.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
