### PR TITLE
Fastlane mev protection

### DIFF
--- a/src/App/functions/approve.ts
+++ b/src/App/functions/approve.ts
@@ -36,11 +36,19 @@ export function useApprove() {
         tokenSymbol: string,
         cb?: (b: boolean) => void,
         tokenQuantity?: bigint,
+        spender?: string,
     ) => {
         if (!crocEnv) return;
         try {
             setIsApprovalPending(true);
-            const tx = await crocEnv.token(tokenAddress).approve(tokenQuantity);
+            let tx;
+            if (spender) {
+                tx = await crocEnv
+                    .token(tokenAddress)
+                    .approveAddr(spender, tokenQuantity);
+            } else {
+                tx = await crocEnv.token(tokenAddress).approve(tokenQuantity);
+            }
             if (tx) addPendingTx(tx?.hash);
             if (tx?.hash)
                 addTransactionByType({

--- a/src/App/hooks/useFastLaneProtection.ts
+++ b/src/App/hooks/useFastLaneProtection.ts
@@ -1,0 +1,43 @@
+import { useEffect, useMemo, useState } from 'react';
+import { monadTestnet } from '../../ambient-utils/constants/networks/monadTestnet';
+
+export interface FastLaneProtectionIF {
+    isEnabled: boolean;
+    enable: () => void;
+    disable: () => void;
+    toggle: () => void;
+    isChainAccepted: (chainId: string) => boolean;
+}
+
+export const useFastLaneProtection = (): FastLaneProtectionIF => {
+    const LS_KEY = 'fastlane_protection';
+    const ACCEPTED_NETWORKS = [monadTestnet];
+
+    const [enabled, setEnabled] = useState<boolean>(() => {
+        const stored = localStorage.getItem(LS_KEY);
+        return stored ? JSON.parse(stored) : false;
+    });
+
+    useEffect(() => {
+        localStorage.setItem(LS_KEY, JSON.stringify(enabled));
+    }, [enabled]);
+
+    const isChainAccepted = (chainId: string): boolean => {
+        return ACCEPTED_NETWORKS.some(
+            (network) =>
+                network.chainId.toLowerCase() === chainId.toLowerCase(),
+        );
+    };
+
+    const result = useMemo(
+        () => ({
+            isEnabled: enabled,
+            enable: () => setEnabled(true),
+            disable: () => setEnabled(false),
+            toggle: () => setEnabled((prev) => !prev),
+            isChainAccepted,
+        }),
+        [enabled],
+    );
+    return result;
+};

--- a/src/App/hooks/useTokenPairAllowance.ts
+++ b/src/App/hooks/useTokenPairAllowance.ts
@@ -6,6 +6,8 @@ import {
     UserDataContext,
 } from '../../contexts';
 import { TradeDataContext } from '../../contexts/TradeDataContext';
+import { ATLAS_ROUTER, monadTestnet } from '../../ambient-utils/constants';
+import { useFastLaneProtection } from './useFastLaneProtection';
 
 export function useTokenPairAllowance() {
     const { isTradeRoute } = useContext(AppStateContext);
@@ -25,6 +27,8 @@ export function useTokenPairAllowance() {
     const [recheckTokenBApproval, setRecheckTokenBApproval] =
         useState<boolean>(false);
 
+    const fastLaneProtection = useFastLaneProtection();
+
     // useEffect to check if user has approved CrocSwap to sell the token A
     useEffect(() => {
         (async () => {
@@ -36,9 +40,21 @@ export function useTokenPairAllowance() {
                 Number((await crocEnv.context).chain.chainId) === tokenA.chainId
             ) {
                 try {
+                    const context = await crocEnv.context;
+                    const acceptedChainId = fastLaneProtection?.isChainAccepted(
+                        (await crocEnv.context).chain.chainId,
+                    );
+                    // Default to false if fastLaneProtection is undefined during initialization
+                    const isFastLaneEnabled =
+                        (fastLaneProtection?.isEnabled && acceptedChainId) ??
+                        false;
+                    const spender = isFastLaneEnabled
+                        ? ATLAS_ROUTER
+                        : await context.dex.getAddress();
+
                     const allowance = await crocEnv
                         .token(tokenA.address)
-                        .allowance(userAddress);
+                        .allowance(userAddress, spender);
 
                     if (tokenAAllowance !== allowance) {
                         setTokenAAllowance(allowance);
@@ -55,6 +71,7 @@ export function useTokenPairAllowance() {
         tokenA.address + tokenA.chainId + userAddress,
         lastBlockNumber,
         recheckTokenAApproval,
+        fastLaneProtection?.isEnabled,
     ]);
 
     // useEffect to check if user has approved CrocSwap to sell the token B
@@ -62,9 +79,21 @@ export function useTokenPairAllowance() {
         (async () => {
             if (isTradeRoute && crocEnv && userAddress && tokenB.address) {
                 try {
+                    const context = await crocEnv.context;
+                    const acceptedChainId = fastLaneProtection?.isChainAccepted(
+                        (await crocEnv.context).chain.chainId,
+                    );
+                    // Default to false if fastLaneProtection is undefined during initialization
+                    const isFastLaneEnabled =
+                        (fastLaneProtection?.isEnabled && acceptedChainId) ??
+                        false;
+                    const spender = isFastLaneEnabled
+                        ? ATLAS_ROUTER
+                        : await context.dex.getAddress();
+
                     const allowance = await crocEnv
                         .token(tokenB.address)
-                        .allowance(userAddress);
+                        .allowance(userAddress, spender);
 
                     if (tokenBAllowance !== allowance) {
                         setTokenBAllowance(allowance);
@@ -81,6 +110,7 @@ export function useTokenPairAllowance() {
         lastBlockNumber,
         isTradeRoute,
         recheckTokenBApproval,
+        fastLaneProtection?.isEnabled,
     ]);
 
     return {

--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -187,10 +187,11 @@ export const DISABLE_ALL_TUTOS =
 
 export const ATLAS_ROUTER = '0x9958Ab9f64EF51194C5378a336D2A0b0A620D31c';
 export const ATLAS_AUCTIONEER_ENDPOINT =
-    import.meta.env.VITE_ATLAS_AUCTIONEER_ENDPOINT || 'http://localhost:8080';
+    import.meta.env.VITE_ATLAS_AUCTIONEER_ENDPOINT ||
+    'https://auctioneer-fra.fastlane-labs.xyz';
 export const ATLAS_REFUND_RECIPIENT =
     import.meta.env.VITE_ATLAS_REFUND_RECIPIENT ||
     '0x0000000000000000000000000000000000000000';
 export const ATLAS_REFUND_PERCENT = import.meta.env.VITE_ATLAS_REFUND_PERCENT
-    ? parseInt(import.meta.env.VITE_ATLAS_REFUND_PERCENT)
-    : 0;
+    ? import.meta.env.VITE_ATLAS_REFUND_PERCENT
+    : '0x0';

--- a/src/ambient-utils/constants/index.ts
+++ b/src/ambient-utils/constants/index.ts
@@ -184,3 +184,13 @@ export const SHOW_TUTOS_DEFAULT =
 // using for disabling all tutorials and to hide help button on ui
 export const DISABLE_ALL_TUTOS =
     import.meta.env.VITE_DISABLE_ALL_TUTOS || false;
+
+export const ATLAS_ROUTER = '0x9958Ab9f64EF51194C5378a336D2A0b0A620D31c';
+export const ATLAS_AUCTIONEER_ENDPOINT =
+    import.meta.env.VITE_ATLAS_AUCTIONEER_ENDPOINT || 'http://localhost:8080';
+export const ATLAS_REFUND_RECIPIENT =
+    import.meta.env.VITE_ATLAS_REFUND_RECIPIENT ||
+    '0x0000000000000000000000000000000000000000';
+export const ATLAS_REFUND_PERCENT = import.meta.env.VITE_ATLAS_REFUND_PERCENT
+    ? parseInt(import.meta.env.VITE_ATLAS_REFUND_PERCENT)
+    : 0;

--- a/src/ambient-utils/dataLayer/transactions/swap.ts
+++ b/src/ambient-utils/dataLayer/transactions/swap.ts
@@ -1,4 +1,12 @@
 import { CrocEnv } from '@crocswap-libs/sdk';
+import { TransactionResponse } from 'ethers';
+import { encodeSurplusArg } from '@crocswap-libs/sdk/dist/encoding/flags';
+import {
+    ATLAS_REFUND_PERCENT,
+    ATLAS_AUCTIONEER_ENDPOINT,
+    ATLAS_REFUND_RECIPIENT,
+} from '../../constants';
+import { Signer } from 'ethers';
 
 interface PerformSwapParams {
     crocEnv: CrocEnv;
@@ -39,4 +47,121 @@ export async function performSwap(params: PerformSwapParams) {
     });
 
     return tx;
+}
+
+export async function performFastLaneSwap(params: {
+    crocEnv: CrocEnv;
+    isQtySell: boolean;
+    qty: string;
+    buyTokenAddress: string;
+    sellTokenAddress: string;
+    slippageTolerancePercentage: number;
+    isWithdrawFromDexChecked?: boolean;
+    isSaveAsDexSurplusChecked?: boolean;
+}): Promise<TransactionResponse> {
+    const {
+        crocEnv,
+        isQtySell,
+        qty,
+        buyTokenAddress,
+        sellTokenAddress,
+        slippageTolerancePercentage,
+        isWithdrawFromDexChecked = true,
+        isSaveAsDexSurplusChecked = false,
+    } = params;
+
+    const plan = isQtySell
+        ? crocEnv.sell(sellTokenAddress, qty).for(buyTokenAddress, {
+              slippage: slippageTolerancePercentage / 100,
+          })
+        : crocEnv.buy(buyTokenAddress, qty).with(sellTokenAddress, {
+              slippage: slippageTolerancePercentage / 100,
+          });
+
+    const context = await crocEnv.context;
+    const actorAddress = await (context.actor as Signer).getAddress();
+    const dexAddress = await context.dex.getAddress();
+    const swapQty = await plan.qty;
+    const slipQty = await plan.calcSlipQty();
+    const limitPrice = await plan.calcLimitPrice();
+    const surplusFlags = encodeSurplusArg([
+        isWithdrawFromDexChecked,
+        isSaveAsDexSurplusChecked,
+    ]);
+
+    const unsignedTx = await context.dex.swap.populateTransaction(
+        plan.baseToken.tokenAddr,
+        plan.quoteToken.tokenAddr,
+        context.chain.poolIndex,
+        plan.sellBase,
+        plan.qtyInBase,
+        swapQty,
+        0,
+        limitPrice,
+        slipQty,
+        surplusFlags,
+    );
+
+    const valueSell = plan.qtyInBase ? swapQty.toString() : slipQty.toString();
+    const maxFeePerGas = (await context.provider.getFeeData()).maxFeePerGas;
+    const maxFeePerGasHex = maxFeePerGas
+        ? '0x' + maxFeePerGas.toString(16)
+        : '0xC1B710800';
+    const value =
+        sellTokenAddress === '0x0000000000000000000000000000000000000000'
+            ? valueSell
+            : '0x0';
+    const payload = {
+        jsonrpc: '2.0',
+        method: 'atlas_sendUnsignedTransaction',
+        params: [
+            {
+                transaction: {
+                    chainId: parseInt(context.chain.chainId),
+                    from: actorAddress,
+                    to: dexAddress,
+                    value: value,
+                    data: unsignedTx.data,
+                    maxFeePerGas: maxFeePerGasHex,
+                },
+                refundRecipient: ATLAS_REFUND_RECIPIENT,
+                refundPercent: ATLAS_REFUND_PERCENT,
+                bidTokenIsOutputToken: true,
+            },
+        ],
+        id: 1,
+    };
+
+    const response = await fetch(ATLAS_AUCTIONEER_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+    });
+    const result = await response.json();
+    if (!result || !result.result) {
+        throw new Error('Failed to get transaction response from Atlas');
+    }
+    if (!context.actor?.sendTransaction) {
+        throw new Error('Actor is undefined');
+    }
+    const txValue = result.result.value
+        ? BigInt(result.result.value.toString())
+        : 0n;
+    const txGasLimit = result.result.gas
+        ? BigInt(result.result.gas.toString())
+        : undefined;
+    const txMaxFeePerGas = result.result.maxFeePerGas
+        ? BigInt(result.result.maxFeePerGas.toString())
+        : undefined;
+    const txResp = await context.actor.sendTransaction({
+        to: result.result.to,
+        value: txValue,
+        gasLimit: txGasLimit,
+        maxFeePerGas: txMaxFeePerGas,
+        data: result.result.data,
+    });
+    if (!txResp) {
+        throw new Error('Failed to send transaction');
+    }
+    return txResp;
 }

--- a/src/components/Global/FastLaneProtectionControl/FastLaneProtectionControl.module.css
+++ b/src/components/Global/FastLaneProtectionControl/FastLaneProtectionControl.module.css
@@ -1,0 +1,11 @@
+.main_container {
+    display: flex;
+    justify-content: space-between;
+    flex-direction: row;
+    align-items: center;
+
+    color: var(--text2);
+    font-size: var(--body-size);
+    line-height: var(--body-lh);
+    margin: 1rem;
+}

--- a/src/components/Global/FastLaneProtectionControl/FastLaneProtectionControl.tsx
+++ b/src/components/Global/FastLaneProtectionControl/FastLaneProtectionControl.tsx
@@ -1,0 +1,35 @@
+import { Dispatch, SetStateAction, useId } from 'react';
+import Toggle from '../../Form/Toggle';
+import styles from './FastLaneProtectionControl.module.css';
+
+interface propsIF {
+    tempEnableFastLane: boolean;
+    setTempEnableFastLane: Dispatch<SetStateAction<boolean>>;
+    displayInSettings?: boolean;
+}
+
+export default function FastLaneProtectionControl(props: propsIF) {
+    const { tempEnableFastLane, setTempEnableFastLane, displayInSettings } = props;
+    const compKey = useId();
+    const toggleAriaLabel = `${
+        tempEnableFastLane ? 'disable' : 'enable'
+    } MEV protection by Fastlane`;
+
+    return (
+        <div className={styles.main_container}>
+            {displayInSettings ? (
+                <p tabIndex={0}>{'Enable MEV-Protection by Fastlane'}</p>
+            ) : (
+                <p tabIndex={0}>Enable MEV-Protection by Fastlane</p>
+            )}
+            <Toggle
+                key={compKey}
+                isOn={tempEnableFastLane}
+                disabled={false}
+                handleToggle={() => setTempEnableFastLane(!tempEnableFastLane)}
+                id='enable_fastlane_toggle'
+                aria-label={toggleAriaLabel}
+            />
+        </div>
+    );
+}

--- a/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
+++ b/src/components/Global/TransactionSettingsModal/TransactionSettingsModal.tsx
@@ -3,6 +3,7 @@ import { FiAlertTriangle } from 'react-icons/fi';
 import { isStablePair } from '../../../ambient-utils/dataLayer';
 import { dexBalanceMethodsIF } from '../../../App/hooks/useExchangePrefs';
 import { skipConfirmIF } from '../../../App/hooks/useSkipConfirm';
+import { FastLaneProtectionIF } from '../../../App/hooks/useFastLaneProtection';
 import { SlippageMethodsIF } from '../../../App/hooks/useSlippage';
 import { AppStateContext } from '../../../contexts/AppStateContext';
 import { PoolContext } from '../../../contexts/PoolContext';
@@ -14,6 +15,7 @@ import ConfirmationModalControl from '../ConfirmationModalControl/ConfirmationMo
 import DollarizationModalControl from '../DollarizationModalControl/DollarizationModalControl';
 import Modal from '../Modal/Modal';
 import SendToDexBalControl from '../SendToDexBalControl/SendToDexBalControl';
+import FastLaneProtectionControl from '../FastLaneProtectionControl/FastLaneProtectionControl';
 import SlippageTolerance from '../SlippageTolerance/SlippageTolerance';
 
 export type TransactionModuleType =
@@ -28,11 +30,19 @@ interface propsIF {
     slippage: SlippageMethodsIF;
     dexBalSwap?: dexBalanceMethodsIF;
     bypassConfirm: skipConfirmIF;
+    fastLaneProtection: FastLaneProtectionIF;
     onClose: () => void;
 }
 
 export default function TransactionSettingsModal(props: propsIF) {
-    const { module, slippage, dexBalSwap, onClose, bypassConfirm } = props;
+    const {
+        module,
+        slippage,
+        dexBalSwap,
+        onClose,
+        bypassConfirm,
+        fastLaneProtection,
+    } = props;
     const { tokenA, tokenB } = useContext(TradeDataContext);
     const {
         activeNetwork: { chainId },
@@ -67,6 +77,11 @@ export default function TransactionSettingsModal(props: propsIF) {
     const [currentDollarizationMode, setCurrentDollarizationMode] =
         useState<boolean>(isTradeDollarizationEnabled);
 
+    const persistedFastLane = fastLaneProtection.isEnabled;
+    const [currentFastLane, setCurrentFastLane] = useState<boolean>(
+        persistedFastLane,
+    );
+
     const updateSettings = (): void => {
         isPairStable
             ? slippage.updateStable(currentSlippage)
@@ -78,6 +93,9 @@ export default function TransactionSettingsModal(props: propsIF) {
                 : dexBalSwap.outputToDexBal.disable()
             : undefined;
         setIsTradeDollarizationEnabled(currentDollarizationMode);
+        currentFastLane
+            ? fastLaneProtection.enable()
+            : fastLaneProtection.disable();
         onClose();
     };
 
@@ -135,6 +153,12 @@ export default function TransactionSettingsModal(props: propsIF) {
                             displayInSettings={true}
                         />
                     )}
+
+                    <FastLaneProtectionControl
+                        tempEnableFastLane={currentFastLane}
+                        setTempEnableFastLane={setCurrentFastLane}
+                        displayInSettings={true}
+                    />
 
                     <ConfirmationModalControl
                         tempBypassConfirm={currentSkipConfirm}

--- a/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
+++ b/src/components/Trade/Reposition/RepositionHeader/RepositionHeader.tsx
@@ -26,7 +26,7 @@ function RepositionHeader(props: propsIF) {
         setCurrentRangeInReposition,
         setAdvancedMode,
     } = useContext(RangeContext);
-    const { bypassConfirmRepo, repoSlippage } = useContext(
+    const { bypassConfirmRepo, repoSlippage, fastLaneProtection } = useContext(
         UserPreferenceContext,
     );
     const { defaultRangeWidthForActivePool } = useContext(TradeDataContext);
@@ -65,6 +65,7 @@ function RepositionHeader(props: propsIF) {
                     module='Reposition'
                     slippage={repoSlippage}
                     bypassConfirm={bypassConfirmRepo}
+                    fastLaneProtection={fastLaneProtection}
                     onClose={closeModal}
                 />
             )}

--- a/src/components/Trade/TradeModules/TradeModuleHeader.tsx
+++ b/src/components/Trade/TradeModules/TradeModuleHeader.tsx
@@ -10,6 +10,7 @@ import { LuSettings, LuSettings2 } from 'react-icons/lu';
 import { dexBalanceMethodsIF } from '../../../App/hooks/useExchangePrefs';
 import { skipConfirmIF } from '../../../App/hooks/useSkipConfirm';
 import { SlippageMethodsIF } from '../../../App/hooks/useSlippage';
+import { FastLaneProtectionIF } from '../../../App/hooks/useFastLaneProtection';
 import { SettingsSvg } from '../../../assets/images/icons/settingsSvg';
 import { AppStateContext } from '../../../contexts';
 import { TradeDataContext } from '../../../contexts/TradeDataContext';
@@ -23,13 +24,20 @@ interface propsIF {
     slippage: SlippageMethodsIF;
     dexBalSwap?: dexBalanceMethodsIF;
     bypassConfirm: skipConfirmIF;
+    fastLaneProtection?: FastLaneProtectionIF;
     settingsTitle: TransactionModuleType;
     isSwapPage?: boolean;
 }
 
 function TradeModuleHeader(props: propsIF) {
-    const { slippage, dexBalSwap, bypassConfirm, settingsTitle, isSwapPage } =
-        props;
+    const {
+        slippage,
+        dexBalSwap,
+        bypassConfirm,
+        fastLaneProtection,
+        settingsTitle,
+        isSwapPage,
+    } = props;
 
     const [isSettingsModalOpen, openSettingsModal, closeSettingsModal] =
         useModal();
@@ -97,6 +105,7 @@ function TradeModuleHeader(props: propsIF) {
                         slippage={slippage}
                         dexBalSwap={dexBalSwap}
                         bypassConfirm={bypassConfirm}
+                        fastLaneProtection={fastLaneProtection!}
                         onClose={closeSettingsModal}
                     />
                 )}
@@ -168,6 +177,7 @@ function TradeModuleHeader(props: propsIF) {
                     slippage={slippage}
                     dexBalSwap={dexBalSwap}
                     bypassConfirm={bypassConfirm}
+                    fastLaneProtection={fastLaneProtection!}
                     onClose={closeSettingsModal}
                 />
             )}

--- a/src/contexts/UserPreferenceContext.tsx
+++ b/src/contexts/UserPreferenceContext.tsx
@@ -5,6 +5,10 @@ import {
 } from '../App/hooks/useExchangePrefs';
 import { favePoolsMethodsIF, useFavePools } from '../App/hooks/useFavePools';
 import { skipConfirmIF, useSkipConfirm } from '../App/hooks/useSkipConfirm';
+import {
+    FastLaneProtectionIF,
+    useFastLaneProtection,
+} from '../App/hooks/useFastLaneProtection';
 import { SlippageMethodsIF, useSlippage } from '../App/hooks/useSlippage';
 import { IS_LOCAL_ENV } from '../ambient-utils/constants';
 import { getMoneynessRankByAddr } from '../ambient-utils/dataLayer';
@@ -24,6 +28,7 @@ export interface UserPreferenceContextIF {
     bypassConfirmLimit: skipConfirmIF;
     bypassConfirmRange: skipConfirmIF;
     bypassConfirmRepo: skipConfirmIF;
+    fastLaneProtection: FastLaneProtectionIF;
     cssDebug: {
         cache: (k: string, v: string) => void;
         check: (k: string) => string | undefined;
@@ -100,6 +105,8 @@ export const UserPreferenceContextProvider = (props: {
         return cssDebugMap.get(k);
     }
 
+    const fastLaneProtection = useFastLaneProtection();
+
     const userPreferencesProps: UserPreferenceContextIF = {
         favePools: useFavePools(),
         swapSlippage: useSlippage('swap'),
@@ -112,6 +119,7 @@ export const UserPreferenceContextProvider = (props: {
         bypassConfirmLimit: useSkipConfirm('limit'),
         bypassConfirmRange: useSkipConfirm('range'),
         bypassConfirmRepo: useSkipConfirm('repo'),
+        fastLaneProtection,
         cssDebug: {
             cache: cacheCSSProperty,
             check: checkCSSPropertyCache,

--- a/src/pages/platformAmbient/Trade/Limit/Limit.tsx
+++ b/src/pages/platformAmbient/Trade/Limit/Limit.tsx
@@ -102,9 +102,8 @@ export default function Limit() {
         updateTransactionHash,
         pendingTransactions,
     } = useContext(ReceiptContext);
-    const { mintSlippage, dexBalLimit, bypassConfirmLimit } = useContext(
-        UserPreferenceContext,
-    );
+    const { mintSlippage, dexBalLimit, bypassConfirmLimit, fastLaneProtection } =
+        useContext(UserPreferenceContext);
     const { basePrice, quotePrice } = poolData;
 
     const [isOpen, openModal, closeModal] = useModal();
@@ -966,6 +965,7 @@ export default function Limit() {
                 <TradeModuleHeader
                     slippage={mintSlippage}
                     bypassConfirm={bypassConfirmLimit}
+                    fastLaneProtection={fastLaneProtection}
                     settingsTitle='Limit Order'
                 />
             }

--- a/src/pages/platformAmbient/Trade/Range/Range.tsx
+++ b/src/pages/platformAmbient/Trade/Range/Range.tsx
@@ -111,9 +111,12 @@ function Range() {
         baseToken: { decimals: baseTokenDecimals },
         quoteToken: { decimals: quoteTokenDecimals },
     } = useContext(TradeTokenContext);
-    const { mintSlippage, dexBalRange, bypassConfirmRange } = useContext(
-        UserPreferenceContext,
-    );
+    const {
+        mintSlippage,
+        dexBalRange,
+        bypassConfirmRange,
+        fastLaneProtection,
+    } = useContext(UserPreferenceContext);
     const { positionsByUser, liquidityFee } = useContext(GraphDataContext);
     const isPoolInitialized = useSimulatedIsPoolInitialized();
 
@@ -1148,6 +1151,7 @@ function Range() {
                 <TradeModuleHeader
                     slippage={mintSlippage}
                     bypassConfirm={bypassConfirmRange}
+                    fastLaneProtection={fastLaneProtection}
                     settingsTitle='Pool'
                 />
             }


### PR DESCRIPTION
### Fastlane MEV Protection
1. Toggle to allow user’s to opt-in to Fastlane MEV Protection
2. Approve
    1. When doing the approval transaction, you need to make sure to approve the correct router.
    2. If toggle on → approve Atlas Router
    3. If toggle off → approve dApp Router
3. Allowance
    1. After a user has done an approval transaction, you need to make sure that the allowance check that gates whether a user can attempt the swap transaction is checking the correct router. 
        1. Note that if the user were to do the approval on one router and then toggle the MEV Protection before actually doing the swap, then they would need to do a new approval transaction on the correct router. 
    2. If toggle on → check allowance of Atlas Router
    3. If toggle off → check allowance of dApp Router
4. Swap
    1. The user should only be able to click the swap button after the appropriate allowance check above. Clicking swap, sends the below payload to the Fastlane auction. The Fastlane auction duration is 2 seconds long. The auction will return the transaction details that the user needs to sign and submit for inclusion in the next block.
    2. If toggle on → swap on Atlas Router
    3. If toggle off → swap on dApp Router
