### PR TITLE
fix logic for displaying price change warnings in swap confirmation

### DIFF
--- a/src/pages/platformAmbient/Trade/Swap/Swap.tsx
+++ b/src/pages/platformAmbient/Trade/Swap/Swap.tsx
@@ -908,6 +908,7 @@ function Swap(props: propsIF) {
                         isSaveAsDexSurplusChecked={isSaveAsDexSurplusChecked}
                         percentDiffUsdValue={percentDiffUsdValue}
                         crocEnv={crocEnv}
+                        priceImpact={priceImpact}
                     />
                 ) : (
                     <></>


### PR DESCRIPTION
### Describe your changes

- fixes bug causing price change warning to appear when the user is buying the base token and the price of the base token decreases
- uses the existing price impact data to determine if the price has changed since the confirmation modal was opened instead of making separate price queries

### Link the related issue

The initial price of ETH when this swap confirmation modal was opened was 2478.1663733329506, so the warning should not be showing.

![image](https://github.com/user-attachments/assets/d087ace3-8e21-4ba9-8527-3e5cadac79d3)

### Checklist before requesting a review

-   [ ] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [ ] I have performed a self-review of my code.
-   [ ] Did I request feedback from a team member prior to the merge?
-   [ ] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1.

2.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
