### PR TITLE
Release 3.7.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "3.7.4",
+    "version": "3.7.5",
     "private": true,
     "type": "module",
     "dependencies": {


### PR DESCRIPTION
- temporarily disable MEV protection on Monad Testnet during upgrade