### PR TITLE
fixed: condensed mode tvl changes comparison

### DIFF
--- a/src/ambient-utils/api/fetchCandleSeries.ts
+++ b/src/ambient-utils/api/fetchCandleSeries.ts
@@ -254,6 +254,7 @@ function decorateCandleData(
                 tvlData: {
                     time: p.time,
                     tvl: p.tvlBase * baseUsdMult + p.tvlQuote * quoteUsdMult,
+                    tvlRaw: p.tvlBase * baseDecMult + p.tvlQuote * quoteDecMult,
                 },
                 volumeUSD:
                     (p.volumeBase * baseUsdMult +

--- a/src/ambient-utils/types/candleData/CandleDataIF.ts
+++ b/src/ambient-utils/types/candleData/CandleDataIF.ts
@@ -4,6 +4,7 @@ export interface CandleDataIF {
     tvlData: {
         time: number;
         tvl: number;
+        tvlRaw: number;
     };
     volumeUSD: number;
     averageLiquidityFee: number;

--- a/src/pages/Chart/ChartUtils/discontinuityScaleUtils.ts
+++ b/src/pages/Chart/ChartUtils/discontinuityScaleUtils.ts
@@ -19,20 +19,17 @@ export function filterCandleWithTransaction(
         .map((item, index, array) => {
             let isShowData = false;
 
-            if (
-                //                index === 0 ||
-                index ===
-                array.length - 1
-            ) {
+            if (index === 0) {
                 isShowData = true;
             }
 
-            const previousTvlData = index > 0 ? array[index - 1].tvlData : null;
+            const previousTvlRawData =
+                index > 0 ? array[index - 1].tvlData : null;
 
             if (
-                !previousTvlData ||
+                !previousTvlRawData ||
                 item.volumeUSD !== 0 ||
-                item.tvlData.tvl !== previousTvlData.tvl
+                item.tvlData.tvlRaw !== previousTvlRawData.tvlRaw
             ) {
                 isShowData = true;
             }


### PR DESCRIPTION
Previously, TVL was calculated only using current USD multipliers, which caused misleading changes in TVL even when the underlying token amounts didn’t change. This PR introduces a raw TVL value based on actual token amounts.

Condensed mode and comparison logic now use tvlRaw for stable results.

Using current prices caused artificial TVL fluctuations in historical data. 
**Because we take candles at 1 minute intervals, so the first 200 candles use the dollar equivalent of the different base Price and quote Price when calculating the tvl** 

![Screenshot_5](https://github.com/user-attachments/assets/8bc7d8e7-7af2-4717-93e4-1ea0b5d1c272)




**Functionalities or workflows that should specifically be tested.**

1. Open this pool on Plume /trade/market/chain=0x18232&tokenA=0xca59ca09e5602fae8b629dee83ffa819741f14be&tokenB=0xda6087e69c51e7d31b6dbad276a3c44703dfdcad
2. wait 1 minute
3. click reset

