### PR TITLE
Block fake plume tokens sep 29

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "ambient-ts-app",
-    "version": "3.9.4",
+    "version": "3.9.5",
     "private": true,
     "type": "module",
     "dependencies": {

--- a/src/ambient-utils/constants/blacklist.ts
+++ b/src/ambient-utils/constants/blacklist.ts
@@ -424,6 +424,26 @@ export const hiddenTokens = [
         address: '0x02cdb5ccc97d5dc7ed2747831b516669eb635706',
         chainId: 98866,
     },
+    {
+        // fake WPLUME on Plume
+        address: '0xAeDd65F2168ecC1f8aBC609f0D09CA364fe7DcDC',
+        chainId: 98866,
+    },
+    {
+        // fake PLC on Plume
+        address: '0x81e68577aD6A499b422f52908fA88B1F0769e9B5',
+        chainId: 98866,
+    },
+    {
+        // fake PLC on Plume
+        address: '0x9786198803BA261D4C06344E6698b76E2DB6Ad1c',
+        chainId: 98866,
+    },
+    {
+        // fake aUSD on Plume
+        address: '0xf07f47f3c160c2f3b2190fc81be38a61337250d6',
+        chainId: 98866,
+    },
 ];
 
 const embargoedTokens = [


### PR DESCRIPTION
blocking the following tokens from appearing on the front-end:

https://explorer.plume.org/token/0xAeDd65F2168ecC1f8aBC609f0D09CA364fe7DcDC (WPLUME - 2 holders)
https://explorer.plume.org/token/0x81e68577ad6a499b422f52908fa88b1f0769e9b5 (PLC - 4 holders)
https://explorer.plume.org/token/0x9786198803ba261d4c06344e6698b76e2db6ad1c (PLC - 7 holders)
https://explorer.plume.org/token/0xf07f47f3c160c2f3b2190fc81be38a61337250d6 (aUSD - 2 holders)
