### PR TITLE
Fix incorrect token selection for vault balance decimals

### DIFF
--- a/src/contexts/ChainDataContext.tsx
+++ b/src/contexts/ChainDataContext.tsx
@@ -279,7 +279,9 @@ export const ChainDataContextProvider = (props: { children: ReactNode }) => {
                 const balance = (await balanceInt).toString();
                 const balanceAmount = toDisplayQty(
                     await balanceInt,
-                    vaultSpec.token1Decimals,
+                    vaultSpec.mainAsset == vaultSpec.token0Address
+                        ? vaultSpec.token0Decimals
+                        : vaultSpec.token1Decimals,
                 );
                 let price = 0;
                 try {


### PR DESCRIPTION
### Describe your changes

Currently vault's `balanceAmount` calculation uses decimals of `token1` instead of `mainAsset` due to confusing naming in the SDK.

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [X] I have performed a self-review of my code.
-   [X] Did I request feedback from a team member prior to the merge?
-   [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Check the total portfolio balance of any depositor in a vault where `mainAsset` isn't `token1`, like `ETH/WBTC` on Scroll.

**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
