### PR TITLE
Fix exchange balance dropdown disappearing on wide screens

### DIFF
--- a/src/components/Global/TabComponent/TabComponent.module.css
+++ b/src/components/Global/TabComponent/TabComponent.module.css
@@ -20,7 +20,7 @@
 }
 
 .tabContent {
-    position: absolute;
+    position: relative;
     top: 0;
     left: 0;
     right: 0;


### PR DESCRIPTION
### Describe your changes

Fix the layout of the exchange balance dropdown breaking on some layouts.

<img width="695" height="773" alt="image" src="https://github.com/user-attachments/assets/a9d065a4-f8d6-491f-b93f-dfc82519556a" />

### Link the related issue

_Closes #0000_

### Checklist before requesting a review

-   [X] Is this PR ready for merge? (Please convert to a draft PR otherwise)
-   [X] I have performed a self-review of my code.
-   [X] Did I request feedback from a team member prior to the merge?
-   [X] Does my code following the style guide at `docs/CODING-STYLE.md`?

### Instructions for Reviewers

**Functionalities or workflows that should specifically be tested.**

1. Various non-mobile screen widths


**Environmental conditions that may result in expected but differential behavior.**

1.

2.

### If relevant, list additional work to complete pre-merge (delete logging, code abstraction, etc)
