### PR TITLE
remove SDK dependency for block explorer lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "3.5.7",
+    "version": "3.5.8",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/src/ambient-utils/constants/networks/baseSepolia.ts
+++ b/src/ambient-utils/constants/networks/baseSepolia.ts
@@ -40,8 +40,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Basescan',
-            url: 'https://sepolia.basescan.org',
-            apiUrl: 'https://api-sepolia.basescan.org/api',
+            url: 'https://sepolia.basescan.org/',
+            apiUrl: 'https://api-sepolia.basescan.org/api/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/blastMainnet.ts
+++ b/src/ambient-utils/constants/networks/blastMainnet.ts
@@ -38,8 +38,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Blastscan',
-            url: 'https://blastscan.io',
-            apiUrl: 'https://api.blastscan.io/api',
+            url: 'https://blastscan.io/',
+            apiUrl: 'https://api.blastscan.io/api/',
         },
     },
 };

--- a/src/ambient-utils/constants/networks/blastSepolia.ts
+++ b/src/ambient-utils/constants/networks/blastSepolia.ts
@@ -44,8 +44,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Blastscan',
-            url: 'https://sepolia.blastscan.io',
-            apiUrl: 'https://api-sepolia.blastscan.io/api',
+            url: 'https://sepolia.blastscan.io/',
+            apiUrl: 'https://api-sepolia.blastscan.io/api/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/ethereumMainnet.ts
+++ b/src/ambient-utils/constants/networks/ethereumMainnet.ts
@@ -35,8 +35,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Etherscan',
-            url: 'https://etherscan.io',
-            apiUrl: 'https://api.etherscan.io/api',
+            url: 'https://etherscan.io/',
+            apiUrl: 'https://api.etherscan.io/api/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/ethereumSepolia.ts
+++ b/src/ambient-utils/constants/networks/ethereumSepolia.ts
@@ -40,8 +40,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Etherscan',
-            url: 'https://sepolia.etherscan.io',
-            apiUrl: 'https://api-sepolia.etherscan.io/api',
+            url: 'https://sepolia.etherscan.io/',
+            apiUrl: 'https://api-sepolia.etherscan.io/api/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/monadTestnet.ts
+++ b/src/ambient-utils/constants/networks/monadTestnet.ts
@@ -44,7 +44,7 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Monad Testnet explorer',
-            url: 'https://testnet.monadexplorer.com',
+            url: 'https://testnet.monadexplorer.com/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/plumeLegacy.ts
+++ b/src/ambient-utils/constants/networks/plumeLegacy.ts
@@ -39,8 +39,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Blockscout',
-            url: 'https://explorer.plumenetwork.xyz',
-            apiUrl: 'https://explorer.plumenetwork.xyz/api',
+            url: 'https://explorer.plumenetwork.xyz/',
+            apiUrl: 'https://explorer.plumenetwork.xyz/api/',
         },
     },
 };

--- a/src/ambient-utils/constants/networks/plumeMainnet.ts
+++ b/src/ambient-utils/constants/networks/plumeMainnet.ts
@@ -39,8 +39,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Blockscout',
-            url: 'https://explorer.plume.org',
-            apiUrl: 'https://explorer.plume.org/api',
+            url: 'https://explorer.plume.org/',
+            apiUrl: 'https://explorer.plume.org/api/',
         },
     },
 };

--- a/src/ambient-utils/constants/networks/scrollMainnet.ts
+++ b/src/ambient-utils/constants/networks/scrollMainnet.ts
@@ -34,8 +34,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Scrollscan',
-            url: 'https://scrollscan.com',
-            apiUrl: 'https://api.scrollscan.com/api',
+            url: 'https://scrollscan.com/',
+            apiUrl: 'https://api.scrollscan.com/api/',
         },
     },
 };

--- a/src/ambient-utils/constants/networks/scrollSepolia.ts
+++ b/src/ambient-utils/constants/networks/scrollSepolia.ts
@@ -34,8 +34,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Scrollscan',
-            url: 'https://sepolia.scrollscan.com',
-            apiUrl: 'https://api-sepolia.scrollscan.com/api',
+            url: 'https://sepolia.scrollscan.com/',
+            apiUrl: 'https://api-sepolia.scrollscan.com/api/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/swellMainnet.ts
+++ b/src/ambient-utils/constants/networks/swellMainnet.ts
@@ -34,8 +34,8 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Swell Explorer',
-            url: 'https://swellchainscan.io',
-            apiUrl: 'https://api.swellchainscan.io',
+            url: 'https://swellchainscan.io/',
+            apiUrl: 'https://api.swellchainscan.io/',
         },
     },
     contracts: {

--- a/src/ambient-utils/constants/networks/swellSepolia.ts
+++ b/src/ambient-utils/constants/networks/swellSepolia.ts
@@ -40,7 +40,7 @@ const chainSpecForAppKit: Chain = {
     blockExplorers: {
         default: {
             name: 'Swell Testnet Explorer',
-            url: 'https://swell-testnet-explorer.alt.technology',
+            url: 'https://swell-testnet-explorer.alt.technology/',
         },
     },
 };

--- a/src/ambient-utils/dataLayer/functions/chains.ts
+++ b/src/ambient-utils/dataLayer/functions/chains.ts
@@ -20,8 +20,13 @@ export function getDefaultPairForChain(chainId: string) {
         supportedNetworks[chainId].defaultPair[1],
     ];
 }
+
+export function getBlockExplorerUrl(chainId: string): string {
+    return supportedNetworks[chainId].blockExplorer;
+}
+
 // Given a chain ID returns the relevant block explorer URL
-export function getChainExplorer(chainId: string | number): string {
+export function getBlockExplorerFromSDK(chainId: string | number): string {
     try {
         const explorer = lookupChain(chainId).blockExplorer;
         if (explorer) {

--- a/src/components/Global/DetailModals/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
+++ b/src/components/Global/DetailModals/RangeDetails/RangeDetailsSimplify/RangeDetailsSimplify.tsx
@@ -110,17 +110,17 @@ function RangeDetailsSimplify(props: propsIF) {
 
     function handleOpenBaseAddress() {
         if (tokenAAddressLowerCase && blockExplorer) {
-            const adressUrl =
+            const blockExplorerUrl =
                 tokenAAddressLowerCase === ZERO_ADDRESS
                     ? `${blockExplorer}address/${addrs.dex}`
                     : `${blockExplorer}token/${tokenAAddressLowerCase}`;
-            window.open(adressUrl);
+            window.open(blockExplorerUrl);
         }
     }
     function handleOpenQuoteAddress() {
         if (tokenBAddressLowerCase && blockExplorer) {
-            const adressUrl = `${blockExplorer}token/${tokenBAddressLowerCase}`;
-            window.open(adressUrl);
+            const blockExplorerUrl = `${blockExplorer}token/${tokenBAddressLowerCase}`;
+            window.open(blockExplorerUrl);
         }
     }
 

--- a/src/components/Global/NotificationCenter/ReceiptDisplay/ReceiptDisplay.tsx
+++ b/src/components/Global/NotificationCenter/ReceiptDisplay/ReceiptDisplay.tsx
@@ -5,7 +5,7 @@ import { MdErrorOutline } from 'react-icons/md';
 import { RiExternalLinkLine } from 'react-icons/ri';
 import { VscClose } from 'react-icons/vsc';
 import {
-    getChainExplorer,
+    getBlockExplorerUrl,
     trimString,
 } from '../../../../ambient-utils/dataLayer';
 import { AppStateContext } from '../../../../contexts';
@@ -32,11 +32,11 @@ export default function ReceiptDisplay(props: ReceiptDisplayPropsIF) {
     const { cachedFetchBlockTime } = useContext(CachedDataContext);
     const { removeReceipt } = useContext(ReceiptContext);
 
-    const blockExplorer = getChainExplorer(chainId ?? currentChainId);
-    const EtherscanTx = `${blockExplorer}tx/${hash}`;
+    const blockExplorer = getBlockExplorerUrl(chainId ?? currentChainId);
+    const txUrl = `${blockExplorer}tx/${hash}`;
 
-    const handleNavigateEtherscan = () => {
-        window.open(EtherscanTx, '_blank');
+    const handleNavigateTxUrl = () => {
+        window.open(txUrl, '_blank');
     };
 
     const pending = <Spinner size={30} bg={'var(--dark2)'} weight={2} />;
@@ -45,7 +45,7 @@ export default function ReceiptDisplay(props: ReceiptDisplayPropsIF) {
         <IoMdCheckmarkCircleOutline
             size={30}
             color='var(--accent1)'
-            onClick={handleNavigateEtherscan}
+            onClick={handleNavigateTxUrl}
         />
     );
 
@@ -135,7 +135,7 @@ export default function ReceiptDisplay(props: ReceiptDisplayPropsIF) {
     return (
         <div className={styles.nContainer}>
             <a
-                href={EtherscanTx}
+                href={txUrl}
                 className={styles.leftSide}
                 target='_blank'
                 rel='noreferrer'
@@ -169,7 +169,7 @@ export default function ReceiptDisplay(props: ReceiptDisplayPropsIF) {
                     />
                 </button>
                 <a
-                    href={EtherscanTx}
+                    href={txUrl}
                     className={styles.action}
                     target='_blank'
                     rel='noreferrer'

--- a/src/components/Trade/TableInfo/FeaturedBox.tsx
+++ b/src/components/Trade/TableInfo/FeaturedBox.tsx
@@ -1,8 +1,8 @@
+import { ZeroAddress } from 'ethers';
 import React, { useContext } from 'react';
 import { FiCopy, FiExternalLink } from 'react-icons/fi';
-import { ZERO_ADDRESS } from '../../../ambient-utils/constants';
 import {
-    getChainExplorer,
+    getBlockExplorerUrl,
     trimString,
     uriToHttp,
 } from '../../../ambient-utils/dataLayer';
@@ -39,7 +39,7 @@ export function FeaturedBox(props: FeaturedBoxPropsIF) {
             chainSpec: { addrs },
         },
     } = useContext(AppStateContext);
-    const blockExplorer = getChainExplorer(chainId);
+    const blockExplorer = getBlockExplorerUrl(chainId);
 
     const [_, copy] = useCopyToClipboard();
 
@@ -91,7 +91,7 @@ export function FeaturedBox(props: FeaturedBoxPropsIF) {
                     >
                         <a
                             href={
-                                token.address === ZERO_ADDRESS
+                                token.address === ZeroAddress
                                     ? `${blockExplorer}address/${addrs.dex}`
                                     : `${blockExplorer}token/${token.address}`
                             }

--- a/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TransactionSubmitted.tsx
+++ b/src/components/Trade/TradeModules/SubmitTransaction/TransactionSubmitted/TransactionSubmitted.tsx
@@ -4,7 +4,7 @@ import { useContext } from 'react';
 import { FiExternalLink } from 'react-icons/fi';
 import { useLocation } from 'react-router-dom';
 import { brand } from '../../../../../ambient-utils/constants';
-import { getChainExplorer } from '../../../../../ambient-utils/dataLayer';
+import { getBlockExplorerUrl } from '../../../../../ambient-utils/dataLayer';
 import { AppStateContext } from '../../../../../contexts/AppStateContext';
 import Button from '../../../../Form/Button';
 import addTokenToWallet from './addTokenToWallet';
@@ -37,7 +37,6 @@ export default function TransactionSubmitted(props: PropsIF) {
         type,
         hash,
         noAnimation,
-        chainId,
         isConfirmed,
         isTransactionFailed,
         importTokenSymbol,
@@ -46,16 +45,17 @@ export default function TransactionSubmitted(props: PropsIF) {
         importTokenImage,
     } = props;
 
-    const blockExplorer = getChainExplorer(chainId);
-    const txUrlOnBlockExplorer = `${blockExplorer}tx/${hash}`;
-    const currentLocation = useLocation()?.pathname;
-    const isFuta = brand === 'futa';
-
     const {
         activeNetwork: {
             chainSpecForAppKit: { nativeCurrency },
+            chainId,
         },
     } = useContext(AppStateContext);
+
+    const blockExplorer = getBlockExplorerUrl(chainId);
+    const txUrlOnBlockExplorer = `${blockExplorer}tx/${hash}`;
+    const currentLocation = useLocation()?.pathname;
+    const isFuta = brand === 'futa';
 
     const { walletProvider } = useAppKitProvider('eip155');
     const handleAddToMetaMask = async () => {

--- a/src/contexts/CrocEnvContext.tsx
+++ b/src/contexts/CrocEnvContext.tsx
@@ -56,35 +56,35 @@ export interface CrocEnvContextIF {
 
 export const CrocEnvContext = createContext({} as CrocEnvContextIF);
 const mainnetProvider = new BatchedJsonRpcProvider(
-    ethereumMainnet.fallbackRpcUrl,
+    ethereumMainnet.evmRpcUrl,
     parseInt(ethereumMainnet.chainId),
     {
         staticNetwork: true,
     },
 );
 const scrollProvider = new BatchedJsonRpcProvider(
-    scrollMainnet.fallbackRpcUrl,
+    scrollMainnet.evmRpcUrl,
     parseInt(scrollMainnet.chainId),
     {
         staticNetwork: true,
     },
 );
 const swellProvider = new BatchedJsonRpcProvider(
-    swellMainnet.fallbackRpcUrl,
+    swellMainnet.evmRpcUrl,
     parseInt(swellMainnet.chainId),
     {
         staticNetwork: true,
     },
 );
 const blastProvider = new BatchedJsonRpcProvider(
-    blastMainnet.fallbackRpcUrl,
+    blastMainnet.evmRpcUrl,
     parseInt(blastMainnet.chainId),
     {
         staticNetwork: true,
     },
 );
 const plumeProvider = new BatchedJsonRpcProvider(
-    plumeMainnet.fallbackRpcUrl,
+    plumeMainnet.evmRpcUrl,
     parseInt(plumeMainnet.chainId),
     {
         staticNetwork: true,

--- a/src/contexts/SidebarContext.tsx
+++ b/src/contexts/SidebarContext.tsx
@@ -1,7 +1,7 @@
 import { TransactionReceipt } from 'ethers';
 import {
-    ReactNode,
     createContext,
+    ReactNode,
     useContext,
     useEffect,
     useMemo,
@@ -12,8 +12,7 @@ import {
     useRecentPools,
 } from '../App/hooks/useRecentPools';
 import { sidebarMethodsIF, useSidebar } from '../App/hooks/useSidebar';
-import { IS_LOCAL_ENV } from '../ambient-utils/constants';
-import { diffHashSig, getChainExplorer } from '../ambient-utils/dataLayer';
+import { diffHashSig, getBlockExplorerUrl } from '../ambient-utils/dataLayer';
 import useMediaQuery from '../utils/hooks/useMediaQuery';
 import { AppStateContext } from './AppStateContext';
 import { PoolContext } from './PoolContext';
@@ -101,8 +100,8 @@ export const SidebarContextProvider = (props: { children: ReactNode }) => {
         (e) => e.txHash === lastReceipt?.hash,
     )?.chainId;
     const blockExplorer = lastReceiptChainId
-        ? getChainExplorer(lastReceiptChainId)
-        : getChainExplorer(chainId);
+        ? getBlockExplorerUrl(lastReceiptChainId)
+        : getBlockExplorerUrl(chainId);
 
     const snackBarContentDisplay = (
         <div className='flexColumn'>
@@ -127,7 +126,6 @@ export const SidebarContextProvider = (props: { children: ReactNode }) => {
     );
     useEffect(() => {
         if (lastReceiptHash) {
-            IS_LOCAL_ENV && console.debug('new receipt to display');
             openSnackbar(
                 snackBarContentDisplay,
                 isLastReceiptSuccess ? 'info' : 'warning',

--- a/src/utils/hooks/useProcessOrder.ts
+++ b/src/utils/hooks/useProcessOrder.ts
@@ -1,6 +1,5 @@
 import { useContext, useEffect, useMemo, useState } from 'react';
 import {
-    getChainExplorer,
     getElapsedTime,
     getFormattedNumber,
     getMoneynessRank,
@@ -20,6 +19,7 @@ import {
 import { lookupChain } from '@crocswap-libs/sdk/dist/context';
 import { getAddress } from 'ethers';
 import moment from 'moment';
+import { getBlockExplorerUrl } from '../../ambient-utils/dataLayer/functions/chains';
 import { getPositionHash } from '../../ambient-utils/dataLayer/functions/getPositionHash';
 import { useFetchBatch } from '../../App/hooks/useFetchBatch';
 import { CachedDataContext } from '../../contexts/CachedDataContext';
@@ -36,7 +36,7 @@ export const useProcessOrder = (
     const { ensName: ensNameConnectedUser } = useContext(UserDataContext);
     const { cachedFetchTokenPrice } = useContext(CachedDataContext);
 
-    const blockExplorer = getChainExplorer(limitOrder.chainId);
+    const blockExplorer = getBlockExplorerUrl(limitOrder.chainId);
 
     const selectedBaseToken = baseToken.address.toLowerCase();
     const selectedQuoteToken = quoteToken.address.toLowerCase();

--- a/src/utils/hooks/useProcessRange.ts
+++ b/src/utils/hooks/useProcessRange.ts
@@ -1,12 +1,12 @@
 import moment from 'moment';
 import { useContext, useEffect, useMemo, useState } from 'react';
 import {
-    getChainExplorer,
     getFormattedNumber,
     getMoneynessRank,
     getUnicodeCharacter,
     trimString,
 } from '../../ambient-utils/dataLayer';
+import { getBlockExplorerUrl } from '../../ambient-utils/dataLayer/functions/chains';
 import { getPositionHash } from '../../ambient-utils/dataLayer/functions/getPositionHash';
 import { PositionIF } from '../../ambient-utils/types';
 import { useFetchBatch } from '../../App/hooks/useFetchBatch';
@@ -19,7 +19,7 @@ export const useProcessRange = (
     account = '',
     isAccountView?: boolean,
 ) => {
-    const blockExplorer = getChainExplorer(position.chainId);
+    const blockExplorer = getBlockExplorerUrl(position.chainId);
 
     const { isDenomBase, poolPriceNonDisplay } = useContext(TradeDataContext);
     const { ensName: ensNameConnectedUser } = useContext(UserDataContext);

--- a/src/utils/hooks/useProcessTransaction.ts
+++ b/src/utils/hooks/useProcessTransaction.ts
@@ -9,13 +9,13 @@ import { getAddress } from 'ethers';
 import moment from 'moment';
 import { useContext, useEffect, useState } from 'react';
 import {
-    getChainExplorer,
     getElapsedTime,
     getFormattedNumber,
     getMoneynessRank,
     getUnicodeCharacter,
     trimString,
 } from '../../ambient-utils/dataLayer';
+import { getBlockExplorerUrl } from '../../ambient-utils/dataLayer/functions/chains';
 import { getPositionHash } from '../../ambient-utils/dataLayer/functions/getPositionHash';
 import { TransactionIF } from '../../ambient-utils/types';
 import { useFetchBatch } from '../../App/hooks/useFetchBatch';
@@ -32,7 +32,7 @@ export const useProcessTransaction = (
     const { tokenA, tokenB, isDenomBase } = useContext(TradeDataContext);
     const { ensName: ensNameConnectedUser } = useContext(UserDataContext);
     const { cachedFetchTokenPrice } = useContext(CachedDataContext);
-    const blockExplorer = getChainExplorer(tx.chainId);
+    const blockExplorer = getBlockExplorerUrl(tx.chainId);
 
     const txHash = tx.txHash;
 


### PR DESCRIPTION
### Describe your changes

Remove dependency on the crocswap SDK for looking up the block explorer address on a particular chain. 

This will allow easier front-end updates in case the block explorer address changes.

(This PR also switches to using the primary RPC for chain stat generation and ENS lookups)

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
